### PR TITLE
Breed/birth follow-ups: multi-pick UX, twin chance, global counters

### DIFF
--- a/FChatDicebot/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
+++ b/FChatDicebot/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
@@ -43,6 +43,7 @@ namespace FChatDicebot.Tests.Fixtures
             Database.ClearCollection("Identifiers");
             Database.ClearCollection("ModMessages");
             Database.ClearCollection("Pledges");
+            Database.ClearCollection("MonsterStats");
         }
 
         /// <summary>

--- a/FChatDicebot/FChatDicebot.Tests/Unit/Breedprocessortests.cs
+++ b/FChatDicebot/FChatDicebot.Tests/Unit/Breedprocessortests.cs
@@ -17,6 +17,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         private readonly TestDatabaseFixture _fixture;
         private readonly IChateauDatabase _database;
         private readonly BreedProcessor _processor;
+        private readonly Random _savedRng;
 
         public BreedProcessorTests(TestDatabaseFixture fixture)
         {
@@ -24,6 +25,16 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             _fixture.Reset();
             _database = _fixture.Database;
             _processor = new BreedProcessor(_database);
+
+            // Default to a deterministic RNG that never triggers the rare-twin event
+            // (Sample()=0.5 → Next(100)=50, never 0). Individual tests can override.
+            _savedRng = BreedProcessor.Rng;
+            BreedProcessor.Rng = new FixedSampleRandom(0.5);
+        }
+
+        public void Dispose()
+        {
+            BreedProcessor.Rng = _savedRng;
         }
 
         [Fact]
@@ -110,10 +121,30 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.Equal("Alice", pregnancy.Initiator);
             Assert.Equal("slime", pregnancy.MonsterType);
             Assert.Equal(2, pregnancy.BroodSize);
+            Assert.False(pregnancy.IsRareTwins); // not a twin event — min was already 2
             Assert.True(pregnancy.ConceivedAt >= before.AddSeconds(-1));
             Assert.True(pregnancy.ReadyAt >= pregnancy.ConceivedAt.AddDays(3).AddSeconds(-1));
             Assert.True(pregnancy.ReadyAt <= pregnancy.ConceivedAt.AddDays(3).AddSeconds(1));
             Assert.False(string.IsNullOrEmpty(pregnancy.Id));
+        }
+
+        [Fact]
+        public void ProcessInteraction_StoresMonsterCategoriesOnPregnancy()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "lamia",
+                categories = new[] { "monster", "snake", "beast", "mount" }
+            });
+
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "lamia")));
+
+            var bob = _database.GetProfile("Bob");
+            var pregnancy = bob.pregnancies.Single();
+            Assert.NotNull(pregnancy.Categories);
+            Assert.Equal(new[] { "monster", "snake", "beast", "mount" }, pregnancy.Categories.ToArray());
         }
 
         [Fact]
@@ -129,7 +160,10 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             var bob = _database.GetProfile("Bob");
             var pregnancy = bob.pregnancies.Single();
+            // Default brood is 1, but the twin RNG check runs here. With our fixture's
+            // Sample()=0.5 RNG, Next(100) returns 50 → never triggers the twin event.
             Assert.Equal(1, pregnancy.BroodSize);
+            Assert.False(pregnancy.IsRareTwins);
             Assert.True(pregnancy.ReadyAt <= pregnancy.ConceivedAt.AddDays(1).AddSeconds(1));
         }
 
@@ -226,7 +260,6 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
                 type = "basilisk",
                 description = "a basilisk",
                 categories = new[] { "snake" }
-                // no explicit gestationDays/broodSize fields → category default applies
             });
 
             var pendingCommand = BuildPendingCommand("Alice", "Bob", "basilisk");
@@ -244,15 +277,12 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         [Fact]
         public void ProcessInteraction_MultipleCategories_HighestPriorityWins()
         {
-            // Lamia-shaped identifier — snake (priority 6) should beat beast (9), mount (7),
-            // and monster (10). Carapace ties snake at 6 but appears later in the categories
-            // array, so snake stays the best.
             new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
             _fixture.SeedIdentifier(new Identifier
             {
                 type = "lamia",
-                description = "Also known as Naga, these snake like creatures love to wrap others in their coils.",
+                description = "lamia",
                 categories = new[] { "monster", "snake", "beast", "mount", "carapace", "poison" }
             });
 
@@ -263,8 +293,8 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             var bob = _database.GetProfile("Bob");
             var pregnancy = bob.pregnancies.Single();
-            Assert.InRange(pregnancy.BroodSize, 4, 8); // snake brood 4-8
-            Assert.True(pregnancy.ReadyAt <= pregnancy.ConceivedAt.AddDays(3).AddSeconds(1)); // snake 3 days
+            Assert.InRange(pregnancy.BroodSize, 4, 8);
+            Assert.True(pregnancy.ReadyAt <= pregnancy.ConceivedAt.AddDays(3).AddSeconds(1));
         }
 
         [Fact]
@@ -276,7 +306,6 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             {
                 type = "bee",
                 categories = new[] { "monster", "insect", "flight" }
-                // insect (1) beats flight (6) and monster (10).
             });
 
             var pendingCommand = BuildPendingCommand("Alice", "Bob", "bee");
@@ -292,7 +321,6 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         [Fact]
         public void ProcessInteraction_OnlyCosmeticCategories_UsesFallback()
         {
-            // poison, cutting, perfume aren't in the defaults table — fall back to (1 day, brood 1)
             new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
             _fixture.SeedIdentifier(new Identifier
@@ -315,7 +343,6 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         [Fact]
         public void ProcessInteraction_ExplicitGestationOverridesCategory_BroodInheritsFromCategory()
         {
-            // dragon category → 7 day / brood 1, but explicit gestationDays=2 overrides only gestation.
             new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
             _fixture.SeedIdentifier(new Identifier
@@ -333,7 +360,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             var bob = _database.GetProfile("Bob");
             var pregnancy = bob.pregnancies.Single();
             Assert.True(pregnancy.ReadyAt <= pregnancy.ConceivedAt.AddDays(2).AddSeconds(1));
-            Assert.Equal(1, pregnancy.BroodSize); // inherited from dragon
+            Assert.Equal(1, pregnancy.BroodSize); // inherited from dragon (min=max=1) — twin chance disabled by RNG
         }
 
         [Fact]
@@ -360,6 +387,113 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         {
             var identifier = new Identifier { type = "mystery", categories = new string[0] };
             Assert.Null(BreedProcessor.ResolveCategoryDefault(identifier));
+        }
+
+        // ─── Rare twin tests ──────────────────────────────────────────────────
+
+        [Fact]
+        public void RollBroodSize_MinMaxBothOne_NoTwinTrigger_ReturnsOne()
+        {
+            int result = BreedProcessor.RollBroodSize(1, 1, new FixedSampleRandom(0.5), out bool isTwins);
+            Assert.Equal(1, result);
+            Assert.False(isTwins);
+        }
+
+        [Fact]
+        public void RollBroodSize_MinMaxBothOne_TwinTrigger_ReturnsTwoAndSetsFlag()
+        {
+            int result = BreedProcessor.RollBroodSize(1, 1, new FixedSampleRandom(0.0), out bool isTwins);
+            Assert.Equal(2, result);
+            Assert.True(isTwins);
+        }
+
+        [Fact]
+        public void RollBroodSize_MinMaxBothTwo_NoTwinChanceFires()
+        {
+            // Twin chance is gated on min==max==1 specifically.
+            int result = BreedProcessor.RollBroodSize(2, 2, new FixedSampleRandom(0.0), out bool isTwins);
+            Assert.Equal(2, result);
+            Assert.False(isTwins);
+        }
+
+        [Fact]
+        public void ProcessInteraction_RareTwinTriggers_PregnancyFlaggedAndBroodIsTwo()
+        {
+            BreedProcessor.Rng = new FixedSampleRandom(0.0); // Next(100) → 0 → twin fires
+
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "dragon",
+                categories = new[] { "dragon" } // dragon → min=max=1
+            });
+
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "dragon")));
+
+            var bob = _database.GetProfile("Bob");
+            var pregnancy = bob.pregnancies.Single();
+            Assert.Equal(2, pregnancy.BroodSize);
+            Assert.True(pregnancy.IsRareTwins);
+        }
+
+        // ─── Global counter tests ─────────────────────────────────────────────
+
+        [Fact]
+        public void ProcessInteraction_IncrementsGlobalPregnancyCounters()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "lamia",
+                categories = new[] { "monster", "snake", "beast" }
+            });
+
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "lamia")));
+
+            var monsterStats = _database.GetMonsterStats(BreedProcessor.MonsterStatsKey("lamia"));
+            Assert.NotNull(monsterStats);
+            Assert.Equal(1, monsterStats.PregnancyCount);
+            Assert.Equal(0, monsterStats.OffspringCount); // breed doesn't bump offspring
+
+            Assert.Equal(1, _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("monster")).PregnancyCount);
+            Assert.Equal(1, _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("snake")).PregnancyCount);
+            Assert.Equal(1, _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("beast")).PregnancyCount);
+        }
+
+        [Fact]
+        public void ProcessInteraction_GlobalPregnancyCountersAccumulateAcrossBreeds()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "slime",
+                categories = new[] { "slime" }
+            });
+
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "slime")));
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Carol", "slime")));
+
+            Assert.Equal(2, _database.GetMonsterStats(BreedProcessor.MonsterStatsKey("slime")).PregnancyCount);
+            Assert.Equal(2, _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("slime")).PregnancyCount);
+        }
+
+        [Fact]
+        public void ProcessInteraction_UnknownMonster_StillBumpsMonsterTypeCounter()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            // No identifier seeded — categories will be empty but the monster-type key
+            // should still be incremented.
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "mystery")));
+
+            var stats = _database.GetMonsterStats(BreedProcessor.MonsterStatsKey("mystery"));
+            Assert.NotNull(stats);
+            Assert.Equal(1, stats.PregnancyCount);
         }
 
         [Fact]
@@ -397,8 +531,18 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             return pendingCommand;
         }
 
-        public void Dispose()
+        /// <summary>
+        /// A Random whose Sample() always returns the same fixed value. Because Random's
+        /// public methods (Next(int), Next(int,int)) are implemented in terms of Sample,
+        /// overriding it gives us deterministic outcomes for both single-arg and
+        /// range-arg Next calls. Pass 0.5 for "middle of every range, never zero" or 0.0
+        /// for "always lower bound / always trigger rare events keyed on Next(N)==0."
+        /// </summary>
+        private class FixedSampleRandom : Random
         {
+            private readonly double _sample;
+            public FixedSampleRandom(double sample) { _sample = sample; }
+            protected override double Sample() => _sample;
         }
     }
 }

--- a/FChatDicebot/FChatDicebot.Tests/Unit/Chateaubirthtests.cs
+++ b/FChatDicebot/FChatDicebot.Tests/Unit/Chateaubirthtests.cs
@@ -1,5 +1,6 @@
 using FChatDicebot.BotCommands;
 using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
 using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
@@ -28,173 +29,136 @@ namespace FChatDicebot.Tests.Unit.BotCommands
         {
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0], out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
 
-            Assert.Null(result);
-            Assert.NotNull(error);
-            Assert.Contains("no pregnancies", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(string.Empty, result.ChannelMessage);
+            Assert.Contains("aren't pregnant", result.PrivateMessage, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
         public void ExecuteBirth_PregnancyNotReady_ReturnsErrorWithTimeRemaining()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = Guid.NewGuid().ToString("N"),
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow,
-                    ReadyAt = DateTime.UtcNow.AddDays(3),
-                    BroodSize = 1
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 0, readyInDays: 3, broodSize: 1));
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0], out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
 
-            Assert.Null(result);
-            Assert.NotNull(error);
-            Assert.Contains("ready", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(string.Empty, result.ChannelMessage);
+            Assert.Contains("ready", result.PrivateMessage, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ExecuteBirth_NoIndex_BirthsOldestReady()
+        public void ExecuteBirth_SingleReady_BirthsIt()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "first",
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-5),
-                    ReadyAt = DateTime.UtcNow.AddDays(-2),
-                    BroodSize = 1
-                },
-                new Pregnancy
-                {
-                    Id = "second",
-                    Initiator = "Carol",
-                    MonsterType = "wasp",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-3),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 4
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 1));
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0], out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
 
-            Assert.Null(error);
-            Assert.NotNull(result);
-            Assert.Contains("slime", result);
+            Assert.Equal(string.Empty, result.PrivateMessage);
+            Assert.Contains("slime", result.ChannelMessage);
 
             var bob = _database.GetProfile("Bob");
-            Assert.Single(bob.pregnancies);
-            Assert.Equal("second", bob.pregnancies[0].Id);
+            Assert.Empty(bob.pregnancies);
+        }
+
+        [Fact]
+        public void ExecuteBirth_MultipleReady_NoIndex_ListsAllReadyPrivately()
+        {
+            CreateCarrierWithPregnancies("Bob",
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 1),
+                BuildPregnancy("Carol", "wasp", conceivedDaysAgo: 3, readyInDays: -1, broodSize: 4));
+
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
+
+            // Channel gets a short prompt; private gets the numbered list.
+            Assert.Contains("multiple pregnancies", result.ChannelMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("Bob", result.ChannelMessage);
+            Assert.Contains("1:", result.PrivateMessage);
+            Assert.Contains("2:", result.PrivateMessage);
+            Assert.Contains("slime", result.PrivateMessage);
+            Assert.Contains("wasp", result.PrivateMessage);
+            Assert.Contains("Alice", result.PrivateMessage);
+            Assert.Contains("Carol", result.PrivateMessage);
+
+            // No actual birthing happened.
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal(2, bob.pregnancies.Count);
+        }
+
+        [Fact]
+        public void ExecuteBirth_MultipleReady_NotReadyOnesExcludedFromList()
+        {
+            CreateCarrierWithPregnancies("Bob",
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 1),
+                BuildPregnancy("Carol", "wasp", conceivedDaysAgo: 0, readyInDays: 3, broodSize: 4), // not ready
+                BuildPregnancy("Dave", "kobold", conceivedDaysAgo: 4, readyInDays: -1, broodSize: 2));
+
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
+
+            // Two ready → multi-listing path.
+            Assert.Contains("slime", result.PrivateMessage);
+            Assert.Contains("kobold", result.PrivateMessage);
+            Assert.DoesNotContain("wasp", result.PrivateMessage);
         }
 
         [Fact]
         public void ExecuteBirth_ExplicitIndex_BirthsThatPregnancy()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "first",
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-5),
-                    ReadyAt = DateTime.UtcNow.AddDays(-2),
-                    BroodSize = 1
-                },
-                new Pregnancy
-                {
-                    Id = "second",
-                    Initiator = "Carol",
-                    MonsterType = "wasp",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-3),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 4
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 1),
+                BuildPregnancy("Carol", "wasp", conceivedDaysAgo: 3, readyInDays: -1, broodSize: 4));
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "2" }, out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "2" });
 
-            Assert.Null(error);
-            Assert.NotNull(result);
-            Assert.Contains("wasp", result);
+            Assert.Contains("wasp", result.ChannelMessage);
+            Assert.DoesNotContain("multiple pregnancies", result.ChannelMessage, StringComparison.OrdinalIgnoreCase);
 
             var bob = _database.GetProfile("Bob");
             Assert.Single(bob.pregnancies);
-            Assert.Equal("first", bob.pregnancies[0].Id);
+            Assert.Equal("slime", bob.pregnancies[0].MonsterType);
         }
 
         [Fact]
         public void ExecuteBirth_IndexOutOfRange_ReturnsError()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "only",
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-2),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 1
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 2, readyInDays: -1, broodSize: 1));
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "5" }, out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "5" });
 
-            Assert.Null(result);
-            Assert.NotNull(error);
-            Assert.Contains("out of range", error, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(string.Empty, result.ChannelMessage);
+            Assert.Contains("out of range", result.PrivateMessage, StringComparison.OrdinalIgnoreCase);
         }
 
         [Fact]
-        public void ExecuteBirth_OnlyCountsReadyPregnanciesForIndex()
+        public void ExecuteBirth_All_BirthsEveryReady()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "notready",
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow,
-                    ReadyAt = DateTime.UtcNow.AddDays(3),
-                    BroodSize = 1
-                },
-                new Pregnancy
-                {
-                    Id = "ready",
-                    Initiator = "Carol",
-                    MonsterType = "wasp",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-2),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 1
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 1),
+                BuildPregnancy("Carol", "wasp", conceivedDaysAgo: 3, readyInDays: -1, broodSize: 4),
+                BuildPregnancy("Dave", "kobold", conceivedDaysAgo: 0, readyInDays: 3, broodSize: 1)); // not ready
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "1" }, out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "all" });
 
-            Assert.Null(error);
-            Assert.NotNull(result);
-            Assert.Contains("wasp", result);
+            Assert.Equal(string.Empty, result.PrivateMessage);
+            Assert.Contains("slime", result.ChannelMessage);
+            Assert.Contains("wasp", result.ChannelMessage);
+            Assert.DoesNotContain("kobold", result.ChannelMessage);
 
             var bob = _database.GetProfile("Bob");
             Assert.Single(bob.pregnancies);
-            Assert.Equal("notready", bob.pregnancies[0].Id);
+            Assert.Equal("kobold", bob.pregnancies[0].MonsterType);
+            Assert.Equal(2, bob.counts["birth"]); // bumped per birth
         }
 
         [Fact]
-        public void ExecuteBirth_AppendsOffspringListEntryAndBumpsBirthCount()
+        public void ExecuteBirth_AppendsOffspringListEntry()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "only",
-                    Initiator = "Alice",
-                    MonsterType = "slime",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-2),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 3
-                });
+                BuildPregnancy("Alice", "slime", conceivedDaysAgo: 2, readyInDays: -1, broodSize: 3));
 
-            ChateauBirth.ExecuteBirth(_database, "Bob", new string[0], out string error);
-            Assert.Null(error);
+            ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
 
             var bob = _database.GetProfile("Bob");
             Assert.True(bob.lists.ContainsKey("offspring"));
@@ -206,32 +170,76 @@ namespace FChatDicebot.Tests.Unit.BotCommands
         }
 
         [Fact]
-        public void ExecuteBirth_BroodSizeOnePhrasing_UsesAnOrA()
+        public void ExecuteBirth_RareTwins_UsesSpecialPhrasing()
+        {
+            var twinPregnancy = BuildPregnancy("Alice", "imp", conceivedDaysAgo: 2, readyInDays: -1, broodSize: 2);
+            twinPregnancy.IsRareTwins = true;
+            CreateCarrierWithPregnancies("Bob", twinPregnancy);
+
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
+
+            Assert.Contains("twins", result.ChannelMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("miraculous", result.ChannelMessage, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("imp", result.ChannelMessage);
+        }
+
+        [Fact]
+        public void ExecuteBirth_BroodOfOne_UsesAnOrA()
         {
             CreateCarrierWithPregnancies("Bob",
-                new Pregnancy
-                {
-                    Id = "only",
-                    Initiator = "Alice",
-                    MonsterType = "imp",
-                    ConceivedAt = DateTime.UtcNow.AddDays(-2),
-                    ReadyAt = DateTime.UtcNow.AddDays(-1),
-                    BroodSize = 1
-                });
+                BuildPregnancy("Alice", "imp", conceivedDaysAgo: 2, readyInDays: -1, broodSize: 1));
 
-            string result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0], out string error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
 
-            Assert.Null(error);
-            Assert.Contains("imp", result);
-            Assert.DoesNotContain("brood of", result);
+            Assert.Contains("imp", result.ChannelMessage);
+            Assert.DoesNotContain("brood of", result.ChannelMessage);
+            Assert.DoesNotContain("twins", result.ChannelMessage);
+        }
+
+        [Fact]
+        public void ExecuteBirth_IncrementsGlobalOffspringCounters()
+        {
+            var pregnancy = BuildPregnancy("Alice", "lamia", conceivedDaysAgo: 2, readyInDays: -1, broodSize: 5);
+            pregnancy.Categories = new List<string> { "monster", "snake", "beast" };
+            CreateCarrierWithPregnancies("Bob", pregnancy);
+
+            ChateauBirth.ExecuteBirth(_database, "Bob", new string[0]);
+
+            var monsterStats = _database.GetMonsterStats(BreedProcessor.MonsterStatsKey("lamia"));
+            Assert.NotNull(monsterStats);
+            Assert.Equal(0, monsterStats.PregnancyCount); // birth doesn't bump pregnancy count
+            Assert.Equal(5, monsterStats.OffspringCount);
+
+            var snakeStats = _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("snake"));
+            Assert.Equal(5, snakeStats.OffspringCount);
+
+            var beastStats = _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("beast"));
+            Assert.Equal(5, beastStats.OffspringCount);
+        }
+
+        [Fact]
+        public void ExecuteBirth_All_AggregatesOffspringCountersAcrossBirths()
+        {
+            var p1 = BuildPregnancy("Alice", "slime", conceivedDaysAgo: 5, readyInDays: -2, broodSize: 3);
+            p1.Categories = new List<string> { "slime" };
+            var p2 = BuildPregnancy("Alice", "slime", conceivedDaysAgo: 4, readyInDays: -1, broodSize: 4);
+            p2.Categories = new List<string> { "slime" };
+            CreateCarrierWithPregnancies("Bob", p1, p2);
+
+            ChateauBirth.ExecuteBirth(_database, "Bob", new[] { "all" });
+
+            var stats = _database.GetMonsterStats(BreedProcessor.MonsterStatsKey("slime"));
+            Assert.Equal(7, stats.OffspringCount);
+            var slimeCat = _database.GetMonsterStats(BreedProcessor.CategoryStatsKey("slime"));
+            Assert.Equal(7, slimeCat.OffspringCount);
         }
 
         [Fact]
         public void ExecuteBirth_UnknownUser_ReturnsError()
         {
-            string result = ChateauBirth.ExecuteBirth(_database, "Ghost", new string[0], out string error);
-            Assert.Null(result);
-            Assert.NotNull(error);
+            var result = ChateauBirth.ExecuteBirth(_database, "Ghost", new string[0]);
+            Assert.Equal(string.Empty, result.ChannelMessage);
+            Assert.NotEqual(string.Empty, result.PrivateMessage);
         }
 
         private void CreateCarrierWithPregnancies(string userName, params Pregnancy[] pregnancies)
@@ -243,6 +251,19 @@ namespace FChatDicebot.Tests.Unit.BotCommands
 
             carrier.pregnancies = new List<Pregnancy>(pregnancies);
             _database.SetProfile(userName, carrier);
+        }
+
+        private static Pregnancy BuildPregnancy(string initiator, string monsterType, int conceivedDaysAgo, int readyInDays, int broodSize)
+        {
+            return new Pregnancy
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Initiator = initiator,
+                MonsterType = monsterType,
+                ConceivedAt = DateTime.UtcNow.AddDays(-conceivedDaysAgo),
+                ReadyAt = DateTime.UtcNow.AddDays(readyInDays),
+                BroodSize = broodSize
+            };
         }
 
         public void Dispose()

--- a/FChatDicebot/FChatDicebot/BotCommands/ChateauBirth.cs
+++ b/FChatDicebot/FChatDicebot/BotCommands/ChateauBirth.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
 
 namespace FChatDicebot.BotCommands
@@ -28,93 +30,185 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
-            string completion = ExecuteBirth(MonDB.GetDatabase(), characterName, rawTerms, out string error);
-            if (error != null)
+            BirthResult result = ExecuteBirth(MonDB.GetDatabase(), characterName, rawTerms);
+            if (!string.IsNullOrEmpty(result.PrivateMessage))
             {
-                bot.SendPrivateMessage(error, characterName);
-                return;
+                bot.SendPrivateMessage(result.PrivateMessage, characterName);
             }
-            bot.SendMessageInChannel(completion, channel);
+            if (!string.IsNullOrEmpty(result.ChannelMessage))
+            {
+                bot.SendMessageInChannel(result.ChannelMessage, channel);
+            }
+        }
+
+        public class BirthResult
+        {
+            public string ChannelMessage { get; set; } = string.Empty;
+            public string PrivateMessage { get; set; } = string.Empty;
         }
 
         /// <summary>
-        /// Pure birthing logic, factored out for testability. Returns the completion message on
-        /// success and sets <paramref name="error"/> to a non-null reason on failure.
+        /// Pure birthing logic, factored out for testability. The returned result has
+        /// non-empty ChannelMessage on a successful birth (or '!birth all'), non-empty
+        /// PrivateMessage on errors or when the user has multiple ready pregnancies and
+        /// must pick one. Both can be set simultaneously: when listing the choices to a
+        /// user, a short prompt is also posted in the channel.
         /// </summary>
-        public static string ExecuteBirth(Database.IChateauDatabase database, string characterName, string[] rawTerms, out string error)
+        public static BirthResult ExecuteBirth(IChateauDatabase database, string characterName, string[] rawTerms)
         {
-            error = null;
+            var result = new BirthResult();
             Profile carrier = database.GetProfile(characterName);
             if (carrier == null)
             {
-                error = ChateauInteractionHandler.notFoundText(characterName);
-                return null;
+                result.PrivateMessage = ChateauInteractionHandler.notFoundText(characterName);
+                return result;
             }
 
             List<Pregnancy> pregnancies = carrier.pregnancies ?? new List<Pregnancy>();
             DateTime now = DateTime.UtcNow;
 
-            var ordered = pregnancies
-                .Select((p, originalIndex) => new { Pregnancy = p, OriginalIndex = originalIndex })
-                .OrderBy(x => x.Pregnancy.ConceivedAt)
+            var ready = pregnancies
+                .Where(p => p.ReadyAt <= now)
+                .OrderBy(p => p.ConceivedAt)
                 .ToList();
-            var ready = ordered.Where(x => x.Pregnancy.ReadyAt <= now).ToList();
-
-            int? requestedIndex = ParseIndex(rawTerms);
 
             if (ready.Count == 0)
             {
                 if (pregnancies.Count == 0)
                 {
-                    error = "You aren't pregnant! Ask someone to !breed you first.";
+                    result.PrivateMessage = "You aren't pregnant! Ask someone to !breed you first.";
                 }
                 else
                 {
-                    var soonest = ordered.OrderBy(x => x.Pregnancy.ReadyAt).First().Pregnancy;
+                    var soonest = pregnancies.OrderBy(p => p.ReadyAt).First();
                     string remaining = Utils.GetTimeSpanPrint(soonest.ReadyAt - now);
-                    error = pregnancies.Count == 1 ? "You aren't ready to give birth yet. Your young will be ready in " + remaining + "." : "None of your young are ready yet. The next will be ready in " + remaining + ".";
+                    result.PrivateMessage = pregnancies.Count == 1
+                        ? "You aren't ready to give birth yet. Your young will be ready in " + remaining + "."
+                        : "None of your young are ready yet. The next will be ready in " + remaining + ".";
                 }
-                return null;
+                return result;
             }
 
-            var target = ready[0];
-            if (requestedIndex.HasValue)
+            bool birthAll = HasAllTerm(rawTerms);
+            int? requestedIndex = birthAll ? (int?)null : ParseIndex(rawTerms);
+
+            // Multi-ready, no explicit choice → list them and let the user pick. Mirrors
+            // the multi-pending-!consent UX in ChateauConsent.cs.
+            if (ready.Count > 1 && !birthAll && !requestedIndex.HasValue)
+            {
+                result.PrivateMessage = BuildReadyList(ready);
+                result.ChannelMessage = "There's multiple pregnancies ready to be born, " + characterName
+                    + ". Either '!birth all', or refer to the list we just messaged you.";
+                return result;
+            }
+
+            // Decide which pregnancies to birth.
+            List<Pregnancy> toBirth;
+            if (birthAll)
+            {
+                toBirth = ready;
+            }
+            else if (requestedIndex.HasValue)
             {
                 int idx = requestedIndex.Value;
                 if (idx < 1 || idx > ready.Count)
                 {
-                    error = "Pregnancy index out of range. You have " + ready.Count + " ready "
+                    result.PrivateMessage = "Pregnancy index out of range. You have " + ready.Count + " ready "
                         + (ready.Count == 1 ? "pregnancy" : "pregnancies") + ".";
-                    return null;
+                    return result;
                 }
-                target = ready[idx - 1];
+                toBirth = new List<Pregnancy> { ready[idx - 1] };
+            }
+            else
+            {
+                toBirth = new List<Pregnancy> { ready[0] };
             }
 
-            carrier.pregnancies.RemoveAt(target.OriginalIndex);
+            // All in-memory mutations on the carrier, then one save. References from
+            // 'toBirth' point into carrier.pregnancies, so List.Remove finds them.
+            if (carrier.lists == null) carrier.lists = new Dictionary<string, List<string>>();
+            if (!carrier.lists.ContainsKey("offspring")) carrier.lists["offspring"] = new List<string>();
 
-            string offspringLabel = "offspring";
-            if (carrier.lists == null)
+            var channelParts = new List<string>();
+            foreach (var pregnancy in toBirth)
             {
-                carrier.lists = new Dictionary<string, List<string>>();
+                carrier.pregnancies.Remove(pregnancy);
+                carrier.lists["offspring"].Add(now.ToString("yyyy-MM-dd") + ": " + pregnancy.MonsterType
+                    + " brood of " + pregnancy.BroodSize
+                    + " (parent: " + pregnancy.Initiator + ")");
+                channelParts.Add(BuildCompletionMessage(carrier, pregnancy));
             }
-            if (!carrier.lists.ContainsKey(offspringLabel))
-            {
-                carrier.lists[offspringLabel] = new List<string>();
-            }
-            string offspringEntry = now.ToString("yyyy-MM-dd") + ": " + target.Pregnancy.MonsterType
-                + " brood of " + target.Pregnancy.BroodSize
-                + " (parent: " + target.Pregnancy.Initiator + ")";
-            carrier.lists[offspringLabel].Add(offspringEntry);
 
             database.SetProfile(characterName, carrier);
-            database.IncrementCount(characterName, "birth");
+            for (int i = 0; i < toBirth.Count; i++)
+            {
+                database.IncrementCount(characterName, "birth");
+            }
 
-            string broodPhrase = target.Pregnancy.BroodSize > 1
-                ? "a brood of " + target.Pregnancy.BroodSize + " " + target.Pregnancy.MonsterType + "s" //do we have a pluralization rule for monster types that don't pluralize with an 's'?
-                : Utils.AnOrA(target.Pregnancy.MonsterType) + " " + target.Pregnancy.MonsterType;
+            // Global offspring counters (monster type + each snapshotted category).
+            foreach (var pregnancy in toBirth)
+            {
+                IncrementGlobalOffspringCounts(database, pregnancy);
+            }
+
+            result.ChannelMessage = string.Join("\n", channelParts);
+            return result;
+        }
+
+        private static void IncrementGlobalOffspringCounts(IChateauDatabase database, Pregnancy pregnancy)
+        {
+            if (string.IsNullOrEmpty(pregnancy.MonsterType) || pregnancy.BroodSize <= 0) return;
+            database.IncrementMonsterStats(BreedProcessor.MonsterStatsKey(pregnancy.MonsterType), pregnancyDelta: 0, offspringDelta: pregnancy.BroodSize);
+            if (pregnancy.Categories == null) return;
+            foreach (var category in pregnancy.Categories)
+            {
+                if (string.IsNullOrEmpty(category)) continue;
+                database.IncrementMonsterStats(BreedProcessor.CategoryStatsKey(category), pregnancyDelta: 0, offspringDelta: pregnancy.BroodSize);
+            }
+        }
+
+        private static string BuildCompletionMessage(Profile carrier, Pregnancy pregnancy)
+        {
+            // Rare-twins flavor: the resolved brood range was [1,1] and the 1% roll fired.
+            if (pregnancy.IsRareTwins)
+            {
+                return carrier.displayName + " has miraculously given birth to a pair of " + pregnancy.MonsterType
+                    + " twins — a rare blessing for a species that normally bears just one! (Sired by "
+                    + pregnancy.Initiator + ".)";
+            }
+
+            string broodPhrase = pregnancy.BroodSize > 1
+                ? "a brood of " + pregnancy.BroodSize + " " + pregnancy.MonsterType + "s"
+                : Utils.AnOrA(pregnancy.MonsterType) + " " + pregnancy.MonsterType;
 
             return carrier.displayName + " has given birth to " + broodPhrase
-                + "! (Sired by " + target.Pregnancy.Initiator + ".)";
+                + "! (Sired by " + pregnancy.Initiator + ".)";
+        }
+
+        private static string BuildReadyList(List<Pregnancy> ready)
+        {
+            string msg = "Use '!birth #' to birth the pregnancy of your choice, or '!birth all' to birth all of them. You have the following pregnancies ready:";
+            int n = 1;
+            foreach (var pregnancy in ready)
+            {
+                msg += "\n" + n + ": [b]" + pregnancy.MonsterType + "[/b] sired by [user]" + pregnancy.Initiator + "[/user]";
+                if (pregnancy.BroodSize > 1)
+                {
+                    msg += " (brood of " + pregnancy.BroodSize + ")";
+                }
+                n++;
+            }
+            return msg;
+        }
+
+        private static bool HasAllTerm(string[] rawTerms)
+        {
+            if (rawTerms == null) return false;
+            foreach (string term in rawTerms)
+            {
+                if (string.Equals(term?.Trim(), "all", StringComparison.OrdinalIgnoreCase)) return true;
+            }
+            return false;
         }
 
         private static int? ParseIndex(string[] rawTerms)

--- a/FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs
@@ -606,6 +606,28 @@ namespace FChatDicebot.Database
             return null;
         }
 
+        // Monster Stats Operations (global aggregate counts for breed/birth)
+        public MonsterStats GetMonsterStats(string key)
+        {
+            var collection = Database.GetCollection<MonsterStats>("MonsterStats");
+            var filter = Builders<MonsterStats>.Filter.Eq(s => s.Id, key);
+            return collection.Find(filter).FirstOrDefault();
+        }
+
+        public void IncrementMonsterStats(string key, int pregnancyDelta, int offspringDelta)
+        {
+            if (string.IsNullOrEmpty(key)) return;
+            if (pregnancyDelta == 0 && offspringDelta == 0) return;
+
+            var collection = Database.GetCollection<MonsterStats>("MonsterStats");
+            var filter = Builders<MonsterStats>.Filter.Eq(s => s.Id, key);
+            var update = Builders<MonsterStats>.Update
+                .Inc(s => s.PregnancyCount, pregnancyDelta)
+                .Inc(s => s.OffspringCount, offspringDelta);
+            var options = new UpdateOptions { IsUpsert = true };
+            collection.UpdateOne(filter, update, options);
+        }
+
         // Mod Message Operations
         public string GetModMessage(string messageLabel)
         {

--- a/FChatDicebot/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/FChatDicebot/Database/Ichateaudatabase.cs
@@ -70,6 +70,10 @@ namespace FChatDicebot.Database
         List<Identifier> GetIdentifiersByCategory(string category);
         List<Identifier> GetAllIdentifiers();
 
+        // Monster Stats Operations (global aggregate counts for breed/birth)
+        MonsterStats GetMonsterStats(string key);
+        void IncrementMonsterStats(string key, int pregnancyDelta, int offspringDelta);
+
         // Mod Message Operations
         string GetModMessage(string messageLabel);
 

--- a/FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
+++ b/FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
@@ -16,6 +16,18 @@ namespace FChatDicebot.InteractionProcessors.Commitment
         public const int MaxGestationDays = 7;
         public const int DefaultGestationDays = 1;
         public const int DefaultBroodSize = 1;
+        public const int RareTwinChanceDenominator = 100; // 1-in-100 → 1% chance
+
+        // Single mutable RNG used for brood-size rolls. Tests can swap this out for a
+        // seeded Random to make twin-chance and brood-range outcomes deterministic.
+        // (Random isn't thread-safe; the bot processes one command at a time so that's
+        // fine here.)
+        internal static Random Rng = new Random();
+
+        // Key-prefix helpers for MonsterStats so the "monster type" and "category"
+        // namespaces can't collide.
+        public static string MonsterStatsKey(string monsterType) => "monster:" + monsterType.ToLowerInvariant();
+        public static string CategoryStatsKey(string category) => "category:" + category.ToLowerInvariant();
 
         internal struct CategoryDefault
         {
@@ -124,7 +136,13 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             Profile recipientProfile = Database.GetProfile(recipient);
 
             Identifier monsterIdentifier = Database.GetIdentifier(monsterType);
-            ResolveGestationAndBrood(monsterIdentifier, out int gestationDays, out int broodSize);
+            ResolveGestationAndBrood(monsterIdentifier, Rng, out int gestationDays, out int broodSize, out bool isRareTwins);
+
+            // Snapshot the monster's categories on the pregnancy so birth-time category
+            // counters don't need to re-fetch the Identifier (which could have changed).
+            List<string> categoriesSnapshot = monsterIdentifier?.categories != null
+                ? new List<string>(monsterIdentifier.categories)
+                : new List<string>();
 
             DateTime now = DateTime.UtcNow;
             Pregnancy pregnancy = new Pregnancy
@@ -134,7 +152,9 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 MonsterType = monsterType,
                 ConceivedAt = now,
                 ReadyAt = now.AddDays(gestationDays),
-                BroodSize = broodSize
+                BroodSize = broodSize,
+                Categories = categoriesSnapshot,
+                IsRareTwins = isRareTwins
             };
 
             if (recipientProfile.pregnancies == null)
@@ -150,9 +170,30 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             Database.SetProfile(initiator, initiatorProfile);
             Database.SetProfile(recipient, recipientProfile);
 
+            // Bump the global pregnancy counter for this monster type and each of its
+            // categories. Offspring counters are bumped at birth time, not here.
+            IncrementGlobalPregnancyCounts(Database, monsterType, categoriesSnapshot);
+
             Database.DeletePendingCommand(command.Id);
 
             return "breed";
+        }
+
+        /// <summary>
+        /// Increment the global pregnancy counter by 1 for the monster type and for each
+        /// of its categories. Used at breed time. (Offspring counters live separately and
+        /// are bumped at birth time by ChateauBirth.)
+        /// </summary>
+        public static void IncrementGlobalPregnancyCounts(IChateauDatabase database, string monsterType, IEnumerable<string> categories)
+        {
+            if (string.IsNullOrEmpty(monsterType)) return;
+            database.IncrementMonsterStats(MonsterStatsKey(monsterType), pregnancyDelta: 1, offspringDelta: 0);
+            if (categories == null) return;
+            foreach (var category in categories)
+            {
+                if (string.IsNullOrEmpty(category)) continue;
+                database.IncrementMonsterStats(CategoryStatsKey(category), pregnancyDelta: 1, offspringDelta: 0);
+            }
         }
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
@@ -188,8 +229,12 @@ namespace FChatDicebot.InteractionProcessors.Commitment
         /// otherwise the absolute fallback (1 day, brood 1) is used. Each field is
         /// resolved independently — a monster can override only gestation while
         /// inheriting brood size from its category, or vice versa.
+        ///
+        /// When the resolved brood range is exactly [1, 1], a 1% twin chance applies:
+        /// the roll yields 2 instead of 1 and <paramref name="isRareTwins"/> is set so
+        /// the birth message can emit special flavor.
         /// </summary>
-        internal static void ResolveGestationAndBrood(Identifier monsterIdentifier, out int gestationDays, out int broodSize)
+        internal static void ResolveGestationAndBrood(Identifier monsterIdentifier, Random random, out int gestationDays, out int broodSize, out bool isRareTwins)
         {
             CategoryDefault? categoryDefault = ResolveCategoryDefault(monsterIdentifier);
 
@@ -221,7 +266,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             }
 
             gestationDays = ClampGestation(resolvedGestation);
-            broodSize = RollBroodSize(resolvedBroodMin, resolvedBroodMax);
+            broodSize = RollBroodSize(resolvedBroodMin, resolvedBroodMax, random, out isRareTwins);
         }
 
         internal static CategoryDefault? ResolveCategoryDefault(Identifier monsterIdentifier)
@@ -254,12 +299,23 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             return rawDays;
         }
 
-        private static int RollBroodSize(int rawMin, int rawMax)
+        internal static int RollBroodSize(int rawMin, int rawMax, Random random, out bool isRareTwins)
         {
+            isRareTwins = false;
             int min = rawMin > 0 ? rawMin : DefaultBroodSize;
             int max = rawMax >= min ? rawMax : min;
-            if (min == max) return min;
-            return new Random().Next(min, max + 1);
+            if (min == max)
+            {
+                // Rare twin chance only fires when both bounds are exactly 1 (the
+                // monster would otherwise always birth a single offspring).
+                if (min == 1 && random.Next(RareTwinChanceDenominator) == 0)
+                {
+                    isRareTwins = true;
+                    return 2;
+                }
+                return min;
+            }
+            return random.Next(min, max + 1);
         }
     }
 }

--- a/FChatDicebot/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/FChatDicebot/Model/ChateauDB.cs
@@ -38,6 +38,31 @@ namespace FChatDicebot.Model
         public DateTime ConceivedAt { get; set; }
         public DateTime ReadyAt { get; set; }
         public int BroodSize { get; set; }
+        // Snapshot of the monster's categories at breed time. Stored on the pregnancy
+        // so birth can update per-category global counters without re-fetching the
+        // Identifier (which may have been edited or removed between breed and birth).
+        [BsonIgnoreIfNull]
+        public List<string> Categories { get; set; }
+        // True when the brood-size roll triggered the rare twin event (the monster's
+        // resolved min and max were both 1, but the 1% twin chance produced 2 anyway).
+        // Used to emit special "rare twins" flavor in the birth message.
+        [BsonIgnoreIfDefault]
+        public bool IsRareTwins { get; set; }
+    }
+
+    /// <summary>
+    /// Aggregate count of all pregnancies conceived and all offspring born for either a
+    /// specific monster type or a category. Keys are prefixed with "monster:" or
+    /// "category:" so the two namespaces can't collide. Maintained incrementally at
+    /// breed/birth time; could in principle be reconstructed by re-scanning every
+    /// profile and historical interaction.
+    /// </summary>
+    public class MonsterStats
+    {
+        [BsonId]
+        public string Id { get; set; } // e.g. "monster:lamia" or "category:snake"
+        public int PregnancyCount { get; set; }
+        public int OffspringCount { get; set; }
     }
 
     public class Title


### PR DESCRIPTION
## Summary

Three follow-up changes on top of the breed/birth feature merged in [#9](https://github.com/JoBiden/FCDiceBotCCVer/pull/9):

1. **Multi-ready listing UX.** `!birth` with no index when multiple pregnancies are ready now privately messages the carrier a numbered list of their ready pregnancies (monster type + sire) and posts a short channel prompt — mirrors the existing `!consent` multi-pending pattern. Adds `!birth all` to birth every ready pregnancy at once.
2. **Rare twin chance.** When the resolved brood range is exactly `[1, 1]`, a 1% roll can produce 2 offspring instead. The `Pregnancy` carries a new `IsRareTwins` flag and the birth message emits special *"miraculously given birth to a pair of {type} twins — a rare blessing..."* flavor.
3. **Global monster stats.** New `MonsterStats` collection with prefixed keys (`monster:lamia`, `category:snake`) tracking aggregate pregnancy and offspring counts per monster type and per category. Breed bumps the pregnancy counter; birth bumps the offspring counter by brood size. Could be reconstructed by re-scanning every profile + interaction history, but maintaining incrementally makes future readouts O(1).

## What changed

| File | Change |
| --- | --- |
| [BotCommands/ChateauBirth.cs](FChatDicebot/FChatDicebot/BotCommands/ChateauBirth.cs) | `ExecuteBirth` returns `BirthResult { ChannelMessage, PrivateMessage }`. Adds multi-ready listing path, `!birth all`, twin special text, and global offspring-counter increments. |
| [InteractionProcessors/Commitment/BreedProcessor.cs](FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs) | Extracts `Random` to a swappable static `Rng` for tests; `RollBroodSize` now takes a `Random` and emits an `isRareTwins` flag. Snapshots monster categories onto the new `Pregnancy.Categories` field. Adds `MonsterStatsKey` / `CategoryStatsKey` helpers and `IncrementGlobalPregnancyCounts`. |
| [Model/ChateauDB.cs](FChatDicebot/FChatDicebot/Model/ChateauDB.cs) | New `MonsterStats` class; `Pregnancy` gains `Categories` and `IsRareTwins` fields (both `BsonIgnoreIfDefault`/`Null`, no migration needed). |
| [Database/Ichateaudatabase.cs](FChatDicebot/FChatDicebot/Database/Ichateaudatabase.cs) | New `GetMonsterStats(key)` and `IncrementMonsterStats(key, pregnancyDelta, offspringDelta)` methods. |
| [Database/Chateaudatabase.cs](FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs) | Implements the new methods with a single MongoDB upsert + `$inc` update so the counter document is created lazily on first hit. |
| [Tests/Fixtures/Testdatabasefixture.cs](FChatDicebot/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs) | Clears `MonsterStats` on `Reset`. |
| [Tests/Unit/Breedprocessortests.cs](FChatDicebot/FChatDicebot.Tests/Unit/Breedprocessortests.cs) | Adds `FixedSampleRandom` for deterministic RNG; new tests for category snapshot, twin trigger/no-trigger paths, global pregnancy counters, unknown-monster counter, accumulation across breeds. |
| [Tests/Unit/Chateaubirthtests.cs](FChatDicebot/FChatDicebot.Tests/Unit/Chateaubirthtests.cs) | Updated for `BirthResult` API; new tests for multi-ready listing, `!birth all`, not-ready exclusion from list, twin flavor, offspring counters per-monster and per-category, aggregation across `!birth all`. |

## Notes

- **Twin chance specifically requires `min==max==1`.** Monsters with a natural multi-brood range don't get extra free brood from the twin event.
- **`BirthResult` lets both messages be set simultaneously** — that's how the multi-ready listing case posts the short prompt in channel and the detailed list privately.
- **`IncrementMonsterStats` is an upsert** so existing deployments need no migration; documents materialize on first hit.
- Pre-existing test comment at [ChateauBreed.cs:55](FChatDicebot/FChatDicebot/BotCommands/ChateauBreed.cs#L55) (`//test comment to confirm Claude sees this edit`) left untouched.

## Test plan

- [x] `dotnet build` — 0 errors.
- [x] `dotnet test` — 547 passed / 0 failed (13 new + 534 pre-existing).
- [ ] Manual: with 2+ ready pregnancies, run `!birth` in channel — verify private DM shows the numbered list and channel shows the prompt. Then run `!birth 2` and `!birth all` to verify each path.
- [ ] Manual: breed a dragon-category monster (min=max=1) ~100 times and observe the rare twin event firing roughly once.
- [ ] Manual: query MongoDB `MonsterStats` collection after a breed/birth cycle to verify both `monster:<type>` and `category:<each>` documents exist with sensible counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)