### PR TITLE
Add Status-Effect Hook infrastructure (Tier 0)

### DIFF
--- a/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
+++ b/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
@@ -1,0 +1,422 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for the status-effect hook infrastructure: contributors registered in
+    /// <see cref="StatusEffectRegistry"/>, aggregated by
+    /// <c>InteractionProcessorBase.GetActiveStatusEffects</c>, surfaced through default
+    /// <see cref="InteractionProcessorBase.GetConsentWarning"/> and
+    /// <see cref="InteractionProcessorBase.ValidateInteraction"/>.
+    /// </summary>
+    [Collection("Database")]
+    public class StatusEffectHookTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly TestProcessor _processor;
+
+        public StatusEffectHookTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+
+            // Tests inject their own contributors; start every test with an empty registry.
+            StatusEffectRegistry.Clear();
+
+            _processor = new TestProcessor(_database);
+        }
+
+        public void Dispose()
+        {
+            // Don't leak per-test contributors into other test classes that may run after.
+            StatusEffectRegistry.Clear();
+        }
+
+        // -------------------------------------------------------------------
+        // Aggregation behavior
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void NoContributors_ReturnsEmptyFragments()
+        {
+            var profile = new ProfileBuilder().Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            Assert.Empty(result.ConsentWarnings);
+            Assert.Empty(result.CompletionAppendix);
+            Assert.Empty(result.Blockers);
+        }
+
+        [Fact]
+        public void NullProfile_ReturnsEmptyFragments()
+        {
+            StatusEffectRegistry.RegisterContributor(
+                new FakeContributor(consentWarning: "[scent fragment]"));
+
+            var result = _processor.CallGetActiveStatusEffects(null, StatusEffectCallSite.Consent);
+
+            Assert.Empty(result.ConsentWarnings);
+            Assert.Empty(result.CompletionAppendix);
+            Assert.Empty(result.Blockers);
+        }
+
+        [Fact]
+        public void Consent_CallSite_ReturnsConsentWarningOnly()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(
+                consentWarning: "(consent text)",
+                completionAppendix: "(completion text)"));
+            var profile = new ProfileBuilder().Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            // Fragments are stored verbatim (no leading whitespace); the base spacing convention
+            // is applied at composition time in AppendStatusFragments, not in the helper.
+            Assert.Single(result.ConsentWarnings);
+            Assert.Equal("(consent text)", result.ConsentWarnings[0]);
+            // FakeContributor returns both lists regardless of call site, so completion text
+            // also flows through; the discrimination is the contributor's responsibility.
+            Assert.Single(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Completion_CallSite_ContributorSeesCorrectSite()
+        {
+            var fake = new FakeContributor(
+                consentWarning: "(consent text)",
+                completionAppendix: "(completion text)");
+            StatusEffectRegistry.RegisterContributor(fake);
+            var profile = new ProfileBuilder().Build();
+
+            _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Completion);
+
+            Assert.Equal(StatusEffectCallSite.Completion, fake.LastCallSite);
+        }
+
+        [Fact]
+        public void Contributor_ReceivesInteractionTypeAndInitiatorFlag()
+        {
+            var fake = new FakeContributor();
+            StatusEffectRegistry.RegisterContributor(fake);
+            var profile = new ProfileBuilder().Build();
+
+            _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent, isInitiator: true);
+
+            Assert.Equal("testinteraction", fake.LastInteractionType);
+            Assert.True(fake.LastIsInitiator);
+        }
+
+        [Fact]
+        public void MultipleContributors_MergeInRegistrationOrder()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "AAA"));
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "BBB"));
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "CCC"));
+            var profile = new ProfileBuilder().Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            Assert.Equal(new[] { "AAA", "BBB", "CCC" }, result.ConsentWarnings);
+        }
+
+        [Fact]
+        public void ContributorThatThrows_DoesNotBreakHelper()
+        {
+            StatusEffectRegistry.RegisterContributor(new ThrowingContributor());
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "after-throw"));
+            var profile = new ProfileBuilder().Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            Assert.Single(result.ConsentWarnings);
+            Assert.Equal("after-throw", result.ConsentWarnings[0]);
+        }
+
+        // -------------------------------------------------------------------
+        // Odorize-style fade: contributor mutates its own profile state
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void OdorizeStyleContributor_DecrementsCounterOnEachCall()
+        {
+            var profile = new ProfileBuilder().Build();
+            profile.characteristics["odorize_musk_uses"] = "3";
+            StatusEffectRegistry.RegisterContributor(new FakeOdorizeContributor("odorize_musk_uses", "(musk lingers)"));
+
+            var first = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Completion);
+            Assert.Single(first.CompletionAppendix);
+            Assert.Equal("2", profile.characteristics["odorize_musk_uses"]);
+
+            var second = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Completion);
+            Assert.Single(second.CompletionAppendix);
+            Assert.Equal("1", profile.characteristics["odorize_musk_uses"]);
+
+            var third = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Completion);
+            Assert.Single(third.CompletionAppendix);
+            Assert.Equal("0", profile.characteristics["odorize_musk_uses"]);
+
+            // Exhausted: no fragment, counter does not go negative.
+            var fourth = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Completion);
+            Assert.Empty(fourth.CompletionAppendix);
+            Assert.Equal("0", profile.characteristics["odorize_musk_uses"]);
+        }
+
+        // -------------------------------------------------------------------
+        // Break-style blockers
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void BreakStyleBlocker_AppearsInBlockersList()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeBreakContributor(
+                bodyPart: "mouth",
+                blockedInteractionType: "testinteraction",
+                reason: "Bob's mouth is broken and cannot be kissed."));
+            var profile = new ProfileBuilder().WithDisplayName("Bob").Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            Assert.Single(result.Blockers);
+            var blocker = result.Blockers[0];
+            Assert.True(blocker.BlocksRecipient);
+            Assert.False(blocker.BlocksInitiator);
+            Assert.Equal("break:mouth", blocker.Source);
+            Assert.Contains("Bob's mouth is broken", blocker.Reason);
+        }
+
+        [Fact]
+        public void BreakBlocker_DoesNotApplyToUnrelatedInteractionType()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeBreakContributor(
+                bodyPart: "mouth",
+                blockedInteractionType: "feed",   // Different interaction
+                reason: "irrelevant"));
+            var profile = new ProfileBuilder().Build();
+
+            var result = _processor.CallGetActiveStatusEffects(profile, StatusEffectCallSite.Consent);
+
+            Assert.Empty(result.Blockers);
+        }
+
+        // -------------------------------------------------------------------
+        // Default GetConsentWarning / ValidateInteraction integration
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void DefaultGetConsentWarning_AppendsConsentFragments_WithSingleSpace()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "[musk lingers]"));
+
+            var initiator = new ProfileBuilder().WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, identifier: "");
+
+            Assert.Contains("Alice", warning);
+            Assert.Contains("Bob", warning);
+            Assert.EndsWith("Do you !consent? [musk lingers]", warning);
+            Assert.DoesNotContain("?  [musk", warning);
+        }
+
+        [Fact]
+        public void DefaultGetConsentWarning_MultipleFragments_EachGetsOneLeadingSpace()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "[scent A]"));
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "[scent B]"));
+
+            var initiator = new ProfileBuilder().WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, identifier: "");
+
+            Assert.EndsWith("Do you !consent? [scent A] [scent B]", warning);
+        }
+
+        [Fact]
+        public void DefaultGetConsentWarning_EmptyFragmentSkipped()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: ""));
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(consentWarning: "[real]"));
+
+            var initiator = new ProfileBuilder().WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, identifier: "");
+
+            Assert.EndsWith("Do you !consent? [real]", warning);
+        }
+
+        [Fact]
+        public void DefaultValidateInteraction_RecipientBlocker_FailsValidation()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            StatusEffectRegistry.RegisterContributor(new FakeBreakContributor(
+                bodyPart: "mouth",
+                blockedInteractionType: "testinteraction",
+                reason: "Bob's mouth is broken."));
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "");
+
+            Assert.False(result.IsValid);
+            Assert.Equal("Bob's mouth is broken.", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void DefaultValidateInteraction_NoBlockers_Succeeds()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+            StatusEffectRegistry.RegisterContributor(
+                new FakeContributor(consentWarning: " (just text)"));
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "");
+
+            Assert.True(result.IsValid);
+        }
+
+        // ===================================================================
+        // Test doubles
+        // ===================================================================
+
+        /// <summary>
+        /// Concrete processor that does nothing real but exposes the protected helper.
+        /// </summary>
+        private class TestProcessor : InteractionProcessorBase
+        {
+            public override string InteractionType => "testinteraction";
+            public override string InvestmentLevel => "casual";
+
+            public TestProcessor(IChateauDatabase database) : base(database) { }
+
+            public override string ProcessInteraction(PendingCommand command) => InteractionType;
+
+            public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+                => $"{initiatorProfile.displayName} test-interacts with {recipientProfile.displayName}.";
+
+            public StatusEffectFragments CallGetActiveStatusEffects(
+                Profile profile, StatusEffectCallSite callSite, bool isInitiator = false)
+                => GetActiveStatusEffects(profile, callSite, isInitiator);
+        }
+
+        /// <summary>
+        /// Inert contributor that echoes whatever fragments it was constructed with and records
+        /// the arguments of its most recent invocation. Always returns both lists; the helper
+        /// is expected to forward them verbatim.
+        /// </summary>
+        private class FakeContributor : IStatusEffectContributor
+        {
+            private readonly string _consentWarning;
+            private readonly string _completionAppendix;
+
+            public StatusEffectCallSite LastCallSite;
+            public string LastInteractionType;
+            public bool LastIsInitiator;
+
+            public FakeContributor(string consentWarning = null, string completionAppendix = null)
+            {
+                _consentWarning = consentWarning;
+                _completionAppendix = completionAppendix;
+            }
+
+            public StatusEffectFragments Contribute(
+                Profile profile, StatusEffectCallSite callSite, string interactionType, bool isInitiator)
+            {
+                LastCallSite = callSite;
+                LastInteractionType = interactionType;
+                LastIsInitiator = isInitiator;
+
+                var f = new StatusEffectFragments();
+                if (_consentWarning != null) f.ConsentWarnings.Add(_consentWarning);
+                if (_completionAppendix != null) f.CompletionAppendix.Add(_completionAppendix);
+                return f;
+            }
+        }
+
+        private class ThrowingContributor : IStatusEffectContributor
+        {
+            public StatusEffectFragments Contribute(
+                Profile profile, StatusEffectCallSite callSite, string interactionType, bool isInitiator)
+            {
+                throw new InvalidOperationException("contributor went sideways");
+            }
+        }
+
+        /// <summary>
+        /// Mimics odorize fade-by-mention: reads a use counter off the profile, emits a fragment
+        /// while > 0, and decrements in place. Demonstrates that contributors are responsible
+        /// for their own state mutation; the helper is just an aggregator.
+        /// </summary>
+        private class FakeOdorizeContributor : IStatusEffectContributor
+        {
+            private readonly string _counterKey;
+            private readonly string _fragment;
+
+            public FakeOdorizeContributor(string counterKey, string fragment)
+            {
+                _counterKey = counterKey;
+                _fragment = fragment;
+            }
+
+            public StatusEffectFragments Contribute(
+                Profile profile, StatusEffectCallSite callSite, string interactionType, bool isInitiator)
+            {
+                var fragments = new StatusEffectFragments();
+                if (profile?.characteristics == null) return fragments;
+                if (!profile.characteristics.ContainsKey(_counterKey)) return fragments;
+                if (!int.TryParse(profile.characteristics[_counterKey], out int uses)) return fragments;
+                if (uses <= 0) return fragments;
+
+                fragments.CompletionAppendix.Add(_fragment);
+                profile.characteristics[_counterKey] = (uses - 1).ToString();
+                return fragments;
+            }
+        }
+
+        /// <summary>
+        /// Mimics break: emits a recipient blocker only when the parent interaction matches.
+        /// </summary>
+        private class FakeBreakContributor : IStatusEffectContributor
+        {
+            private readonly string _bodyPart;
+            private readonly string _blockedInteractionType;
+            private readonly string _reason;
+
+            public FakeBreakContributor(string bodyPart, string blockedInteractionType, string reason)
+            {
+                _bodyPart = bodyPart;
+                _blockedInteractionType = blockedInteractionType;
+                _reason = reason;
+            }
+
+            public StatusEffectFragments Contribute(
+                Profile profile, StatusEffectCallSite callSite, string interactionType, bool isInitiator)
+            {
+                var fragments = new StatusEffectFragments();
+                if (!string.Equals(interactionType, _blockedInteractionType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return fragments;
+                }
+
+                fragments.Blockers.Add(new ValidationBlock
+                {
+                    Reason = _reason,
+                    Source = "break:" + _bodyPart,
+                    BlocksRecipient = !isInitiator,
+                    BlocksInitiator = isInitiator
+                });
+                return fragments;
+            }
+        }
+    }
+}

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -340,6 +340,9 @@
     <Compile Include="InteractionProcessors\IInteractionProcessor.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorBase.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorRegistry.cs" />
+    <Compile Include="InteractionProcessors\IStatusEffectContributor.cs" />
+    <Compile Include="InteractionProcessors\StatusEffectFragments.cs" />
+    <Compile Include="InteractionProcessors\StatusEffectRegistry.cs" />
     <Compile Include="InteractionProcessors\Involved\DressupProcessor.cs" />
     <Compile Include="InteractionProcessors\Involved\FeedProcessor.cs" />
     <Compile Include="InteractionProcessors\Involved\GoldenProcessor.cs" />

--- a/FChatDicebot/InteractionProcessors/IStatusEffectContributor.cs
+++ b/FChatDicebot/InteractionProcessors/IStatusEffectContributor.cs
@@ -1,0 +1,38 @@
+using FChatDicebot.Model;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Implemented by consequence interactions (odorize, dose, break, infest, corrupt, curse)
+    /// that want to surface text or validation gates inside *other* interactions' consent and
+    /// completion phases. Contributors are registered in <see cref="StatusEffectRegistry"/>;
+    /// the parent interaction's processor calls
+    /// <c>InteractionProcessorBase.GetActiveStatusEffects</c>, which walks the registry and
+    /// merges results.
+    ///
+    /// Contributors own their own state mutations. For fade-by-mention semantics (e.g. odorize
+    /// decrementing a use counter every time it contributes a non-empty fragment), perform the
+    /// decrement inside <see cref="Contribute"/> before returning.
+    ///
+    /// **Whitespace convention:** fragments should not include leading whitespace. The base
+    /// class inserts a single space between the host message and each fragment via
+    /// <c>AppendStatusFragments</c>.
+    /// </summary>
+    public interface IStatusEffectContributor
+    {
+        /// <param name="profile">The profile being inspected for active status effects.
+        /// Depending on <paramref name="isInitiator"/> this is either the initiator or the
+        /// recipient of the parent interaction.</param>
+        /// <param name="callSite">Whether the parent interaction is asking for Consent-phase
+        /// or Completion-phase contributions.</param>
+        /// <param name="interactionType">The parent interaction's type (e.g. "kiss", "milk").
+        /// Lets a contributor tailor its fragment to the interaction.</param>
+        /// <param name="isInitiator">True if <paramref name="profile"/> is the initiator of
+        /// the parent interaction; false if it is the recipient.</param>
+        StatusEffectFragments Contribute(
+            Profile profile,
+            StatusEffectCallSite callSite,
+            string interactionType,
+            bool isInitiator);
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors
 {
@@ -110,8 +111,10 @@ namespace FChatDicebot.InteractionProcessors
         public abstract string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier);
 
         /// <summary>
-        /// Basic validation - checks that profiles exist.
-        /// Override to add interaction-specific validation.
+        /// Basic validation - checks that profiles exist and honors any recipient-blocking
+        /// status effects (e.g. a !break on the relevant body part). Override to add
+        /// interaction-specific validation; overrides that still want status-effect gating
+        /// should call <see cref="GetActiveStatusEffects"/> themselves.
         /// </summary>
         public virtual ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
         {
@@ -128,15 +131,87 @@ namespace FChatDicebot.InteractionProcessors
                 return ValidationResult.Failure(ChateauInteractionHandler.notFoundText(recipient));
             }
 
+            var recipientEffects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, isInitiator: false);
+            var recipientBlocker = recipientEffects.Blockers.FirstOrDefault(b => b.BlocksRecipient);
+            if (recipientBlocker != null)
+            {
+                return ValidationResult.Failure(recipientBlocker.Reason);
+            }
+
             return ValidationResult.Success();
         }
 
         /// <summary>
-        /// Default consent warning. Override to provide interaction-specific warnings.
+        /// Default consent warning. Appends any active status-effect consent fragments for the
+        /// recipient, prefixing each with a single space (contributors should not include
+        /// their own leading whitespace). Override to provide interaction-specific warnings;
+        /// overrides that still want status-effect text should call
+        /// <see cref="GetActiveStatusEffects"/> with <see cref="StatusEffectCallSite.Consent"/>
+        /// and use <see cref="AppendStatusFragments"/> to apply the same spacing convention.
         /// </summary>
         public virtual string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            return $"{initiatorProfile.displayName} wants to {InteractionType} with {recipientProfile.displayName}. Do you !consent?";
+            string baseWarning = $"{initiatorProfile.displayName} wants to {InteractionType} with {recipientProfile.displayName}. Do you !consent?";
+            var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, isInitiator: false);
+            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+        }
+
+        /// <summary>
+        /// Concatenate a base message with status-effect fragments, separating each non-empty
+        /// fragment with a single leading space. Use this in overridden
+        /// <see cref="GetConsentWarning"/> / <see cref="GetCompletionMessage"/> implementations
+        /// so spacing stays consistent across processors.
+        /// </summary>
+        protected static string AppendStatusFragments(string baseMessage, IEnumerable<string> fragments)
+        {
+            if (fragments == null) return baseMessage ?? string.Empty;
+            string result = baseMessage ?? string.Empty;
+            foreach (var fragment in fragments)
+            {
+                if (string.IsNullOrEmpty(fragment)) continue;
+                result += " " + fragment;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Walks <see cref="StatusEffectRegistry"/> and aggregates each contributor's fragments
+        /// for the given profile. Returns an empty fragments instance if no contributors are
+        /// registered. Processors call this from <see cref="GetConsentWarning"/>,
+        /// <see cref="GetCompletionMessage"/>, and <see cref="ValidateInteraction"/> to opt
+        /// into status-effect surfacing.
+        ///
+        /// Contributors own their own state mutations (e.g. odorize decrementing its use
+        /// counter); the helper itself is a pure aggregator.
+        /// </summary>
+        /// <param name="profile">Initiator or recipient profile to inspect.</param>
+        /// <param name="callSite">Which lifecycle phase is asking.</param>
+        /// <param name="isInitiator">True if <paramref name="profile"/> is the initiator of
+        /// the parent interaction. Defaults to false (recipient) to match the most common
+        /// call shape.</param>
+        protected StatusEffectFragments GetActiveStatusEffects(
+            Profile profile,
+            StatusEffectCallSite callSite,
+            bool isInitiator = false)
+        {
+            var merged = new StatusEffectFragments();
+            if (profile == null) return merged;
+
+            foreach (var contributor in StatusEffectRegistry.GetAllContributors())
+            {
+                StatusEffectFragments contributed;
+                try
+                {
+                    contributed = contributor.Contribute(profile, callSite, InteractionType, isInitiator);
+                }
+                catch (Exception)
+                {
+                    // A misbehaving contributor must not break the parent interaction.
+                    continue;
+                }
+                merged.MergeWith(contributed);
+            }
+            return merged;
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/StatusEffectFragments.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectFragments.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Where in the parent interaction lifecycle a status-effect contributor is being asked
+    /// to contribute. Consent is shown before the recipient !consents; Completion is shown
+    /// in the channel after the interaction has been performed.
+    /// </summary>
+    public enum StatusEffectCallSite
+    {
+        Consent,
+        Completion
+    }
+
+    /// <summary>
+    /// A validation gate produced by a status-effect contributor. A processor that calls
+    /// the status-effect helper from inside <see cref="IInteractionProcessor.ValidateInteraction"/>
+    /// can refuse the interaction by returning <see cref="ValidationResult.Failure"/> with
+    /// <see cref="Reason"/>.
+    /// </summary>
+    public class ValidationBlock
+    {
+        // Plain text shown to the channel, e.g. "Bob's mouth is broken and cannot be kissed."
+        public string Reason;
+
+        // Diagnostic tag identifying which contributor produced this block, e.g. "break:mouth".
+        // Not shown to users; useful for tests and future logging.
+        public string Source;
+
+        // True if the initiator of the parent interaction is the blocked party.
+        public bool BlocksInitiator;
+
+        // True if the recipient of the parent interaction is the blocked party.
+        public bool BlocksRecipient;
+    }
+
+    /// <summary>
+    /// Aggregated contributions from all status-effect contributors for a single call site.
+    /// Returned by <c>InteractionProcessorBase.GetActiveStatusEffects</c>; processors append
+    /// the relevant collection to their consent/completion text or check <see cref="Blockers"/>
+    /// in validation.
+    /// </summary>
+    public class StatusEffectFragments
+    {
+        public List<string> ConsentWarnings = new List<string>();
+        public List<string> CompletionAppendix = new List<string>();
+        public List<ValidationBlock> Blockers = new List<ValidationBlock>();
+
+        /// <summary>
+        /// Merge another fragments instance into this one in place. Order within each list
+        /// is preserved (registration order of contributors).
+        /// </summary>
+        public void MergeWith(StatusEffectFragments other)
+        {
+            if (other == null) return;
+            if (other.ConsentWarnings != null) ConsentWarnings.AddRange(other.ConsentWarnings);
+            if (other.CompletionAppendix != null) CompletionAppendix.AddRange(other.CompletionAppendix);
+            if (other.Blockers != null) Blockers.AddRange(other.Blockers);
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Registry of <see cref="IStatusEffectContributor"/> instances. Parallels
+    /// <see cref="InteractionProcessorRegistry"/>. Status-effect-producing interactions
+    /// (odorize, dose, break, infest, corrupt, curse) add their contributor here in
+    /// <see cref="Initialize"/>; <see cref="InteractionProcessorBase.GetActiveStatusEffects"/>
+    /// walks the list and merges what each one returns.
+    ///
+    /// Order of contribution is registration order. Tests can call <see cref="Clear"/> and
+    /// <see cref="RegisterContributor"/> to inject fakes in isolation.
+    /// </summary>
+    public static class StatusEffectRegistry
+    {
+        private static readonly List<IStatusEffectContributor> _contributors = new List<IStatusEffectContributor>();
+        private static bool _initialized = false;
+
+        /// <summary>
+        /// Seed the registry with all built-in contributors. Idempotent. Called automatically
+        /// the first time the registry is queried.
+        /// </summary>
+        public static void Initialize()
+        {
+            if (_initialized) return;
+
+            // Contributors are added here as their feature lands. Until the first consequence
+            // interaction (odorize / dose / break / infest / corrupt / curse) is implemented,
+            // this list is intentionally empty — the helper degrades to an empty result.
+
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Append a contributor. Public so consequence-interaction wiring and tests can both
+        /// register; production callers should prefer adding their entry to
+        /// <see cref="Initialize"/> so the contributor is on for every run.
+        /// </summary>
+        public static void RegisterContributor(IStatusEffectContributor contributor)
+        {
+            if (contributor == null) return;
+            _contributors.Add(contributor);
+        }
+
+        /// <summary>
+        /// Drop all contributors and reset the initialized flag. Intended for test isolation
+        /// only — production code never needs this.
+        /// </summary>
+        public static void Clear()
+        {
+            _contributors.Clear();
+            _initialized = false;
+        }
+
+        /// <summary>
+        /// Snapshot of currently-registered contributors, in registration order. Triggers
+        /// <see cref="Initialize"/> if it hasn't run yet.
+        /// </summary>
+        public static IReadOnlyList<IStatusEffectContributor> GetAllContributors()
+        {
+            Initialize();
+            return _contributors.AsReadOnly();
+        }
+    }
+}

--- a/wiki-docs/Architecture.md
+++ b/wiki-docs/Architecture.md
@@ -43,7 +43,7 @@ This page explains the overall architecture of FCDiceBot and how the major compo
 
 ### 1. BotMain (938 lines)
 
-**Location:** `FChatDicebot/FChatDicebot/BotMain.cs`
+**Location:** `FChatDicebot/BotMain.cs`
 
 The heart of the bot, responsible for:
 
@@ -84,7 +84,7 @@ The heart of the bot, responsible for:
 
 ### 2. BotCommandController (442 lines)
 
-**Location:** `FChatDicebot/FChatDicebot/BotCommandController.cs`
+**Location:** `FChatDicebot/BotCommandController.cs`
 
 Command discovery, dispatch, and execution:
 
@@ -117,7 +117,7 @@ Command discovery, dispatch, and execution:
 
 ### 3. ChateauInteractionHandler
 
-**Location:** `FChatDicebot/FChatDicebot/ChateauInteractionHandler.cs`
+**Location:** `FChatDicebot/ChateauInteractionHandler.cs`
 
 Routes interactions to processors or legacy handler:
 
@@ -138,7 +138,7 @@ Routes interactions to processors or legacy handler:
 
 ### 4. InteractionProcessorRegistry
 
-**Location:** `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs`
+**Location:** `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs`
 
 Manages all interaction processors:
 
@@ -163,7 +163,7 @@ Manages all interaction processors:
 
 ### 5. DiceBot
 
-**Location:** `FChatDicebot/FChatDicebot/DiceFunctions/DiceBot.cs`
+**Location:** `FChatDicebot/DiceFunctions/DiceBot.cs`
 
 Dice rolling and game management:
 
@@ -192,7 +192,7 @@ Dice rolling and game management:
 **Dual Storage System:**
 
 #### MongoDB (Primary)
-**Location:** `FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs`
+**Location:** `FChatDicebot/Database/Chateaudatabase.cs`
 
 - Database: "ChateauDb"
 - Collections:
@@ -210,7 +210,7 @@ Dice rolling and game management:
 - Used for: account settings, channel settings, chips, tables, decks, slots, coupons
 
 #### MonDB Adapter
-**Location:** `FChatDicebot/FChatDicebot/MonDB.cs`
+**Location:** `FChatDicebot/MonDB.cs`
 
 - Static facade over IChateauDatabase
 - Backward compatibility layer

--- a/wiki-docs/Database-and-Persistence.md
+++ b/wiki-docs/Database-and-Persistence.md
@@ -38,7 +38,7 @@ mongodb://localhost:27017
 
 **Database Name:** `ChateauDb`
 
-**Location:** `FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs`
+**Location:** `FChatDicebot/Database/Chateaudatabase.cs`
 
 ```csharp
 const string connectionString = "mongodb://localhost:27017";
@@ -660,7 +660,7 @@ private void BackupDataFiles() {
 
 **MonDB Static Adapter:**
 
-**Location:** `FChatDicebot/FChatDicebot/MonDB.cs`
+**Location:** `FChatDicebot/MonDB.cs`
 
 Provides static methods that delegate to an `IChateauDatabase` instance:
 
@@ -689,7 +689,7 @@ public static class MonDB
 
 ### IChateauDatabase Interface
 
-**Location:** `FChatDicebot/FChatDicebot/Database/Ichateaudatabase.cs`
+**Location:** `FChatDicebot/Database/Ichateaudatabase.cs`
 
 Defines all database operations:
 
@@ -728,7 +728,7 @@ public interface IChateauDatabase
 
 ### ChateauDatabase Implementation
 
-**Location:** `FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs`
+**Location:** `FChatDicebot/Database/Chateaudatabase.cs`
 
 MongoDB implementation of `IChateauDatabase`:
 

--- a/wiki-docs/Installation-and-Setup.md
+++ b/wiki-docs/Installation-and-Setup.md
@@ -105,7 +105,7 @@ The bot will automatically create the `ChateauDb` database and collections on fi
 
 If using a remote MongoDB instance, update the connection string in:
 
-`FChatDicebot/FChatDicebot/Database/Chateaudatabase.cs`
+`FChatDicebot/Database/Chateaudatabase.cs`
 
 ```csharp
 const string connectionString = "mongodb://your-remote-host:27017";

--- a/wiki-docs/specs/Future-Interactions/Break-and-Rest.md
+++ b/wiki-docs/specs/Future-Interactions/Break-and-Rest.md
@@ -124,13 +124,13 @@ The full validation table needs the user's sign-off before this spec lands in co
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/BreakInstance.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Break.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Rest.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/BreakStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/BreakInstance.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Break.cs` *(new)*
+- `FChatDicebot/BotCommands/Rest.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/BreakStatusContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - Migration / seed: ensure the 10 break parts exist in the `Identifiers` catalog with category `"break"`.
 - `FChatDicebot.Tests/Unit/BreakProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/BreakAutoHealTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Breed-and-Birth.md
+++ b/wiki-docs/specs/Future-Interactions/Breed-and-Birth.md
@@ -128,15 +128,15 @@ When listing pregnancies (e.g. `!pregnancies` informational command — recommen
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Breed.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Birth.cs` *(new — system command, not interaction)*
-- `FChatDicebot/FChatDicebot/Model/Pregnancy.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Model/Profile.cs` *(modify — add `pregnancies`)*
-- `FChatDicebot/FChatDicebot/Model/Identifier.cs` *(modify — add `gestationDays`, `broodSizeMin/Max`)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/PregnancyStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Breed.cs` *(new)*
+- `FChatDicebot/BotCommands/Birth.cs` *(new — system command, not interaction)*
+- `FChatDicebot/Model/Pregnancy.cs` *(new)*
+- `FChatDicebot/Model/Profile.cs` *(modify — add `pregnancies`)*
+- `FChatDicebot/Model/Identifier.cs` *(modify — add `gestationDays`, `broodSizeMin/Max`)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/PregnancyStatusContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/BreedProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/BirthCommandTests.cs` *(new)*
-- Recommended: `FChatDicebot/FChatDicebot/BotCommands/Pregnancies.cs` *(new — informational list)*
+- Recommended: `FChatDicebot/BotCommands/Pregnancies.cs` *(new — informational list)*

--- a/wiki-docs/specs/Future-Interactions/Climaxfor.md
+++ b/wiki-docs/specs/Future-Interactions/Climaxfor.md
@@ -100,9 +100,9 @@ Flavor descriptor pool size ~12, weighted by the count that day:
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Climaxfor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/Model/Profile.cs` *(modify — `dailyClimaxCounts`)*
-- `FChatDicebot/FChatDicebot/ChateauSystemTitles.cs` *(modify — climax titles)*
+- `FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Climaxfor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/Profile.cs` *(modify — `dailyClimaxCounts`)*
+- `FChatDicebot/ChateauSystemTitles.cs` *(modify — climax titles)*
 - `FChatDicebot.Tests/Unit/ClimaxforProcessorTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Corrupt-and-Purify.md
+++ b/wiki-docs/specs/Future-Interactions/Corrupt-and-Purify.md
@@ -123,12 +123,12 @@ The dice roll happens in `GetCompletionMessage`, not deterministic.
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs` *(new — registered for both `"corrupt"` and `"purify"`)*
-- `FChatDicebot/FChatDicebot/BotCommands/Corrupt.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Purify.cs` *(new — thin wrapper that flips verb_sign)*
-- `FChatDicebot/FChatDicebot/Model/Profile.cs` *(modify — `dailyMagnitudes`)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register both interaction types pointing to one processor instance)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/CorruptionStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs` *(new — registered for both `"corrupt"` and `"purify"`)*
+- `FChatDicebot/BotCommands/Corrupt.cs` *(new)*
+- `FChatDicebot/BotCommands/Purify.cs` *(new — thin wrapper that flips verb_sign)*
+- `FChatDicebot/Model/Profile.cs` *(modify — `dailyMagnitudes`)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register both interaction types pointing to one processor instance)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/CorruptionStatusContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/CorruptionProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/CorruptionStatusContributorTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Curse-and-Cleanse.md
+++ b/wiki-docs/specs/Future-Interactions/Curse-and-Cleanse.md
@@ -162,15 +162,15 @@ Out of v1 scope unless the user requests it. Pattern: same conversational flow a
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/Curse.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Model/CurseInstance.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Curse.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Cleanse.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/CurseStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Database/IChateauDatabase.cs` *(modify — Curse accessors)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/Curse.cs` *(new)*
+- `FChatDicebot/Model/CurseInstance.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Curse.cs` *(new)*
+- `FChatDicebot/BotCommands/Cleanse.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/CurseStatusContributor.cs` *(new)*
+- `FChatDicebot/Database/IChateauDatabase.cs` *(modify — Curse accessors)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - Seed data file: `FChatDicebot/Data/curses.starter.json` *(new — loaded into MongoDB on first run)*
 - `FChatDicebot.Tests/Unit/CurseProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/CurseStatusContributorTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Dose-and-Detox.md
+++ b/wiki-docs/specs/Future-Interactions/Dose-and-Detox.md
@@ -134,13 +134,13 @@ When the parent interaction *itself* would naturally provide the vice — i.e.:
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/ViceInstance.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Dose.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Detox.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/DoseStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/ViceInstance.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Dose.cs` *(new)*
+- `FChatDicebot/BotCommands/Detox.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/DoseStatusContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/DoseProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/DoseStatusContributorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/DetoxCommandTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infest-and-Purge.md
+++ b/wiki-docs/specs/Future-Interactions/Infest-and-Purge.md
@@ -150,18 +150,18 @@ Triggered by `!defineparasite` — starts a [Conversational Flow](Infrastructure
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/Parasite.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Model/ParasiteInstance.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Infest.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Purge.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/DefineParasite.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Conversational/Handlers/DefineParasiteFlowHandler.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Database/IChateauDatabase.cs` *(modify — add `GetParasite`, `SaveParasite`, `ListParasites`)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/Conversational/ConversationalFlowRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/Parasite.cs` *(new)*
+- `FChatDicebot/Model/ParasiteInstance.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Infest.cs` *(new)*
+- `FChatDicebot/BotCommands/Purge.cs` *(new)*
+- `FChatDicebot/BotCommands/DefineParasite.cs` *(new)*
+- `FChatDicebot/Conversational/Handlers/DefineParasiteFlowHandler.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteStatusContributor.cs` *(new)*
+- `FChatDicebot/Database/IChateauDatabase.cs` *(modify — add `GetParasite`, `SaveParasite`, `ListParasites`)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/Conversational/ConversationalFlowRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/InfestProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/ParasiteStatusContributorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/PurgeCommandTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infrastructure/Conversational-Flows.md
+++ b/wiki-docs/specs/Future-Interactions/Infrastructure/Conversational-Flows.md
@@ -82,9 +82,9 @@ MongoDB collection `ConversationalFlows`. Indexed on `OwnerName` (unique). Recor
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Conversational/ConversationalFlow.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Conversational/IConversationalFlowHandler.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Conversational/ConversationalFlowRegistry.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Conversational/ConversationalFlowDispatcher.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommandController.cs` *(modify — route to dispatcher before normal parsing if flow active)*
+- `FChatDicebot/Conversational/ConversationalFlow.cs` *(new)*
+- `FChatDicebot/Conversational/IConversationalFlowHandler.cs` *(new)*
+- `FChatDicebot/Conversational/ConversationalFlowRegistry.cs` *(new)*
+- `FChatDicebot/Conversational/ConversationalFlowDispatcher.cs` *(new)*
+- `FChatDicebot/BotCommandController.cs` *(modify — route to dispatcher before normal parsing if flow active)*
 - `FChatDicebot.Tests/Unit/ConversationalFlowDispatcherTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infrastructure/Currency-and-Milk-Inventory.md
+++ b/wiki-docs/specs/Future-Interactions/Infrastructure/Currency-and-Milk-Inventory.md
@@ -112,11 +112,11 @@ Bob sold 3 bottles of cum (sourced from Alice) for 75 copper. Empty bottles refu
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/MilkBottle.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Model/Profile.cs` *(modify — add `milkInventory`, `emptyBottles`)*
-- `FChatDicebot/FChatDicebot/ChateauCurrency.cs` *(new — denominations, pricing, parsing)*
-- `FChatDicebot/FChatDicebot/BotCommands/Sell.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Pay.cs` *(modify — accept denomination shorthand)*
+- `FChatDicebot/Model/MilkBottle.cs` *(new)*
+- `FChatDicebot/Model/Profile.cs` *(modify — add `milkInventory`, `emptyBottles`)*
+- `FChatDicebot/ChateauCurrency.cs` *(new — denominations, pricing, parsing)*
+- `FChatDicebot/BotCommands/Sell.cs` *(new)*
+- `FChatDicebot/BotCommands/Pay.cs` *(modify — accept denomination shorthand)*
 - `FChatDicebot.Tests/Unit/MilkInventoryTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/SellCommandTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/CurrencyDisplayTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infrastructure/NPC-System.md
+++ b/wiki-docs/specs/Future-Interactions/Infrastructure/NPC-System.md
@@ -69,13 +69,13 @@ Initial integrations (other specs trigger this):
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/NPC.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Database/IChateauDatabase.cs` *(modify — add NPC accessors)*
-- `FChatDicebot/FChatDicebot/Database/MongoChateauDatabase.cs` *(modify — implement)*
-- `FChatDicebot/FChatDicebot/BotCommands/Npcs.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/NpcInfo.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/RenameNpc.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/DescribeNpc.cs` *(new)*
-- `FChatDicebot/FChatDicebot/NpcNameGenerator.cs` *(new)*
+- `FChatDicebot/Model/NPC.cs` *(new)*
+- `FChatDicebot/Database/IChateauDatabase.cs` *(modify — add NPC accessors)*
+- `FChatDicebot/Database/MongoChateauDatabase.cs` *(modify — implement)*
+- `FChatDicebot/BotCommands/Npcs.cs` *(new)*
+- `FChatDicebot/BotCommands/NpcInfo.cs` *(new)*
+- `FChatDicebot/BotCommands/RenameNpc.cs` *(new)*
+- `FChatDicebot/BotCommands/DescribeNpc.cs` *(new)*
+- `FChatDicebot/NpcNameGenerator.cs` *(new)*
 - `FChatDicebot.Tests/Unit/NPCRepositoryTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/NPCNameGeneratorTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md
+++ b/wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md
@@ -2,7 +2,7 @@
 
 Shared mechanism that lets passive status effects (odorize, dose, break, infest, corrupt, curse) surface text and validation gates in *other* interactions' consent and completion phases.
 
-**Status:** Infrastructure spec — implement before any consequence interaction that contributes status text.
+**Status:** Implemented (initial infrastructure landed; registry seeded empty until the first consequence-interaction contributor lands).
 
 ## Goal
 
@@ -10,25 +10,36 @@ When user A initiates `!kiss` with user B, and B is `!odorize`d with "musk" and 
 
 ## API
 
-Add to `InteractionProcessorBase`:
+On `InteractionProcessorBase`:
 
 ```csharp
-protected StatusEffectFragments GetActiveStatusEffects(Profile profile, StatusEffectCallSite callSite);
+// Aggregator. Walks StatusEffectRegistry, calls each contributor, merges results.
+// isInitiator defaults to false (recipient) — the most common call shape.
+protected StatusEffectFragments GetActiveStatusEffects(
+    Profile profile,
+    StatusEffectCallSite callSite,
+    bool isInitiator = false);
+
+// Spacing helper. Use in overridden GetConsentWarning / GetCompletionMessage to
+// concatenate fragments onto a base message with one space separator per non-empty
+// fragment. Contributors should NOT include their own leading whitespace.
+protected static string AppendStatusFragments(string baseMessage, IEnumerable<string> fragments);
 
 public enum StatusEffectCallSite { Consent, Completion }
 
 public class StatusEffectFragments
 {
-    public List<string> ConsentWarnings = new List<string>();   // appended to GetConsentWarning output
-    public List<string> CompletionAppendix = new List<string>(); // appended to GetCompletionMessage output
-    public List<ValidationBlock> Blockers = new List<ValidationBlock>(); // see below
+    public List<string> ConsentWarnings = new List<string>();    // surfaced in GetConsentWarning
+    public List<string> CompletionAppendix = new List<string>(); // surfaced in GetCompletionMessage
+    public List<ValidationBlock> Blockers = new List<ValidationBlock>();
+    public void MergeWith(StatusEffectFragments other);          // append-merge in place
 }
 
 public class ValidationBlock
 {
     public string Reason;          // "Bob's mouth is broken and cannot be kissed."
-    public string Source;          // "break:mouth"
-    public bool BlocksInitiator;   // true if the *initiator* would be the blocked party
+    public string Source;          // "break:mouth" — diagnostic tag, not shown to users
+    public bool BlocksInitiator;   // true if the initiator would be the blocked party
     public bool BlocksRecipient;
 }
 ```
@@ -46,9 +57,11 @@ public interface IStatusEffectContributor
 }
 ```
 
-Contributors register in `StatusEffectRegistry.Initialize()` (parallel to `InteractionProcessorRegistry`).
+Contributors register in `StatusEffectRegistry.Initialize()` (parallel to `InteractionProcessorRegistry`). Tests can use `StatusEffectRegistry.Clear()` + `RegisterContributor(...)` for isolation.
 
-`GetActiveStatusEffects` walks the registry, calls each contributor, and merges the returned fragments. It also handles odorize's "fade-by-mention" semantics by **decrementing the use counter on the profile every time a non-empty fragment for that scent is returned** — see [Odorize-and-Wash.md](../Odorize-and-Wash.md).
+`GetActiveStatusEffects` is a pure aggregator: it walks the registry, calls each contributor, and merges what each one returns. Contributors that throw are skipped silently so one misbehaving contributor cannot break the parent interaction.
+
+**Contributors own their own state mutations.** Fade-by-mention semantics (e.g. odorize decrementing a use counter every time it contributes a non-empty fragment) live inside the contributor's `Contribute()` method — see [Odorize-and-Wash.md](../Odorize-and-Wash.md). The helper does not introspect contributor state.
 
 ## How processors consume it
 
@@ -57,7 +70,7 @@ In `GetConsentWarning`:
 ```csharp
 var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent);
 string baseWarning = $"...";
-return baseWarning + string.Join("", effects.ConsentWarnings);
+return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
 ```
 
 In `GetCompletionMessage`:
@@ -65,8 +78,10 @@ In `GetCompletionMessage`:
 ```csharp
 var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Completion);
 string baseMessage = $"...";
-return baseMessage + string.Join("", effects.CompletionAppendix);
+return AppendStatusFragments(baseMessage, effects.CompletionAppendix);
 ```
+
+For an initiator-side check (e.g. a broken `dick` blocking the initiator of `!breed`), call the helper a second time with `isInitiator: true` against `initiatorProfile`.
 
 Validation blockers are checked in `ValidateInteraction`:
 
@@ -79,8 +94,9 @@ if (relevantBlocker != null)
 
 ## Which interactions opt in
 
-- **Default ON for all consent-driven interactions** (Casual, Involved, Commitment, Consequence). The base class's default `GetConsentWarning` / `GetCompletionMessage` should already call the helper, so processors that don't override those get it for free.
-- **OFF for system commands**: `!work`, `!volunteer`, `!pay`, `!sell`, `!stats`, `!dossier`, `!showtitles`, etc.
+- **Default consent + validation are ON.** The base class's default `GetConsentWarning` calls the helper and appends fragments via `AppendStatusFragments`; the default `ValidateInteraction` checks recipient blockers. Processors that don't override either get this for free.
+- **`GetCompletionMessage` is abstract.** Every existing processor overrides it, so there is no usable base default. Overrides that want completion-time status text must call the helper + `AppendStatusFragments` themselves (see snippet above).
+- **System commands skip the helper entirely.** Commands like `!work`, `!volunteer`, `!pay`, `!sell`, `!stats`, `!dossier`, `!showtitles` are not `InteractionProcessorBase` subclasses and never call into the registry.
 
 ## Persistence
 
@@ -88,23 +104,30 @@ No new collections. Status-effect state lives on the `Profile` of whichever inte
 
 ## Tests
 
-- `StatusEffectHookTests.cs`:
-  - With no active effects, all collections are empty.
-  - With one odorize active, `Completion` returns the scent fragment; `Consent` returns the warning. After the call, the use counter on the profile decremented.
-  - With a `break:mouth` active, calling for a `kiss` interaction puts a `BlocksRecipient = true` blocker in the list.
-  - Multiple effects merge in registration order.
-  - System command path (call site flag) returns empty.
+`StatusEffectHookTests.cs` covers, using inline `FakeContributor` / `FakeBreakContributor` / `FakeOdorizeContributor` doubles plus a `TestProcessor` that exposes the protected helper:
+
+- **Aggregation:** empty registry → empty fragments; null profile → empty; contributor receives `interactionType` and `isInitiator`; multiple contributors merge in registration order; a throwing contributor is skipped without breaking the helper.
+- **Call site routing:** the contributor sees the correct `StatusEffectCallSite` value.
+- **Odorize-style fade:** a contributor that decrements a counter on each invocation does so on every call, stops emitting fragments at 0, and never goes negative.
+- **Break-style blockers:** a recipient blocker for a matching `interactionType` shows up in `Blockers` with `BlocksRecipient = true`; same blocker for an unrelated `interactionType` does not.
+- **Default `GetConsentWarning` integration:** appends fragments with a single space separator each, skips empty fragments, never produces double-space artifacts.
+- **Default `ValidateInteraction` integration:** a recipient-blocking contributor fails validation with the contributor's `Reason`; no contributors → validation succeeds.
+
+The original spec also listed "system command path returns empty" as a test — that case isn't testable here because system commands don't subclass `InteractionProcessorBase` and therefore cannot reach the helper; the responsibility is structural.
 
 ## Assumptions
 
-- Decrement-on-mention is performed inside `GetActiveStatusEffects` rather than by each consumer. **Override:** if the user wants explicit consumption, factor it into a separate `ConsumeOdorizeMention(profile, scent)` call.
-- Order of fragments is registration order; not configurable per spec. **Override:** if specific stacking order matters, add a `Priority` int on `IStatusEffectContributor`.
-- ValidationBlock surface is recipient-only at the call sites listed; initiator-blocking effects (e.g. broken `dick` blocking the *initiator* of `!breed`) are surfaced by adding a second `GetActiveStatusEffects(initiatorProfile, ...)` call. Specs that need this list it explicitly.
+- **Helper signature carries `isInitiator`.** The original spec showed `(Profile, callSite)`; an `isInitiator` parameter (default `false`) was added so the same helper can be called twice — once for the recipient, once for the initiator — which the spec's own `IStatusEffectContributor` already required.
+- **Spacing convention: contributors emit fragments without leading whitespace.** The base class's `AppendStatusFragments` inserts exactly one space between the host message and each fragment, and between consecutive fragments. **Override:** if a contributor needs a different separator (e.g. newline), it has to build the full text in the host message before calling, since `AppendStatusFragments` is space-only.
+- **Contributors own their own state mutations.** Fade-by-mention decrement (odorize's use counter) lives inside the contributor, not the helper. The helper is purely an aggregator. **Override:** if you want explicit, per-call consumption, factor it into a separate `ConsumeOdorizeMention(profile, scent)` call invoked by the consumer instead of the contributor.
+- **Order of fragments is registration order.** Not configurable per spec. **Override:** if specific stacking order matters, add a `Priority` int on `IStatusEffectContributor` and sort in `GetAllContributors`.
+- **ValidationBlock surface is recipient-only at the default call sites.** The default `ValidateInteraction` checks recipient blockers; initiator-blocking effects (e.g. broken `dick` blocking the *initiator* of `!breed`) require a second `GetActiveStatusEffects(initiatorProfile, ..., isInitiator: true)` call in the processor's overridden `ValidateInteraction`. Specs that need this list it explicitly.
+- **Contributor exceptions are swallowed.** A `Contribute()` that throws is skipped and the remaining contributors still run. **Override:** if a contributor's failure should be visible (e.g. for debugging), wire logging into `GetActiveStatusEffects`.
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectFragments.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/IStatusEffectContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs` *(modify — add helper, fold default into base messages)*
+- `FChatDicebot/InteractionProcessors/StatusEffectFragments.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/IStatusEffectContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs` *(modify — add helper, fold default into base messages)*
 - `FChatDicebot.Tests/Unit/StatusEffectHookTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Milk.md
+++ b/wiki-docs/specs/Future-Interactions/Milk.md
@@ -94,8 +94,8 @@ If the recipient is corrupted/purified, the warning includes the modifier flavor
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Milk.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Milk.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/MilkProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/MilkBottleIntegrationTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Odorize-and-Wash.md
+++ b/wiki-docs/specs/Future-Interactions/Odorize-and-Wash.md
@@ -125,13 +125,13 @@ Multiple distinct scents on the same profile **all** contribute and **all** decr
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/Model/ScentLayer.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Odorize.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Wash.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectContributors/OdorizeStatusContributor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
+- `FChatDicebot/Model/ScentLayer.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Odorize.cs` *(new)*
+- `FChatDicebot/BotCommands/Wash.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/OdorizeStatusContributor.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
 - `FChatDicebot.Tests/Unit/OdorizeProcessorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/OdorizeStatusContributorTests.cs` *(new)*
 - `FChatDicebot.Tests/Unit/WashCommandTests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Train.md
+++ b/wiki-docs/specs/Future-Interactions/Train.md
@@ -107,9 +107,9 @@ If only one advances, phrasing reflects the asymmetry: "...the tutoring pays off
 
 ## Files to create/modify
 
-- `FChatDicebot/FChatDicebot/InteractionProcessors/Commitment/TrainProcessor.cs` *(new)*
-- `FChatDicebot/FChatDicebot/BotCommands/Train.cs` *(new)*
-- `FChatDicebot/FChatDicebot/Model/Profile.cs` *(modify — `trainings` dict)*
-- `FChatDicebot/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
-- `FChatDicebot/FChatDicebot/ChateauSystemTitles.cs` *(modify — apprentice/adept/master/grandmaster)*
+- `FChatDicebot/InteractionProcessors/Commitment/TrainProcessor.cs` *(new)*
+- `FChatDicebot/BotCommands/Train.cs` *(new)*
+- `FChatDicebot/Model/Profile.cs` *(modify — `trainings` dict)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register)*
+- `FChatDicebot/ChateauSystemTitles.cs` *(modify — apprentice/adept/master/grandmaster)*
 - `FChatDicebot.Tests/Unit/TrainProcessorTests.cs` *(new)*


### PR DESCRIPTION
## Summary

Implements the **Status-Effect Hook** — the Tier 0 infrastructure spec from [`wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md`](wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md). This is the shared mechanism that will let passive status effects (odorize, dose, break, infest, corrupt, curse) surface text and validation gates inside *other* interactions' consent and completion phases, without each processor knowing about each status effect.

- **Registry seeded empty.** No contributors are wired up yet, so there is **no observable behavior change in production** — the helper degrades to empty fragments. Contributors land alongside their respective consequence interactions (Odorize next, per spec dependency order).
- Unblocks 6 of the 8 remaining feature specs (Odorize, Dose, Break, Infest, Corrupt, Curse — plus Climaxfor as a consumer).

## What changed

**New (`FChatDicebot/InteractionProcessors/`):**
- `StatusEffectFragments.cs` — `StatusEffectCallSite` enum, `ValidationBlock`, `StatusEffectFragments` (with `MergeWith`)
- `IStatusEffectContributor.cs` — contributor interface
- `StatusEffectRegistry.cs` — static registry with `Clear` / `RegisterContributor` for test isolation

**Modified:**
- `InteractionProcessorBase.cs` — added `protected GetActiveStatusEffects(profile, callSite, isInitiator)` aggregator and `protected static AppendStatusFragments(base, fragments)` spacing helper. Default `GetConsentWarning` now appends fragments with a single space separator each; default `ValidateInteraction` honors recipient blockers. `GetCompletionMessage` remains abstract — overrides opt in with one line.
- `FChatDicebot.csproj` — registered the three new files (legacy-style csproj).

**Tests:** `FChatDicebot.Tests/Unit/Statuseffecthooktests.cs` — 15 unit tests covering aggregation, call-site routing, odorize-style fade (contributor-owned counter decrement), break-style blockers, spacing convention (single space, empty fragments skipped), and exception isolation (a throwing contributor doesn't break the helper).

## Spec deviations to call out

These are documented in the spec's **Assumptions** section and resolve gaps in the original spec:

1. **Helper signature carries `isInitiator`.** Original spec showed `(profile, callSite)`; added `bool isInitiator = false` so the same helper can be called twice (once per profile), which the spec's own `IStatusEffectContributor.Contribute` already required.
2. **Contributors own their own state mutations.** Original spec said the helper itself decrements the use counter; generically the helper can't know which counter key belongs to which contributor, so fade-by-mention logic lives inside `Contribute()`. The Odorize-style test demonstrates the pattern.
3. **Spacing convention.** Base inserts exactly one space between the host message and each fragment via `AppendStatusFragments`; contributors emit fragments without leading whitespace. Locked in via two dedicated tests.
4. **System-command "OFF" is structural.** Original spec listed a test for "system command call-site returns empty"; system commands (`!work`, `!volunteer`, etc.) don't subclass `InteractionProcessorBase`, so they can't reach the helper at all — there's nothing to test at the helper level. Replaced with `NullProfile` and `ContributorThatThrows` resilience tests instead.

## Drive-by cleanup

Mechanical path-flatten cleanup: 106 instances of `FChatDicebot/FChatDicebot/` -> `FChatDicebot/` across 17 wiki-docs files (post-flatten artifact from the repo restructure in [`385b8de`](../commit/385b8de)). Touches docs only; no behavior impact.

The Status-Effect-Hook spec body itself was also rewritten to match the shipped API (deviations 1-4 above), so future implementation sessions for Odorize/Dose/etc. read accurate docs.

## Test plan

- [x] `dotnet build` succeeds (0 errors; pre-existing CS0414/CS0435 warnings unchanged)
- [x] Full test suite green: **562/562 passing** (547 pre-existing + 15 new hook tests)
- [x] No source file outside `InteractionProcessors/` was touched (no risk to consent flow, command routing, MongoDB)
- [ ] After merge, confirm registry stays empty in `InteractionProcessorRegistry`-equivalent init paths until the first consequence interaction PR

## Notes for the reviewer

- The base class behavior change is opt-in for overrides — every existing processor overrides `GetConsentWarning` and `GetCompletionMessage`, so nothing they do today is affected. The full suite passing confirms this.
- `StatusEffectRegistry` exposes `Clear()` and `RegisterContributor()` publicly to support test isolation; production code never calls them.
- Co-Authored-By is on the commit.