### PR TITLE
Implement !corrupt / !purify with shared CorruptionProcessor

### DIFF
--- a/FChatDicebot.Tests/Unit/Corruptionprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Corruptionprocessortests.cs
@@ -1,0 +1,631 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    [Collection("Database")]
+    public class CorruptionProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly CorruptionProcessor _processor;
+        private readonly Random _originalRng;
+
+        public CorruptionProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new CorruptionProcessor(_database);
+            // Snapshot and replace the static RNG so easter-egg-sensitive tests are
+            // deterministic. Restore in Dispose so other test classes aren't disturbed.
+            _originalRng = CorruptionProcessor.Rng;
+            CorruptionProcessor.Rng = new Random(0);
+        }
+
+        public void Dispose()
+        {
+            CorruptionProcessor.Rng = _originalRng;
+        }
+
+        [Fact]
+        public void InteractionType_ReturnsCorrupt()
+        {
+            // The processor is also registered as "purify" in the registry, but its own
+            // InteractionType property returns the primary key.
+            Assert.Equal("corrupt", _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsCommitment()
+        {
+            Assert.Equal("commitment", _processor.InvestmentLevel);
+        }
+
+        // -------------------------------------------------------------------
+        // Verb / sign composition
+        // -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("corrupt", 5, "corrupt")]
+        [InlineData("corrupt", -5, "purify")]   // negative amount flips direction
+        [InlineData("purify", 5, "purify")]
+        [InlineData("purify", -5, "corrupt")]   // negative amount flips direction
+        [InlineData("corrupt", 0, "corrupt")]   // zero keeps typed verb (no-op anyway)
+        public void EffectiveVerb_FlipsOnNegativeAmount(string typed, int amount, string expected)
+        {
+            Assert.Equal(expected, CorruptionProcessor.EffectiveVerb(typed, amount));
+        }
+
+        [Theory]
+        [InlineData("corrupt", -1)]
+        [InlineData("purify", 1)]
+        [InlineData("unknown", 0)]
+        public void VerbSign_ReturnsExpected(string verb, int expected)
+        {
+            Assert.Equal(expected, CorruptionProcessor.VerbSign(verb));
+        }
+
+        // -------------------------------------------------------------------
+        // Identifier round-trip
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Identifier_RoundTrip_PreservesVerbAndMagnitude()
+        {
+            string id = CorruptionProcessor.ComposeIdentifier("corrupt", 7);
+            Assert.Equal("corrupt", CorruptionProcessor.ParseVerbFromIdentifier(id));
+            Assert.Equal(7, CorruptionProcessor.ParseMagnitudeFromIdentifier(id));
+        }
+
+        [Fact]
+        public void Identifier_ParseDefaults_OnGarbage()
+        {
+            // Defends against historical interaction records that predate this scheme.
+            Assert.Equal("corrupt", CorruptionProcessor.ParseVerbFromIdentifier(null));
+            Assert.Equal(1, CorruptionProcessor.ParseMagnitudeFromIdentifier(null));
+            Assert.Equal(1, CorruptionProcessor.ParseMagnitudeFromIdentifier("corrupt|bogus"));
+            Assert.Equal(1, CorruptionProcessor.ParseMagnitudeFromIdentifier("nopipe"));
+        }
+
+        // -------------------------------------------------------------------
+        // Quota math
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void RemainingQuota_ClampsAtZero()
+        {
+            Assert.Equal(CorruptionProcessor.DailyMagnitudeLimit, CorruptionProcessor.RemainingQuota(0));
+            Assert.Equal(0, CorruptionProcessor.RemainingQuota(CorruptionProcessor.DailyMagnitudeLimit));
+            Assert.Equal(0, CorruptionProcessor.RemainingQuota(CorruptionProcessor.DailyMagnitudeLimit + 5));
+        }
+
+        [Fact]
+        public void RecordUsedQuota_PrunesStaleDates()
+        {
+            var alice = new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            DateTime yesterday = new DateTime(2026, 5, 16, 0, 0, 0, DateTimeKind.Utc);
+            DateTime today = new DateTime(2026, 5, 17, 0, 0, 0, DateTimeKind.Utc);
+            alice.dailyMagnitudes[CorruptionProcessor.QuotaKey("Bob", yesterday)] = 7;
+
+            CorruptionProcessor.RecordUsedQuota(alice, "Bob", today, 3);
+
+            Assert.False(alice.dailyMagnitudes.ContainsKey(CorruptionProcessor.QuotaKey("Bob", yesterday)));
+            Assert.Equal(3, alice.dailyMagnitudes[CorruptionProcessor.QuotaKey("Bob", today)]);
+        }
+
+        [Fact]
+        public void RecordUsedQuota_LeavesOtherRecipientsAlone()
+        {
+            var alice = new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            DateTime today = new DateTime(2026, 5, 17, 0, 0, 0, DateTimeKind.Utc);
+            alice.dailyMagnitudes[CorruptionProcessor.QuotaKey("Carol", today)] = 4;
+
+            CorruptionProcessor.RecordUsedQuota(alice, "Bob", today, 6);
+
+            Assert.Equal(4, alice.dailyMagnitudes[CorruptionProcessor.QuotaKey("Carol", today)]);
+            Assert.Equal(6, alice.dailyMagnitudes[CorruptionProcessor.QuotaKey("Bob", today)]);
+        }
+
+        // -------------------------------------------------------------------
+        // ProcessInteraction
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ProcessInteraction_Corrupt_AppliesNegativeDelta()
+        {
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 5));
+
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal("-5", bob.characteristics["corruption"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_Purify_AppliesPositiveDelta()
+        {
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "purify", magnitude: 4));
+
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal("4", bob.characteristics["corruption"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_AccumulatesAcrossCalls()
+        {
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 3));
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "purify", magnitude: 2));
+
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal("-1", bob.characteristics["corruption"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DailyQuotaPartiallyClampsSecondCall()
+        {
+            // 6 then 5 → second clamps to 4. Verifies the spec's headline behavior.
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 6));
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "purify", magnitude: 5));
+
+            var bob = _database.GetProfile("Bob");
+            // -6 + 4 = -2
+            Assert.Equal("-2", bob.characteristics["corruption"]);
+
+            var alice = _database.GetProfile("Alice");
+            string quotaKey = CorruptionProcessor.QuotaKey("Bob", DateTime.UtcNow.Date);
+            Assert.Equal(10, alice.dailyMagnitudes[quotaKey]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_QuotaExhausted_ZeroDeltaAndNoCorruptionChange()
+        {
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 10));
+            // Third call: quota fully spent.
+            var bob = _database.GetProfile("Bob");
+            int corruptionBefore = int.Parse(bob.characteristics["corruption"]);
+
+            var pending = BuildPending("Alice", "Bob", "corrupt", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            bob = _database.GetProfile("Bob");
+            Assert.Equal(corruptionBefore, int.Parse(bob.characteristics["corruption"]));
+            // Identifier should report applied=0 so the completion message suppresses
+            // channel output and the initiator private-note path fires instead.
+            Assert.Equal(0, CorruptionProcessor.ParseMagnitudeFromIdentifier(pending.pendingInteraction.identifier));
+        }
+
+        [Fact]
+        public void ProcessInteraction_DifferentRecipients_DoNotShareQuota()
+        {
+            // Alice exhausts quota on Bob, then corrupts Carol — should still work.
+            SeedPair();
+            new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 10));
+            _processor.ProcessInteraction(BuildPending("Alice", "Carol", "corrupt", magnitude: 7));
+
+            var carol = _database.GetProfile("Carol");
+            Assert.Equal("-7", carol.characteristics["corruption"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DifferentInitiators_DoNotShareQuota()
+        {
+            // Alice and Carol can both corrupt Bob fully on the same day.
+            SeedPair();
+            new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 10));
+            _processor.ProcessInteraction(BuildPending("Carol", "Bob", "corrupt", magnitude: 10));
+
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal("-20", bob.characteristics["corruption"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SelfTarget_AppliesAndUsesQuota()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Alice", "purify", magnitude: 6));
+
+            var alice = _database.GetProfile("Alice");
+            Assert.Equal("6", alice.characteristics["corruption"]);
+            int used = CorruptionProcessor.GetUsedQuota(alice, "Alice", DateTime.UtcNow.Date);
+            Assert.Equal(6, used);
+        }
+
+        [Fact]
+        public void ProcessInteraction_IncrementsDirectionalCounts()
+        {
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 3));
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "purify", magnitude: 2));
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            Assert.Equal(1, alice.counts["corruptgive"]);
+            Assert.Equal(1, alice.counts["purifygive"]);
+            Assert.Equal(1, bob.counts["corrupttake"]);
+            Assert.Equal(1, bob.counts["purifytake"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "corrupt", magnitude: 3);
+            _database.AddPendingCommand(pending);
+
+            _processor.ProcessInteraction(pending);
+
+            Assert.Null(_database.GetPendingCommand(pending.Id));
+        }
+
+        [Fact]
+        public void ProcessInteraction_StampsAppliedMagnitudeIntoIdentifier()
+        {
+            // After clamping, the in-memory identifier should report the applied magnitude
+            // so GetCompletionMessage (called right after) emits truthful numbers.
+            SeedPair();
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 6));
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            Assert.Equal(4, CorruptionProcessor.ParseMagnitudeFromIdentifier(pending.pendingInteraction.identifier));
+            Assert.Equal("purify", CorruptionProcessor.ParseVerbFromIdentifier(pending.pendingInteraction.identifier));
+        }
+
+        // -------------------------------------------------------------------
+        // GetCompletionMessage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetCompletionMessage_CorruptFromZero_DescribesIncreasingCorruption()
+        {
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "corrupt", magnitude: 3);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their corruption has increased by 3", msg);
+            Assert.Contains("3 degrees of corruption", msg);
+            // Raw signed integer should not leak into the channel-visible text.
+            Assert.DoesNotContain("-3", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_PurifyFromZero_DescribesIncreasingPurity()
+        {
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 4);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their purity has increased by 4", msg);
+            Assert.Contains("4 degrees of purity", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_PurifyOnPositiveBob_DescribesIncreasingPurity()
+        {
+            // 2 → 7 via purify 5: still on purity side, magnitude went up → "increasing purity".
+            SeedPair();
+            SeedRecipientCorruption("Bob", 2);
+
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their purity has increased by 5", msg);
+            Assert.Contains("7 degrees of purity", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_PurifyOnNegativeBob_DescribesDecreasingCorruption()
+        {
+            // -7 → -2 via purify 5: still on corruption side, magnitude went down → "decreasing corruption".
+            SeedPair();
+            SeedRecipientCorruption("Bob", -7);
+
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their corruption has decreased by 5", msg);
+            Assert.Contains("2 degrees of corruption", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_PurifyCrossesZero_DescribesEndSide()
+        {
+            // -2 → 3 via purify 5: crosses zero, ends on purity side → "increasing purity".
+            SeedPair();
+            SeedRecipientCorruption("Bob", -2);
+
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their purity has increased by 5", msg);
+            Assert.Contains("3 degrees of purity", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_LandsExactlyAtZero_UsesEternalTugOfWarPhrase()
+        {
+            // +5 → 0 via corrupt 5: ends at neutral, special phrasing on the trailing clause.
+            // Side is chosen from prior value (purity), action is "decreased".
+            SeedPair();
+            SeedRecipientCorruption("Bob", 5);
+
+            var pending = BuildPending("Alice", "Bob", "corrupt", magnitude: 5);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("Their purity has decreased by 5", msg);
+            Assert.Contains("leaving them once again neutral in the eternal tug of war of purity and corruption", msg);
+            // The "X degrees of …" pattern should NOT appear when neutral.
+            Assert.DoesNotContain("degrees of", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_QuotaExhausted_ReturnsEmptyAndStashesPrivateNoteMatchingCommandWording()
+        {
+            // TOCTOU edge: queued pending consents but quota was eaten meanwhile. The
+            // channel-visible message should be suppressed and the initiator should get
+            // a private heads-up — identical wording to the command-time refusal so the
+            // two paths can't drift.
+            SeedPair();
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 10));
+            var doomed = BuildPending("Alice", "Bob", "corrupt", magnitude: 4);
+            _processor.ProcessInteraction(doomed);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, doomed.pendingInteraction.identifier);
+
+            Assert.Equal(string.Empty, msg);
+            string privateNote = _processor.GetAndClearInitiatorPrivateMessage();
+            // Should exactly match the centralized quota-exhausted helper output (modulo the
+            // time-until-reset suffix, which depends on the current second).
+            Assert.StartsWith(
+                "You can only increase or decrease someone's corruption/purity by 10 per day! "
+                + "Please respect that 'Commitment' interactions are meant to be meaningful, and not spammed. "
+                + "You can corrupt Bob further in",
+                privateNote);
+        }
+
+        [Fact]
+        public void GetAndClearInitiatorPrivateMessage_ReturnsEmptyAfterDrain()
+        {
+            SeedPair();
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 10));
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "corrupt", magnitude: 4));
+
+            Assert.NotEmpty(_processor.GetAndClearInitiatorPrivateMessage());
+            // Second drain should yield nothing — the field was cleared by the first call.
+            Assert.Empty(_processor.GetAndClearInitiatorPrivateMessage());
+        }
+
+        [Fact]
+        public void GetCompletionMessage_EasterEggSubstitutesUnPurifyForCorrupt()
+        {
+            // Force the easter egg to fire by replacing Rng with a stub that always rolls 0.
+            CorruptionProcessor.Rng = new AlwaysZeroRandom();
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "corrupt", magnitude: 2);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            // "has un-purified Bob" with the substituted past tense.
+            Assert.Contains("un-purified", msg);
+            Assert.DoesNotContain("corrupted Bob", msg);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_EasterEggSubstitutesUnCorruptForPurify()
+        {
+            CorruptionProcessor.Rng = new AlwaysZeroRandom();
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "purify", magnitude: 2);
+            _processor.ProcessInteraction(pending);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            string msg = _processor.GetCompletionMessage(alice, bob, pending.pendingInteraction.identifier);
+
+            Assert.Contains("un-corrupted", msg);
+            Assert.DoesNotContain("purified Bob", msg);
+        }
+
+        [Fact]
+        public void EasterEggRoll_FiresAtRoughlyAdvertisedRate()
+        {
+            // Statistical sanity: 1/20 expected, 200 trials → expect ~10. Tolerance is wide
+            // to avoid flakiness on the seeded RNG.
+            CorruptionProcessor.Rng = new Random(42);
+            int hits = 0;
+            const int trials = 200;
+            for (int i = 0; i < trials; i++)
+            {
+                if (CorruptionProcessor.RollEasterEgg()) hits++;
+            }
+            Assert.True(hits > 0, "Easter egg never fired in 200 trials — suspicious.");
+            Assert.True(hits < trials / 2, "Easter egg fired suspiciously often: " + hits + "/" + trials);
+        }
+
+        // -------------------------------------------------------------------
+        // GetConsentWarning
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetConsentWarning_CorruptOnNeutralBob_DescribesIncreasingCorruption()
+        {
+            // Bob at 0 → -3 after corrupt 3: end side is corruption, increasing.
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("corrupt", 3));
+
+            Assert.Contains("Alice wants to corrupt Bob", warning);
+            Assert.Contains("increasing their corruption by 3", warning);
+            Assert.Contains("Do you !consent to being corrupted?", warning);
+            // No current/projected numbers in the consent line per user direction.
+            Assert.DoesNotContain("currently", warning);
+            Assert.DoesNotContain("become", warning);
+        }
+
+        [Fact]
+        public void GetConsentWarning_PurifyOnNegativeBob_DescribesDecreasingCorruption()
+        {
+            // Bob at -7 → -2 after purify 5: end side is still corruption, decreasing.
+            SeedPair();
+            SeedRecipientCorruption("Bob", -7);
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("purify", 5));
+
+            Assert.Contains("Alice wants to purify Bob", warning);
+            Assert.Contains("decreasing their corruption by 5", warning);
+            Assert.Contains("Do you !consent to being purified?", warning);
+        }
+
+        [Fact]
+        public void GetConsentWarning_PurifyOnPositiveBob_DescribesIncreasingPurity()
+        {
+            // Bob at 2 → 7 after purify 5: end side is purity, increasing.
+            SeedPair();
+            SeedRecipientCorruption("Bob", 2);
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("purify", 5));
+
+            Assert.Contains("increasing their purity by 5", warning);
+        }
+
+        // -------------------------------------------------------------------
+        // LevelChange direction resolver
+        // -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(2, 7, "purity", "increasing", "increased")]      // both purity, magnitude up
+        [InlineData(7, 2, "purity", "decreasing", "decreased")]      // both purity, magnitude down
+        [InlineData(-7, -2, "corruption", "decreasing", "decreased")] // both corruption, magnitude down
+        [InlineData(-2, -7, "corruption", "increasing", "increased")] // both corruption, magnitude up
+        [InlineData(-2, 3, "purity", "increasing", "increased")]     // cross-zero, ends on purity
+        [InlineData(2, -3, "corruption", "increasing", "increased")] // cross-zero, ends on corruption
+        [InlineData(0, -5, "corruption", "increasing", "increased")] // from neutral to corruption
+        [InlineData(0, 5, "purity", "increasing", "increased")]      // from neutral to purity
+        [InlineData(5, 0, "purity", "decreasing", "decreased")]      // landing at zero from purity
+        [InlineData(-5, 0, "corruption", "decreasing", "decreased")] // landing at zero from corruption
+        public void LevelChange_DescribesEndStateCorrectly(int oldValue, int newValue, string expectedSide, string expectedPresent, string expectedPast)
+        {
+            var change = CorruptionProcessor.LevelChange.From(oldValue, newValue);
+            Assert.Equal(expectedSide, change.Side);
+            Assert.Equal(expectedPresent, change.ActionPresent);
+            Assert.Equal(expectedPast, change.ActionPast);
+        }
+
+        [Fact]
+        public void DescribeCurrentLevel_ZeroEndsWithEternalTugPhrase()
+        {
+            string phrase = CorruptionProcessor.DescribeCurrentLevel(0);
+            Assert.Equal("leaving them once again neutral in the eternal tug of war of purity and corruption", phrase);
+        }
+
+        [Theory]
+        [InlineData(-50, "leaving them with 50 degrees of corruption")]
+        [InlineData(-1, "leaving them with 1 degrees of corruption")]
+        [InlineData(1, "leaving them with 1 degrees of purity")]
+        [InlineData(50, "leaving them with 50 degrees of purity")]
+        public void DescribeCurrentLevel_NonZeroUsesDegreesOfSide(int value, string expected)
+        {
+            Assert.Equal(expected, CorruptionProcessor.DescribeCurrentLevel(value));
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private void SeedPair()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+        }
+
+        private void SeedRecipientCorruption(string userName, int corruption)
+        {
+            var profile = _database.GetProfile(userName);
+            profile.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = corruption.ToString();
+            _database.SetProfile(userName, profile);
+        }
+
+        private static PendingCommand BuildPending(string initiator, string recipient, string effectiveVerb, int magnitude)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = effectiveVerb,
+                    identifier = CorruptionProcessor.ComposeIdentifier(effectiveVerb, magnitude),
+                    investmentLevel = "commitment",
+                    interactionTime = DateTime.UtcNow,
+                    extraParameters = new MongoDB.Bson.BsonArray { magnitude }
+                }
+            };
+        }
+
+        /// <summary>Random subclass whose Next(anyBound) always returns 0 — forces the easter egg to fire.</summary>
+        private class AlwaysZeroRandom : Random
+        {
+            public override int Next(int maxValue) => 0;
+            public override int Next() => 0;
+            public override int Next(int minValue, int maxValue) => minValue;
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Corruptionstatuscontributortests.cs
+++ b/FChatDicebot.Tests/Unit/Corruptionstatuscontributortests.cs
@@ -1,0 +1,134 @@
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.StatusEffectContributors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for <see cref="CorruptionStatusContributor"/>. The contributor is a pure
+    /// read of <c>profile.characteristics["corruption"]</c>; it doesn't need a database
+    /// fixture because there's no state mutation to persist.
+    /// </summary>
+    public class CorruptionStatusContributorTests
+    {
+        private readonly CorruptionStatusContributor _contributor = new CorruptionStatusContributor();
+
+        [Fact]
+        public void NullProfile_ReturnsEmpty()
+        {
+            var result = _contributor.Contribute(null, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+            Assert.Empty(result.ConsentWarnings);
+            Assert.Empty(result.CompletionAppendix);
+            Assert.Empty(result.Blockers);
+        }
+
+        [Fact]
+        public void ConsentCallSite_ReturnsEmpty()
+        {
+            // Per spec, the corruption descriptor is a completion-time flavor only.
+            var bob = ProfileWithCorruption(-50);
+            var result = _contributor.Contribute(bob, StatusEffectCallSite.Consent, "kiss", isInitiator: false);
+            Assert.Empty(result.CompletionAppendix);
+            Assert.Empty(result.ConsentWarnings);
+        }
+
+        [Fact]
+        public void NeutralBand_ReturnsNoFragment()
+        {
+            foreach (int corruption in new[] { -9, -1, 0, 1, 9 })
+            {
+                var profile = ProfileWithCorruption(corruption);
+                var result = _contributor.Contribute(profile, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+                Assert.Empty(result.CompletionAppendix);
+            }
+        }
+
+        [Theory]
+        // Corruption side
+        [InlineData(-100, "An absolute aura of corruption radiates from Bob.")]
+        [InlineData(-200, "An absolute aura of corruption radiates from Bob.")]
+        [InlineData(-99,  "A strong aura of corruption emanates from Bob.")]
+        [InlineData(-50,  "A strong aura of corruption emanates from Bob.")]
+        [InlineData(-49,  "A faint aura of corruption emanates from Bob.")]
+        [InlineData(-10,  "A faint aura of corruption emanates from Bob.")]
+        // Purity side
+        [InlineData(10,   "A faint aura of purity emanates from Bob.")]
+        [InlineData(49,   "A faint aura of purity emanates from Bob.")]
+        [InlineData(50,   "A strong aura of purity emanates from Bob.")]
+        [InlineData(99,   "A strong aura of purity emanates from Bob.")]
+        [InlineData(100,  "An absolute aura of purity radiates from Bob.")]
+        [InlineData(500,  "An absolute aura of purity radiates from Bob.")]
+        public void Bands_MapToCorrectFragment(int corruption, string expectedFragment)
+        {
+            Assert.Equal(expectedFragment, CorruptionStatusContributor.DescribeBand(corruption, "Bob"));
+
+            var profile = ProfileWithCorruption(corruption);
+            profile.displayName = "Bob";
+            var result = _contributor.Contribute(profile, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+            Assert.Single(result.CompletionAppendix);
+            Assert.Equal(expectedFragment, result.CompletionAppendix[0]);
+        }
+
+        [Fact]
+        public void CorruptInteractionType_SkipsSelfReference()
+        {
+            // The !corrupt completion message already reports the new value, so the
+            // contributor stays silent to avoid double-up.
+            var bob = ProfileWithCorruption(-50);
+            var result = _contributor.Contribute(bob, StatusEffectCallSite.Completion,
+                CorruptionProcessor.CorruptType, isInitiator: false);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void PurifyInteractionType_SkipsSelfReference()
+        {
+            var bob = ProfileWithCorruption(50);
+            var result = _contributor.Contribute(bob, StatusEffectCallSite.Completion,
+                CorruptionProcessor.PurifyType, isInitiator: false);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Fragment_HasNoLeadingWhitespace()
+        {
+            // Whitespace convention: AppendStatusFragments inserts the separator. Contributors
+            // must not prepend their own.
+            var bob = ProfileWithCorruption(-50);
+            bob.displayName = "Bob";
+            var result = _contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+            Assert.NotEqual(" ", result.CompletionAppendix[0].Substring(0, 1));
+        }
+
+        [Fact]
+        public void UnparseableCorruptionString_TreatedAsZero()
+        {
+            // Defends against legacy or hand-edited profiles where the field exists but
+            // doesn't parse as an int.
+            var profile = new ProfileBuilder().Build();
+            profile.characteristics["corruption"] = "not-a-number";
+            var result = _contributor.Contribute(profile, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void MissingCorruptionField_ReturnsEmpty()
+        {
+            var profile = new ProfileBuilder().Build();
+            var result = _contributor.Contribute(profile, StatusEffectCallSite.Completion, "kiss", isInitiator: false);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        private static Profile ProfileWithCorruption(int value)
+        {
+            return new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithDisplayName("Bob")
+                .WithCharacteristic(CorruptionProcessor.CorruptionCharacteristicKey, value.ToString())
+                .Build();
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -78,6 +78,14 @@ namespace FChatDicebot.BotCommands
                         Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
                         channelMessage += processor.GetCompletionMessage(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
                         channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
+
+                        // Drain any out-of-band private note the processor wants sent to
+                        // the initiator (e.g. corrupt/purify's TOCTOU exhaustion notice).
+                        string initiatorPrivate = processor.GetAndClearInitiatorPrivateMessage();
+                        if (!string.IsNullOrEmpty(initiatorPrivate))
+                        {
+                            bot.SendPrivateMessage(initiatorPrivate, toConsent.pendingInteraction.initiator);
+                        }
                     }
                     else
                     {
@@ -110,6 +118,14 @@ namespace FChatDicebot.BotCommands
                     Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
                     channelMessage += processor.GetCompletionMessage(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
                     channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
+
+                    // Drain any out-of-band private note the processor wants sent to
+                    // the initiator (e.g. corrupt/purify's TOCTOU exhaustion notice).
+                    string initiatorPrivate = processor.GetAndClearInitiatorPrivateMessage();
+                    if (!string.IsNullOrEmpty(initiatorPrivate))
+                    {
+                        bot.SendPrivateMessage(initiatorPrivate, toConsent.pendingInteraction.initiator);
+                    }
                 }
                 else
                 {

--- a/FChatDicebot/BotCommands/ChateauCorrupt.cs
+++ b/FChatDicebot/BotCommands/ChateauCorrupt.cs
@@ -1,0 +1,39 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors.Commitment;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!corrupt</c> shifts the recipient's corruption value down by the given magnitude.
+    /// Pairs with <c>!purify</c>: both commands share <see cref="CorruptionProcessor"/> and
+    /// derive the effective direction from <c>verb_sign * sign(amount)</c>, so
+    /// <c>!corrupt -3</c> is equivalent to <c>!purify 3</c>. Amount defaults to 1.
+    /// Self-target is allowed. Daily quota clamping happens at process time inside the
+    /// shared processor (see <see cref="CorruptionProcessor.DailyMagnitudeLimit"/>).
+    /// </summary>
+    public class ChateauCorrupt : ChatBotCommand
+    {
+        public ChateauCorrupt()
+        {
+            Name = "corrupt";
+            Aliases = new string[] { };
+            Category = "Commitment Interaction";
+            ShortDescription = "Push another resident toward corruption";
+            LongDescription = "Move another resident's corruption value downward (toward 'corrupt') by the given magnitude. Negative amounts flip the direction, behaving as !purify of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per UTC day, summed across both directions — the excess is clamped silently at process time.";
+            Usage = "!corrupt [noparse][user]NameInUserTag[/user][/noparse] {amount}\nor\n!corrupt [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "purify", "consent", "dossier" };
+            CooldownDuration = "Daily quota (10 magnitude per recipient)";
+            CooldownAppliesTo = "initiator";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            CorruptionCommandSupport.Run(bot, commandController, rawTerms, characterName, channel, CorruptionProcessor.CorruptType);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauPurify.cs
+++ b/FChatDicebot/BotCommands/ChateauPurify.cs
@@ -1,0 +1,37 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors.Commitment;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!purify</c> shifts the recipient's corruption value up by the given magnitude.
+    /// Pairs with <c>!corrupt</c>: both commands share <see cref="CorruptionProcessor"/> and
+    /// derive the effective direction from <c>verb_sign * sign(amount)</c>, so
+    /// <c>!purify -3</c> is equivalent to <c>!corrupt 3</c>. Amount defaults to 1.
+    /// </summary>
+    public class ChateauPurify : ChatBotCommand
+    {
+        public ChateauPurify()
+        {
+            Name = "purify";
+            Aliases = new string[] { };
+            Category = "Commitment Interaction";
+            ShortDescription = "Push another resident toward purity";
+            LongDescription = "Move another resident's corruption value upward (toward 'pure') by the given magnitude. Negative amounts flip the direction, behaving as !corrupt of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per UTC day, summed across both directions — the excess is clamped silently at process time.";
+            Usage = "!purify [noparse][user]NameInUserTag[/user][/noparse] {amount}\nor\n!purify [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "corrupt", "consent", "dossier" };
+            CooldownDuration = "Daily quota (10 magnitude per recipient)";
+            CooldownAppliesTo = "initiator";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            CorruptionCommandSupport.Run(bot, commandController, rawTerms, characterName, channel, CorruptionProcessor.PurifyType);
+        }
+    }
+}

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -198,6 +198,8 @@
     <Compile Include="BotCommands\ChateauMonsterize.cs" />
     <Compile Include="BotCommands\ChateauOdorize.cs" />
     <Compile Include="BotCommands\ChateauWash.cs" />
+    <Compile Include="BotCommands\ChateauCorrupt.cs" />
+    <Compile Include="BotCommands\ChateauPurify.cs" />
     <Compile Include="BotCommands\ChateauRename.cs" />
     <Compile Include="BotCommands\ChateauSpank.cs" />
     <Compile Include="BotCommands\ChateauDossier.cs" />
@@ -361,6 +363,9 @@
     <Compile Include="InteractionProcessors\Commitment\EmployProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\BondProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\BreedProcessor.cs" />
+    <Compile Include="InteractionProcessors\Commitment\CorruptionProcessor.cs" />
+    <Compile Include="InteractionProcessors\Commitment\CorruptionCommandSupport.cs" />
+    <Compile Include="InteractionProcessors\StatusEffectContributors\CorruptionStatusContributor.cs" />
     <Compile Include="InteractionProcessors\Involved\PaymentGiveProcessor.cs" />
     <Compile Include="InteractionProcessors\Involved\PaymentReceiveProcessor.cs" />
     <Compile Include="Model\ChateauDB.cs" />

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs
@@ -1,0 +1,121 @@
+using FChatDicebot.Model;
+using System;
+
+namespace FChatDicebot.InteractionProcessors.Commitment
+{
+    /// <summary>
+    /// Shared command-side wiring for <c>!corrupt</c> and <c>!purify</c>. Both commands
+    /// parse the same way (user tag + optional signed integer amount) and the only
+    /// difference is the typed verb, so we centralize the parse, validation, quota
+    /// pre-clamping, and pending-command creation here.
+    ///
+    /// This deliberately lives outside <c>FChatDicebot.BotCommands</c> so the reflection-
+    /// based loader in <c>BotCommandController</c> doesn't try to <c>Activator.CreateInstance</c>
+    /// it as a chat command.
+    /// </summary>
+    public static class CorruptionCommandSupport
+    {
+        public const int DefaultMagnitudeWhenAmountOmitted = 1;
+
+        public static void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string characterName, string channel, string typedVerb)
+        {
+            // No-target and not-registered cases fall through to the existing
+            // notFoundText helper (same pattern as !breed / !odorize): a null recipient
+            // yields a null profile lookup, which we then report below.
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+                return;
+            }
+
+            int signedAmount = DefaultMagnitudeWhenAmountOmitted;
+            string[] rawInts = commandController.GetIntsFromCommandTermsAsStrings(rawTerms);
+            if (rawInts != null && rawInts.Length > 0)
+            {
+                try
+                {
+                    signedAmount = Convert.ToInt32(rawInts[0]);
+                }
+                catch (Exception)
+                {
+                    // Wording mirrors ChateauPay's invalid-number message.
+                    bot.SendPrivateMessage("The amount must be a valid whole number.", characterName);
+                    return;
+                }
+            }
+
+            if (signedAmount == 0)
+            {
+                bot.SendPrivateMessage(
+                    "We don't track corruption interactions that fail to move the needle. Please specify a non-zero whole number amount.",
+                    characterName);
+                return;
+            }
+
+            // Compose the *effective* verb from typed verb + amount sign. Stored on the
+            // Interaction.type so the processor never has to re-derive direction.
+            string effectiveVerb = CorruptionProcessor.EffectiveVerb(typedVerb, signedAmount);
+            int requestedMagnitude = Math.Abs(signedAmount);
+
+            DateTime utcNow = DateTime.UtcNow;
+            DateTime utcDay = utcNow.Date;
+            int used = CorruptionProcessor.GetUsedQuota(initiatorProfile, recipient, utcDay);
+            int remaining = CorruptionProcessor.RemainingQuota(used);
+
+            if (remaining <= 0)
+            {
+                // Quota fully exhausted → refuse before sending a consent prompt. Same
+                // wording as the rare TOCTOU exhaustion that can happen at process time
+                // (see CorruptionProcessor.QuotaExhaustedPrivateMessage).
+                bot.SendPrivateMessage(
+                    CorruptionProcessor.QuotaExhaustedPrivateMessage(effectiveVerb, recipientProfile.displayName),
+                    characterName);
+                return;
+            }
+
+            // Pre-clamp the magnitude to remaining quota so the recipient never sees a
+            // consent prompt for a number larger than what could actually land. The
+            // processor will re-clamp at process time as a TOCTOU safety net.
+            int pendingMagnitude = Math.Min(requestedMagnitude, remaining);
+            if (pendingMagnitude < requestedMagnitude)
+            {
+                string untilReset = Utils.GetTimeSpanPrint(utcDay.AddDays(1) - utcNow);
+                bot.SendPrivateMessage(
+                    "You can only increase or decrease someone's corruption/purity by "
+                    + CorruptionProcessor.DailyMagnitudeLimit + " per day! We appreciate your enthusiasm, "
+                    + "but have changed your pending interaction to the maximum you can currently perform, "
+                    + pendingMagnitude + ". Feel free to " + effectiveVerb + " " + recipientProfile.displayName
+                    + " further in " + untilReset + ".",
+                    characterName);
+            }
+
+            Interaction interaction = new Interaction
+            {
+                initiator = characterName,
+                recipient = recipient,
+                type = effectiveVerb,
+                identifier = CorruptionProcessor.ComposeIdentifier(effectiveVerb, pendingMagnitude),
+                investmentLevel = "commitment",
+                interactionTime = DateTime.UtcNow,
+                extraParameters = new MongoDB.Bson.BsonArray { pendingMagnitude }
+            };
+
+            PendingCommand pending = new PendingCommand
+            {
+                pendingInteraction = interaction,
+                awaitingConsentFrom = recipient
+            };
+
+            MonDB.addPendingCommand(pending);
+
+            var processor = InteractionProcessorRegistry.GetProcessor(effectiveVerb);
+            string consentMessage = processor != null
+                ? processor.GetConsentWarning(initiatorProfile, recipientProfile, interaction.identifier)
+                : (initiatorProfile.displayName + " wants to " + effectiveVerb + " " + recipientProfile.displayName + ". Do you !consent?");
+            bot.SendMessageInChannel(consentMessage, channel);
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
@@ -1,0 +1,432 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.InteractionProcessors.Commitment
+{
+    /// <summary>
+    /// Single processor that backs both <c>!corrupt</c> and <c>!purify</c>. The same instance
+    /// is registered in <see cref="InteractionProcessorRegistry"/> under both interaction
+    /// types. The corresponding command derives the *effective* verb from the user-typed verb
+    /// composed with the sign of the amount (a negative amount flips the verb's direction, so
+    /// <c>!corrupt -3</c> ≡ <c>!purify 3</c>) and stores that effective verb on
+    /// <see cref="Interaction.type"/> — the processor never has to re-derive direction.
+    ///
+    /// Rate-limiting is by a per-day, per-(initiator, recipient) magnitude quota, not a hard
+    /// cooldown — the same initiator may run multiple corrupts/purifies against the same
+    /// recipient in a UTC day as long as the cumulative absolute magnitude stays within
+    /// <see cref="DailyMagnitudeLimit"/>. The quota counts both directions: a 6 followed by a
+    /// 5 the same day partially clamps the second to 4. Clamping happens at process (consent)
+    /// time so that queuing multiple pending commands can't bypass the limit.
+    ///
+    /// Per-call magnitude is carried on the in-memory <see cref="Interaction.identifier"/>
+    /// as <c>"{effectiveVerb}|{magnitude}"</c>; the command writes the *requested* magnitude
+    /// there, and <see cref="ProcessInteraction"/> overwrites it with the *applied* magnitude
+    /// before <see cref="GetCompletionMessage"/> is called so the channel message is truthful.
+    /// </summary>
+    public class CorruptionProcessor : InteractionProcessorBase
+    {
+        public const string CorruptType = "corrupt";
+        public const string PurifyType = "purify";
+        public const string CorruptionCharacteristicKey = "corruption";
+        public const int DailyMagnitudeLimit = 10;
+        // 1-in-EasterEggChanceDenominator chance the completion message renders the verb
+        // as "un-purify" / "un-corrupt" instead of the literal verb. 20 ⇒ 5%.
+        public const int EasterEggChanceDenominator = 20;
+
+        // Single mutable RNG used for easter-egg rolls. Tests can swap this for a seeded
+        // Random to make the easter-egg outcome deterministic.
+        internal static Random Rng = new Random();
+
+        // Primary registry key for this processor. The "purify" alias is registered
+        // separately in InteractionProcessorRegistry; both keys map to the same instance.
+        public override string InteractionType => CorruptType;
+        public override string InvestmentLevel => "commitment";
+
+        public CorruptionProcessor(IChateauDatabase database) : base(database) { }
+        public CorruptionProcessor() : base() { }
+
+        public override string GetInteractionVerb(VerbTense tense)
+        {
+            // The base would yield "corruption" by stripping "Processor"; we want "corrupt".
+            switch (tense)
+            {
+                case VerbTense.Past: return "corrupted";
+                case VerbTense.Present: return "corrupts";
+                case VerbTense.Future: return "will corrupt";
+                default: return "corrupt";
+            }
+        }
+
+        /// <summary>+1 for <c>purify</c>, -1 for <c>corrupt</c>, 0 otherwise.</summary>
+        public static int VerbSign(string verb)
+        {
+            if (string.Equals(verb, PurifyType, StringComparison.OrdinalIgnoreCase)) return 1;
+            if (string.Equals(verb, CorruptType, StringComparison.OrdinalIgnoreCase)) return -1;
+            return 0;
+        }
+
+        /// <summary>
+        /// Compose the user-typed verb with the sign of the user-supplied amount and return
+        /// the *effective* verb. A negative amount flips the verb's direction (so
+        /// <c>!corrupt -3</c> becomes a "purify"). Zero amounts keep the typed verb.
+        /// </summary>
+        public static string EffectiveVerb(string typedVerb, int signedAmount)
+        {
+            int typedSign = VerbSign(typedVerb);
+            int amountSign = signedAmount < 0 ? -1 : 1;
+            int composed = typedSign * amountSign;
+            if (composed < 0) return CorruptType;
+            if (composed > 0) return PurifyType;
+            return typedVerb;
+        }
+
+        /// <summary>
+        /// Quota tracker key. Stored on the *initiator's* dailyMagnitudes so the limit is
+        /// "this initiator against this recipient on this UTC day" — different initiators
+        /// can stack on the same recipient and one initiator can spend budget independently
+        /// against multiple recipients.
+        /// </summary>
+        public static string QuotaKey(string recipientUserName, DateTime utcDay)
+        {
+            return "corruption_" + recipientUserName + "_" + utcDay.ToString("yyyy-MM-dd");
+        }
+
+        /// <summary>Suffix used when pruning stale entries from another day.</summary>
+        public static string TodayQuotaSuffix(DateTime utcDay)
+        {
+            return "_" + utcDay.ToString("yyyy-MM-dd");
+        }
+
+        /// <summary>Read corruption int from a profile; absent / unparseable returns 0.</summary>
+        public static int ReadCorruption(Profile profile)
+        {
+            if (profile == null || profile.characteristics == null) return 0;
+            if (!profile.characteristics.TryGetValue(CorruptionCharacteristicKey, out string raw)) return 0;
+            return int.TryParse(raw, out int value) ? value : 0;
+        }
+
+        /// <summary>Magnitude already spent today by initiator against recipient.</summary>
+        public static int GetUsedQuota(Profile initiatorProfile, string recipientUserName, DateTime utcDay)
+        {
+            if (initiatorProfile == null || initiatorProfile.dailyMagnitudes == null) return 0;
+            string key = QuotaKey(recipientUserName, utcDay);
+            return initiatorProfile.dailyMagnitudes.TryGetValue(key, out int used) ? used : 0;
+        }
+
+        /// <summary>Remaining quota for today's call; clamps to zero so callers can hand it to Math.Min.</summary>
+        public static int RemainingQuota(int usedMagnitude)
+        {
+            int remaining = DailyMagnitudeLimit - usedMagnitude;
+            return remaining > 0 ? remaining : 0;
+        }
+
+        /// <summary>
+        /// Set today's quota entry to the new total and drop any stale-dated entries from
+        /// previous days. Mutates the profile in place; caller is responsible for persisting.
+        /// </summary>
+        public static void RecordUsedQuota(Profile initiatorProfile, string recipientUserName, DateTime utcDay, int newUsedTotal)
+        {
+            if (initiatorProfile == null) return;
+            if (initiatorProfile.dailyMagnitudes == null)
+            {
+                initiatorProfile.dailyMagnitudes = new Dictionary<string, int>();
+            }
+            string todaySuffix = TodayQuotaSuffix(utcDay);
+            var stale = initiatorProfile.dailyMagnitudes.Keys
+                .Where(k => k.StartsWith("corruption_", StringComparison.Ordinal)
+                            && !k.EndsWith(todaySuffix, StringComparison.Ordinal))
+                .ToList();
+            foreach (var key in stale)
+            {
+                initiatorProfile.dailyMagnitudes.Remove(key);
+            }
+            initiatorProfile.dailyMagnitudes[QuotaKey(recipientUserName, utcDay)] = newUsedTotal;
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+            string effectiveVerb = command.pendingInteraction.type;
+            int requestedMagnitude = ParseMagnitudeFromIdentifier(command.pendingInteraction.identifier);
+            DateTime utcDay = DateTime.UtcNow.Date;
+            bool isSelf = string.Equals(initiator, recipient, StringComparison.Ordinal);
+
+            Profile initiatorProfile = Database.GetProfile(initiator);
+            // For self-target, share the single in-memory Profile so reads and writes against
+            // the same underlying record don't desync.
+            Profile recipientProfile = isSelf ? initiatorProfile : Database.GetProfile(recipient);
+
+            int used = GetUsedQuota(initiatorProfile, recipient, utcDay);
+            int remaining = RemainingQuota(used);
+            int appliedMagnitude = Math.Min(requestedMagnitude, remaining);
+            int sign = VerbSign(effectiveVerb);
+
+            if (appliedMagnitude > 0 && sign != 0)
+            {
+                int oldCorruption = ReadCorruption(recipientProfile);
+                int newCorruption = oldCorruption + sign * appliedMagnitude;
+                if (recipientProfile.characteristics == null)
+                {
+                    recipientProfile.characteristics = new Dictionary<string, string>();
+                }
+                recipientProfile.characteristics[CorruptionCharacteristicKey] = newCorruption.ToString();
+
+                RecordUsedQuota(initiatorProfile, recipient, utcDay, used + appliedMagnitude);
+            }
+            else
+            {
+                // TOCTOU edge case: the command pre-clamped against today's remaining quota
+                // and queued a pending interaction, but by the time the recipient consented,
+                // *other* queued pendings from the same initiator had already eaten the
+                // remaining quota. Suppress the channel-visible completion message (set the
+                // identifier's magnitude to 0 so GetCompletionMessage returns empty) and
+                // stash a private heads-up for the initiator instead — same wording as the
+                // command-time refusal, drained by ChateauConsent via
+                // GetAndClearInitiatorPrivateMessage.
+                string recipientName = recipientProfile?.displayName ?? recipient;
+                _lastInitiatorPrivateMessage = QuotaExhaustedPrivateMessage(effectiveVerb, recipientName);
+            }
+
+            // Stamp the applied magnitude back onto the interaction so the completion message,
+            // which is called after ProcessInteraction with the same in-memory PendingCommand,
+            // can report the truthful (post-clamp) value. Done before AddInteraction so the
+            // saved historical record is also accurate.
+            command.pendingInteraction.identifier = ComposeIdentifier(effectiveVerb, appliedMagnitude);
+            Database.AddInteraction(command.pendingInteraction);
+
+            // Save profiles FIRST. The IncrementDifferentCounts call below mutates the DB
+            // record directly (it does its own read-modify-write), so doing it after
+            // SetProfile avoids the in-memory profile clobbering the count back to zero.
+            Database.SetProfile(initiator, initiatorProfile);
+            if (!isSelf)
+            {
+                Database.SetProfile(recipient, recipientProfile);
+            }
+
+            if (appliedMagnitude > 0 && sign != 0)
+            {
+                // Counts are keyed by effective direction (not by what the user typed) so a
+                // !corrupt -5 (which behaves as a purify) doesn't pollute the corrupt counters.
+                if (sign < 0)
+                {
+                    IncrementDifferentCounts(initiator, recipient, "corruptgive", "corrupttake");
+                }
+                else
+                {
+                    IncrementDifferentCounts(initiator, recipient, "purifygive", "purifytake");
+                }
+            }
+
+            Database.DeletePendingCommand(command.Id);
+
+            return effectiveVerb;
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            int appliedMagnitude = ParseMagnitudeFromIdentifier(identifier);
+            // Process-time clamp resolved to 0 (rare TOCTOU; see ProcessInteraction) —
+            // suppress channel output. The initiator already received a private heads-up
+            // via _lastInitiatorPrivateMessage.
+            if (appliedMagnitude <= 0) return string.Empty;
+
+            string verb = ParseVerbFromIdentifier(identifier);
+            int sign = VerbSign(verb);
+            string verbLabel = RenderVerb(verb, sign, useEasterEgg: RollEasterEgg());
+
+            // After ProcessInteraction the recipient's persisted corruption holds the new
+            // value; derive the prior value from (new − sign * applied) so the side/action
+            // descriptor can be chosen from where they actually ended up vs where they were.
+            int newCorruption = ReadCorruption(recipientProfile);
+            int oldCorruption = newCorruption - sign * appliedMagnitude;
+            LevelChange change = LevelChange.From(oldCorruption, newCorruption);
+
+            string subject = initiatorProfile?.displayName ?? "Someone";
+            bool isSelf = string.Equals(initiatorProfile?.userName, recipientProfile?.userName, StringComparison.Ordinal);
+            string target = isSelf ? "themself" : (recipientProfile?.displayName ?? "someone");
+
+            return subject + " has " + PastTense(verbLabel) + " " + target + "! Their " + change.Side + " has "
+                + change.ActionPast + " by " + appliedMagnitude + ", " + DescribeCurrentLevel(newCorruption) + ".";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            string verb = ParseVerbFromIdentifier(identifier);
+            int requestedMagnitude = ParseMagnitudeFromIdentifier(identifier);
+            int sign = VerbSign(verb);
+
+            // Project the post-consent value so the consent text describes the actual
+            // end-state side ("purity" / "corruption") rather than just the action's
+            // direction. Example: !purify 5 on someone at -7 ends at -2 — still on the
+            // corruption side, so the warning reads "decreasing their corruption by 5".
+            int currentCorruption = ReadCorruption(recipientProfile);
+            int projectedCorruption = currentCorruption + sign * requestedMagnitude;
+            LevelChange change = LevelChange.From(currentCorruption, projectedCorruption);
+
+            string subject = initiatorProfile?.displayName ?? "Someone";
+            bool isSelf = string.Equals(initiatorProfile?.userName, recipientProfile?.userName, StringComparison.Ordinal);
+            string target = isSelf ? "themself" : (recipientProfile?.displayName ?? "you");
+
+            return subject + " wants to " + verb + " " + target + ", " + change.ActionPresent + " their "
+                + change.Side + " by " + requestedMagnitude + "! "
+                + "[b]This should not be taken lightly, and can not be done frequently.[/b] "
+                + "Do you !consent to being " + PastTense(verb) + "?";
+        }
+
+        /// <summary>
+        /// Renders the trailing "leaving them with X degrees of (corruption|purity)" clause
+        /// on the completion message. The exact-zero end state gets a flowery override per
+        /// spec — "leaving them once again neutral in the eternal tug of war of purity and
+        /// corruption." — so the user-facing message reads cleanly without a clunky
+        /// "0 degrees of purity" line.
+        /// </summary>
+        public static string DescribeCurrentLevel(int corruption)
+        {
+            if (corruption == 0)
+            {
+                return "leaving them once again neutral in the eternal tug of war of purity and corruption";
+            }
+            int abs = Math.Abs(corruption);
+            string side = corruption < 0 ? "corruption" : "purity";
+            return "leaving them with " + abs + " degrees of " + side;
+        }
+
+        /// <summary>Past-tense form for the consent/completion templates: "corrupted", "purified", "un-purified", "un-corrupted".</summary>
+        public static string PastTense(string verb)
+        {
+            if (verb.EndsWith("y", StringComparison.Ordinal)) return verb.Substring(0, verb.Length - 1) + "ied";
+            if (verb.EndsWith("e", StringComparison.Ordinal)) return verb + "d";
+            return verb + "ed";
+        }
+
+        /// <summary>
+        /// Bundle of "what side is this on" + "did the action increase or decrease that side"
+        /// derived from the old and new corruption values. Used by both consent (projected
+        /// new value) and completion (actual new value) so the wording is symmetrical.
+        ///
+        /// Examples:
+        ///   2 → 7  : Side="purity",     Increase (purify drove purity up)
+        ///   7 → 2  : Side="purity",     Decrease (corrupt ate into existing purity)
+        ///   -7 → -2: Side="corruption", Decrease (purify ate into existing corruption)
+        ///   -2 → 3 : Side="purity",     Increase (cross-side; landed on purity side)
+        ///   5 → 0  : Side="purity",     Decrease (zero end-state inherits side from prior)
+        /// </summary>
+        public struct LevelChange
+        {
+            public string Side;
+            public string ActionPresent;
+            public string ActionPast;
+
+            public static LevelChange From(int oldValue, int newValue)
+            {
+                int delta = newValue - oldValue;
+                if (newValue > 0)
+                {
+                    bool increasing = delta > 0;
+                    return new LevelChange
+                    {
+                        Side = "purity",
+                        ActionPresent = increasing ? "increasing" : "decreasing",
+                        ActionPast = increasing ? "increased" : "decreased",
+                    };
+                }
+                if (newValue < 0)
+                {
+                    // More-negative = more corruption, so a *negative* delta means corruption increased.
+                    bool increasing = delta < 0;
+                    return new LevelChange
+                    {
+                        Side = "corruption",
+                        ActionPresent = increasing ? "increasing" : "decreasing",
+                        ActionPast = increasing ? "increased" : "decreased",
+                    };
+                }
+                // newValue == 0: inherit side from where they were before (can't have arrived
+                // here from 0 itself — zero-amount calls are rejected at the command layer —
+                // so oldValue is guaranteed non-zero). The action is necessarily a decrease
+                // toward neutrality.
+                return new LevelChange
+                {
+                    Side = oldValue > 0 ? "purity" : "corruption",
+                    ActionPresent = "decreasing",
+                    ActionPast = "decreased",
+                };
+            }
+        }
+
+        /// <summary>
+        /// Shared "you've hit your daily corruption/purity quota" message used by both the
+        /// command-time pre-check in <see cref="CorruptionCommandSupport"/> and the rare
+        /// process-time TOCTOU path in <see cref="ProcessInteraction"/>. Centralized so the
+        /// two paths can't drift in wording.
+        /// </summary>
+        public static string QuotaExhaustedPrivateMessage(string effectiveVerb, string recipientDisplayName)
+        {
+            DateTime now = DateTime.UtcNow;
+            string untilReset = Utils.GetTimeSpanPrint(now.Date.AddDays(1) - now);
+            return "You can only increase or decrease someone's corruption/purity by "
+                + DailyMagnitudeLimit + " per day! Please respect that "
+                + "'Commitment' interactions are meant to be meaningful, and not spammed. "
+                + "You can " + effectiveVerb + " " + recipientDisplayName + " further in " + untilReset + ".";
+        }
+
+        /// <summary>
+        /// Hook for tests: swap <see cref="Rng"/> to a seeded Random to deterministically
+        /// trigger or suppress the easter egg. Returns true with probability
+        /// <c>1 / EasterEggChanceDenominator</c>.
+        /// </summary>
+        internal static bool RollEasterEgg()
+        {
+            return Rng.Next(EasterEggChanceDenominator) == 0;
+        }
+
+        /// <summary>
+        /// Render the verb for display. When <paramref name="useEasterEgg"/> is true the verb
+        /// flips to its inverse form ("un-purify" for a corrupt action, "un-corrupt" for a
+        /// purify action) — describes the same movement from the opposite perspective.
+        /// </summary>
+        public static string RenderVerb(string verb, int sign, bool useEasterEgg)
+        {
+            if (!useEasterEgg) return verb;
+            if (sign < 0) return "un-purify";
+            if (sign > 0) return "un-corrupt";
+            return verb;
+        }
+
+        // -----------------------------------------------------------------------
+        // Identifier payload helpers.
+        //
+        // The Interaction model has no per-call magnitude slot, so we piggyback the
+        // identifier field as a compact "{verb}|{magnitude}" payload. The command writes
+        // the *requested* magnitude there; ProcessInteraction overwrites it with the
+        // *applied* magnitude so GetCompletionMessage (called immediately after with the
+        // same in-memory PendingCommand) reports the truthful clamped value.
+        // -----------------------------------------------------------------------
+
+        public static string ComposeIdentifier(string verb, int magnitude)
+        {
+            return verb + "|" + magnitude.ToString();
+        }
+
+        public static string ParseVerbFromIdentifier(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier)) return CorruptType;
+            int pipe = identifier.IndexOf('|');
+            return pipe < 0 ? identifier : identifier.Substring(0, pipe);
+        }
+
+        public static int ParseMagnitudeFromIdentifier(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier)) return 1;
+            int pipe = identifier.IndexOf('|');
+            if (pipe < 0 || pipe >= identifier.Length - 1) return 1;
+            string magPart = identifier.Substring(pipe + 1);
+            return int.TryParse(magPart, out int value) && value >= 0 ? value : 1;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -56,6 +56,16 @@ namespace FChatDicebot.InteractionProcessors
         /// <param name="identifier">The identifier (if any) for this interaction</param>
         /// <returns>The message to display in channel</returns>
         string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier);
+
+        /// <summary>
+        /// Drain any out-of-band private note the processor wants delivered to the
+        /// initiator after <see cref="ProcessInteraction"/> ran (e.g. corrupt/purify's
+        /// "your queued interaction landed but daily quota was already spent" notice).
+        /// Returns empty string when nothing is pending; the consent handler is expected
+        /// to call this once per processed interaction and route any non-empty result to
+        /// a private message.
+        /// </summary>
+        string GetAndClearInitiatorPrivateMessage();
     }
 
     /// <summary>

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -15,6 +15,11 @@ namespace FChatDicebot.InteractionProcessors
     {
         protected readonly IChateauDatabase Database;
         protected string _lastRateLimitMessage = string.Empty;
+        // Optional out-of-band note a processor wants the consent handler to send privately
+        // to the initiator (e.g. corrupt/purify's "this didn't land because your queued
+        // pending raced against the daily quota" notice). Drained after ProcessInteraction
+        // by ChateauConsent via GetAndClearInitiatorPrivateMessage.
+        protected string _lastInitiatorPrivateMessage = string.Empty;
 
         public enum VerbTense
         {
@@ -97,6 +102,19 @@ namespace FChatDicebot.InteractionProcessors
         {
             string msg = _lastRateLimitMessage;
             _lastRateLimitMessage = string.Empty;
+            return msg;
+        }
+
+        /// <summary>
+        /// Drain any pending out-of-band private note the processor wants sent to the
+        /// initiator (used by corrupt/purify when a queued pending interaction lands
+        /// after the daily quota has been spent — no channel message, but the initiator
+        /// gets a privately-routed heads-up). Returns empty string when nothing's pending.
+        /// </summary>
+        public string GetAndClearInitiatorPrivateMessage()
+        {
+            string msg = _lastInitiatorPrivateMessage;
+            _lastInitiatorPrivateMessage = string.Empty;
             return msg;
         }
 

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
@@ -1,7 +1,7 @@
 using FChatDicebot.InteractionProcessors.Casual;
-using FChatDicebot.InteractionProcessors.Involved;
 using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.InteractionProcessors.Involved;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -42,6 +42,11 @@ namespace FChatDicebot.InteractionProcessors
             RegisterProcessor(new EmployProcessor());
             RegisterProcessor(new BondProcessor());
             RegisterProcessor(new BreedProcessor());
+            // CorruptionProcessor backs both !corrupt and !purify — same instance under
+            // two type keys so each verb routes to the shared sign-aware logic.
+            var corruption = new CorruptionProcessor();
+            RegisterProcessor(corruption);
+            RegisterProcessor(CorruptionProcessor.PurifyType, corruption);
 
             //involved interactions
             RegisterProcessor(new FeedProcessor());
@@ -59,11 +64,21 @@ namespace FChatDicebot.InteractionProcessors
         }
 
         /// <summary>
-        /// Register a processor for a specific interaction type
+        /// Register a processor under its own InteractionType key.
         /// </summary>
         private static void RegisterProcessor(IInteractionProcessor processor)
         {
             _processors[processor.InteractionType.ToLower()] = processor;
+        }
+
+        /// <summary>
+        /// Register a processor under an additional alias type key. Used when one processor
+        /// instance backs multiple interaction verbs (e.g. CorruptionProcessor handles both
+        /// <c>"corrupt"</c> and <c>"purify"</c>).
+        /// </summary>
+        private static void RegisterProcessor(string interactionType, IInteractionProcessor processor)
+        {
+            _processors[interactionType.ToLower()] = processor;
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/StatusEffectContributors/CorruptionStatusContributor.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectContributors/CorruptionStatusContributor.cs
@@ -1,0 +1,72 @@
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.Model;
+using System;
+
+namespace FChatDicebot.InteractionProcessors.StatusEffectContributors
+{
+    /// <summary>
+    /// Surfaces a profile's stored corruption value as a flavor fragment on the completion
+    /// messages of *other* interactions (so a "deeply corrupted Bob" reads differently from
+    /// a "transcendently pure Bob" when they get kissed, fed, etc.).
+    ///
+    /// Pure read of <c>profile.characteristics["corruption"]</c>; this contributor does not
+    /// mutate any state — corruption changes only via <see cref="CorruptionProcessor"/>.
+    /// The <c>corrupt</c> and <c>purify</c> interactions themselves are skipped to avoid a
+    /// redundant fragment on their own completion text (which already reports the new value).
+    /// Consent and Validation call sites are deliberately not contributed to — the spec
+    /// limits the descriptor to completion-time channel output.
+    /// </summary>
+    public class CorruptionStatusContributor : IStatusEffectContributor
+    {
+        public StatusEffectFragments Contribute(
+            Profile profile,
+            StatusEffectCallSite callSite,
+            string interactionType,
+            bool isInitiator)
+        {
+            var result = new StatusEffectFragments();
+            if (profile == null) return result;
+            if (callSite != StatusEffectCallSite.Completion) return result;
+            if (string.Equals(interactionType, CorruptionProcessor.CorruptType, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(interactionType, CorruptionProcessor.PurifyType, StringComparison.OrdinalIgnoreCase))
+            {
+                return result;
+            }
+
+            int corruption = CorruptionProcessor.ReadCorruption(profile);
+            string fragment = DescribeBand(corruption, string.IsNullOrEmpty(profile.displayName) ? profile.userName : profile.displayName);
+            if (string.IsNullOrEmpty(fragment)) return result;
+
+            // No leading whitespace — the base AppendStatusFragments will insert a single
+            // separating space when composing the host completion message.
+            result.CompletionAppendix.Add(fragment);
+            return result;
+        }
+
+        /// <summary>
+        /// Threshold bands per the corrupt/purify spec. Returns an empty string for the
+        /// neutral band (-9..+9) so the contributor stays silent there. The strongest tier
+        /// uses "radiates" instead of "emanates" to mark a step-change in intensity.
+        ///
+        /// | Range       | Fragment                                                |
+        /// |-------------|---------------------------------------------------------|
+        /// | ≤ -100      | An absolute aura of corruption radiates from {name}.    |
+        /// | -99..-50    | A strong aura of corruption emanates from {name}.       |
+        /// | -49..-10    | A faint aura of corruption emanates from {name}.        |
+        /// | -9..9       | (no fragment)                                           |
+        /// | 10..49      | A faint aura of purity emanates from {name}.            |
+        /// | 50..99      | A strong aura of purity emanates from {name}.           |
+        /// | ≥ 100       | An absolute aura of purity radiates from {name}.        |
+        /// </summary>
+        public static string DescribeBand(int corruption, string subjectName)
+        {
+            if (corruption <= -100) return "An absolute aura of corruption radiates from " + subjectName + ".";
+            if (corruption <= -50)  return "A strong aura of corruption emanates from "    + subjectName + ".";
+            if (corruption <= -10)  return "A faint aura of corruption emanates from "     + subjectName + ".";
+            if (corruption >= 100)  return "An absolute aura of purity radiates from "     + subjectName + ".";
+            if (corruption >= 50)   return "A strong aura of purity emanates from "        + subjectName + ".";
+            if (corruption >= 10)   return "A faint aura of purity emanates from "         + subjectName + ".";
+            return string.Empty;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
@@ -28,6 +28,7 @@ namespace FChatDicebot.InteractionProcessors
 
             // Contributors are added here as their feature lands.
             RegisterContributor(new OdorizeStatusContributor(MonDB.GetDatabase()));
+            RegisterContributor(new CorruptionStatusContributor());
 
             _initialized = true;
         }

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -26,8 +26,12 @@ namespace FChatDicebot.Model
         public int[] displayedTitleSlots { get; set; } = new int[9] { -1, -1, -1, -1, -1, -1, -1, -1, -1 };
         public List<Pregnancy> pregnancies { get; set; } = new List<Pregnancy>();
 
-
-
+        // Sparse daily quota tracker keyed like "corruption_{recipient}_{yyyy-MM-dd}".
+        // Each entry records magnitude already spent that UTC day by this profile against
+        // a single recipient. Entries with stale date prefixes are dropped on next write
+        // (see CorruptionProcessor.PruneStaleQuotaEntries) so the map stays small.
+        [BsonIgnoreIfNull]
+        public Dictionary<string, int> dailyMagnitudes { get; set; } = new Dictionary<string, int>();
     }
 
     public class Pregnancy

--- a/wiki-docs/specs/Future-Interactions/Corrupt-and-Purify.md
+++ b/wiki-docs/specs/Future-Interactions/Corrupt-and-Purify.md
@@ -1,134 +1,191 @@
 # `!corrupt` + `!purify`
 
-Move someone's corruption value down (corrupt) or up (purify). One signed integer per character; no caps except `int.MinValue` / `int.MaxValue`.
+Move someone's corruption value down (corrupt) or up (purify). One signed integer per character, stored as a string in `profile.characteristics["corruption"]`.
 
-**Investment level:** Commitment
-**Reversal:** Same processor handles both directions (single processor, two command aliases).
-**Depends on:** [Status-Effect-Hook](Infrastructure/Status-Effect-Hook.md)
+**Status:** Implemented.
+**Investment level:** Commitment.
+**Reversal:** Same processor handles both directions — one `CorruptionProcessor` instance registered under both `"corrupt"` and `"purify"` interaction-type keys.
+**Depends on:** [Status-Effect-Hook](Infrastructure/Status-Effect-Hook.md).
 
 ## Command syntax
 
 ```
-!corrupt [user]Bob[/user] {amount}      → amount is positive: subtracts from Bob's corruption (more corrupt)
+!corrupt [user]Bob[/user] {amount}      → positive amount: shifts Bob's corruption value downward (more corrupt)
 !corrupt [user]Bob[/user] -{amount}     → equivalent to !purify {amount}
-!purify  [user]Bob[/user] {amount}      → adds to Bob's corruption (more pure)
+!purify  [user]Bob[/user] {amount}      → shifts Bob's corruption value upward (more pure)
 !purify  [user]Bob[/user] -{amount}     → equivalent to !corrupt {amount}
 ```
 
-If `amount` omitted, default to `1`.
+If `amount` is omitted, defaults to `1`. Self-target is allowed.
+
+## Daily quota
+
+A single initiator may move any single recipient's corruption value by **at most 10 total magnitude per UTC day**, summed across both directions. `!corrupt 6` then `!purify 5` on the same recipient → second call partially clamps to 4.
+
+- Tracked on the **initiator's** `Profile.dailyMagnitudes` (new field, `Dictionary<string, int>`).
+- Key shape: `corruption_{recipientUserName}_{yyyy-MM-dd}` (UTC date).
+- Stale-date entries are pruned on next write to keep the map small. `[BsonIgnoreIfNull]` so legacy profiles don't grow an empty field.
+
+Clamping happens at **both** command time (so the recipient never sees a consent prompt for a magnitude that can't fully land) and process time (TOCTOU safety net for rapid command queueing).
 
 ## Validation
 
-- Recipient must be registered.
-- `amount` parses as a positive integer once sign-flipping is resolved.
-- **Daily per-initiator quota**: a single initiator may move *any single recipient's* corruption value by **at most 10 total per UTC day**, summed across both directions. Initiating `!corrupt 6` then `!purify 5` = 11 total magnitude → second call partially clamps to 4. Reject the *excess* with a warning, not the whole command.
-- Self-target allowed (philosophy: you can corrupt or purify yourself).
+- Recipient must be registered (falls through to `ChateauInteractionHandler.notFoundText` on failure, same pattern as `!breed`).
+- `amount` parses as an integer (`ChateauPay`-style wording on failure).
+- `amount == 0` rejected with a "no needle movement" private message.
+- Quota fully exhausted → command refuses *before* sending a consent prompt; the initiator gets a private heads-up.
+- Quota partially available → command pre-clamps the pending magnitude and sends an "enthusiasm appreciated" private heads-up before forwarding the (clamped) consent prompt.
 
 ## Processor logic (`CorruptionProcessor`)
 
-Single processor, registered under both interaction types `"corrupt"` and `"purify"`. Determines effective sign from:
+Single processor registered twice: once under its own `InteractionType` (`"corrupt"`) and a second time under `"purify"` via a new `RegisterProcessor(string aliasType, IInteractionProcessor)` overload on `InteractionProcessorRegistry`.
 
-1. The verb (`corrupt` ⇒ negative, `purify` ⇒ positive).
-2. The amount sign (negative flips the verb's sign).
+### Effective verb resolution
 
-Composite: effective delta = `verb_sign * sign(amount) * abs(amount)`.
+The command computes the **effective verb** before creating the pending interaction. Effective verb = `verbSign(typedVerb) * sign(amount)`:
 
-Then:
+| Typed | Amount | Effective verb |
+|-------|-------:|----------------|
+| `corrupt` | `+N` | `corrupt` |
+| `corrupt` | `-N` | `purify` |
+| `purify` | `+N` | `purify` |
+| `purify` | `-N` | `corrupt` |
 
-1. Read `recipient.characteristics["corruption"]` as int (default 0).
-2. Look up `initiator.timers["corruption_quota_" + recipient.userName + "_" + UtcDay]` for today's already-used quota magnitude.
-3. Compute clamped magnitude = `min(abs(delta), 10 - already_used)`.
-4. Apply: `recipient.characteristics["corruption"] = old + sign(delta) * clamped`.
-5. Update quota tracker.
-6. Set 24-hour cooldown timer (standard commitment).
-7. Increment counts: `corruptgive` / `corrupttake` if delta is negative; `purifygive` / `purifytake` if positive.
-8. Save interaction. Delete pending command.
+Stored on `Interaction.type`. The processor never re-derives direction.
+
+### Identifier payload trick
+
+The `Interaction.identifier` field is repurposed as a compact `"{verb}|{magnitude}"` payload:
+
+- Set by the command with the **requested** (pre-clamped) magnitude.
+- Overwritten inside `ProcessInteraction` with the **actually applied** magnitude (after process-time clamp).
+- Read by `GetCompletionMessage` immediately after `ProcessInteraction` returns — they share the in-memory `PendingCommand`, so the rewrite is visible.
+
+This is the only way to get the post-clamp magnitude into `GetCompletionMessage`, whose signature is `(Profile, Profile, string identifier)` — there is no per-call state slot on the interface.
+
+### Process flow
+
+1. Read `effectiveVerb` from `Interaction.type` and `requestedMagnitude` from the identifier payload.
+2. Look up the initiator's current quota usage for today against this recipient.
+3. `appliedMagnitude = Math.Min(requestedMagnitude, RemainingQuota)`.
+4. **If applied > 0:** update `recipient.characteristics["corruption"]`, update `initiator.dailyMagnitudes`, and (after `SetProfile`) call `IncrementDifferentCounts` with direction-keyed labels (`corruptgive`/`corrupttake` or `purifygive`/`purifytake`).
+   **If applied == 0** (rare TOCTOU from rapid command queueing): suppress channel output (set identifier magnitude to 0 — `GetCompletionMessage` returns empty) and stash a private heads-up for the initiator in `_lastInitiatorPrivateMessage`; ChateauConsent drains it via `GetAndClearInitiatorPrivateMessage`.
+5. Rewrite identifier with `appliedMagnitude`, then `AddInteraction`.
+6. `SetProfile` for both participants **before** the count increments — the count increments go directly to the DB; doing them after `SetProfile` avoids the in-memory profile clobbering them back to zero.
+7. `DeletePendingCommand`.
+
+**Self-target:** initiator and recipient resolve to the same `Profile` reference so reads/writes against the underlying record stay coherent; only one `SetProfile` call is made.
+
+### Direction-of-effect wording (`LevelChange`)
+
+The user-facing "increasing corruption" / "decreasing purity" wording is chosen from the **end-state side**, not the verb's direction. Going from `2` to `7` via `!purify 5` reads as *"increasing their purity by 5"*; going from `-7` to `-2` via the same `!purify 5` reads as *"decreasing their corruption by 5"*. Implemented by the `CorruptionProcessor.LevelChange.From(oldValue, newValue)` struct, called by both consent and completion paths (consent uses the projected new value; completion uses the actual stored value, recovered as `newCorruption - sign * appliedMagnitude`).
+
+| Old | New | Side | Action |
+|-----|-----|------|--------|
+| 2 | 7 | purity | increasing |
+| 7 | 2 | purity | decreasing |
+| -7 | -2 | corruption | decreasing |
+| -2 | -7 | corruption | increasing |
+| -2 | 3 | purity | increasing (cross-zero) |
+| 5 | 0 | purity | decreasing (inherits side from prior) |
+
+The zero end-state gets a special trailing clause — *"…leaving them once again neutral in the eternal tug of war of purity and corruption."* — instead of the standard *"leaving them with X degrees of (corruption|purity)"*.
+
+### Easter egg
+
+`1 / EasterEggChanceDenominator` (= 1/20 = 5%) of completion messages substitute the verb for its inverse — `corrupt` → `un-purify`, `purify` → `un-corrupt`. The `Rng` field is `internal static` so tests can swap in a seeded `Random` or an `AlwaysZeroRandom` to force the egg.
 
 ## Persistence
 
-On `Profile`:
-
 ```csharp
-// in characteristics
-characteristics["corruption"] = "<signed int>"; // negative = corrupt, positive = pure
+// On the recipient's Profile
+characteristics["corruption"] = "<signed int>";  // negative = corrupt, positive = pure
+
+// On the initiator's Profile (new field)
+[BsonIgnoreIfNull]
+public Dictionary<string, int> dailyMagnitudes;  // key: corruption_{recipient}_{yyyy-MM-dd}
 ```
 
-On `Profile.timers`:
+## Counts incremented (per call with appliedMagnitude > 0)
 
-```csharp
-timers["corruption_quota_{recipientName}_{yyyy-MM-dd}"] = CoolDown {
-    timerEnd = next UTC day midnight,
-    // re-uses the existing CoolDown shape — `quota_used_magnitude` stored as a side field if extended,
-    // OR use a new typed `Dictionary<string, int>` on profile for daily quotas (cleaner).
-}
-```
+- Effective `corrupt`: `corruptgive` on initiator, `corrupttake` on recipient.
+- Effective `purify`: `purifygive` on initiator, `purifytake` on recipient.
 
-**Recommended:** add a new `dailyMagnitudes` dictionary instead of overloading timers:
-
-```csharp
-public Dictionary<string, int> dailyMagnitudes; // key = "corruption_{recipient}_{yyyy-MM-dd}", value = magnitude consumed
-```
-
-Pruned by date at write time (drop entries where the date prefix is not today).
+Direction-keyed (not verb-typed) so `!corrupt -5` correctly bumps the purify counters.
 
 ## Status-effect contributions
 
-`CorruptionStatusContributor` reads `recipient.characteristics["corruption"]` and emits flavor on completion messages of other interactions:
+`CorruptionStatusContributor` (registered in `StatusEffectRegistry.Initialize()`) reads `profile.characteristics["corruption"]` and emits a fragment on the **completion** call site of other interactions. Consent and validation paths are intentionally silent. Self-referencing call sites (`"corrupt"` / `"purify"` as the parent `interactionType`) are skipped so the corrupt/purify completion message doesn't get a redundant fragment on top.
 
-| Range | Flavor descriptor |
-|-------|-------------------|
-| ≤ -100 | "utterly debased" |
-| -99 to -50 | "deeply corrupted" |
-| -49 to -10 | "tinged with corruption" |
-| -9 to 9 | (no fragment) |
-| 10 to 49 | "noticeably purified" |
-| 50 to 99 | "radiant with purity" |
-| ≥ 100 | "transcendently pure" |
+| Range | Fragment |
+|-------|----------|
+| ≤ -100 | An absolute aura of corruption radiates from {name}. |
+| -99 to -50 | A strong aura of corruption emanates from {name}. |
+| -49 to -10 | A faint aura of corruption emanates from {name}. |
+| -9 to 9 | *(no fragment)* |
+| 10 to 49 | A faint aura of purity emanates from {name}. |
+| 50 to 99 | A strong aura of purity emanates from {name}. |
+| ≥ 100 | An absolute aura of purity radiates from {name}. |
 
-Examples in other specs:
+The strongest tier uses *"radiates"*; the milder tiers use *"emanates"*.
 
-- [Milk](Milk.md): "corrupt milk" / "purified milk" tags on bottles, derived from these thresholds (use **±10** as the threshold for the bottle tag — same as the `tinged with corruption` / `noticeably purified` band).
-- [Climaxfor](Climaxfor.md): adds a "wickedly satisfied" / "blessedly serene" flavor.
+## Cross-spec consumers
 
-## Easter egg
+- [Milk](Milk.md): the `corruptionTag` on milk bottles is computed from the ≥ ±10 thresholds (this spec's first non-neutral band).
+- [Climaxfor](Climaxfor.md): may add its own initiator-side flavor based on the same characteristic.
 
-Roughly 5% of completion messages should render the verb as `un-purify` (when corrupting) or `un-corrupt` (when purifying):
+## TOCTOU private-message wiring
 
-> "Alice un-purifies Bob by a magnitude of 3. Bob's corruption is now -8."
+Added to support the rare case where a queued pending lands but its quota has been eaten between command and consent:
 
-The dice roll happens in `GetCompletionMessage`, not deterministic.
+- `IInteractionProcessor.GetAndClearInitiatorPrivateMessage()` — drained by `ChateauConsent` after every successful `ProcessInteraction`.
+- `InteractionProcessorBase._lastInitiatorPrivateMessage` — backing field for any processor that wants to use this channel.
+- `CorruptionProcessor.QuotaExhaustedPrivateMessage(verb, displayName)` — shared between the command-time refusal and the TOCTOU fallback so the two paths can't drift.
 
-## Consent warning
-
-> "Alice wants to {corrupt|purify} you by {amount} magnitude. Your corruption is currently {value}; if you !consent it will become {projected_value} (or less, if Alice has already used some of their daily quota with you). Do you !consent?"
+Any future processor that wants out-of-band private notifications to the initiator after a consent fires can set `_lastInitiatorPrivateMessage` and the existing drain will deliver it.
 
 ## Tests
 
-- `CorruptionProcessorTests.cs`:
-  - Sign flipping: `!corrupt -5` ↔ `!purify 5`.
-  - Daily quota: 6 + 5 → second clamps to 4 with partial-success message.
-  - Self-target works.
-  - Counts go to the right give/take labels based on effective sign.
-- `CorruptionStatusContributorTests.cs`:
-  - Threshold bands return correct fragments.
-  - 0 returns no fragment.
-  - Easter-egg occurrence is non-zero in 200 trials and approximately 5%.
+- `CorruptionProcessorTests.cs` (~50 tests):
+  - Sign-flipping for `EffectiveVerb` across all four verb × sign combinations.
+  - Identifier-payload round-trip + parse defaults on garbage input.
+  - Quota math (`RemainingQuota`, `RecordUsedQuota` pruning by date and not crossing recipients).
+  - Quota partial clamp (the spec's 6 + 5 → 4 case).
+  - Different recipients / different initiators don't share quotas.
+  - Self-target.
+  - Directional counts on success.
+  - Pending command deleted on success.
+  - Identifier rewritten with applied magnitude.
+  - Completion wording for the corrupt-side, purify-side, cross-zero, and lands-exactly-at-zero cases.
+  - TOCTOU exhaustion: empty completion + private note that matches the command-time refusal wording.
+  - `GetAndClearInitiatorPrivateMessage` clears after drain.
+  - Consent wording for end-state-on-corruption / end-state-on-purity / cross-zero.
+  - `LevelChange.From` direction resolution across 10 representative combos.
+  - `DescribeCurrentLevel` neutrality + non-zero degrees rendering.
+  - Easter-egg substitution (forced via `AlwaysZeroRandom`) and statistical sanity over 200 trials.
+- `CorruptionStatusContributorTests.cs` (~15 tests): null profile, consent silence, neutral-band silence, exact band thresholds for all 6 tiers, self-reference skip, no leading whitespace, unparseable / missing field defaults.
 
-## Assumptions
+## Assumptions and overrides
 
-- 5% easter-egg rate is hardcoded. **Override** in a constant.
-- Daily quota magnitude limit is 10. **Override** if play-tests show it's too restrictive.
-- Storage as a stringified int in `characteristics`. **Override:** add a typed int slot on `Profile` if desired.
-- `dailyMagnitudes` over timer-overload is a recommendation; either works.
+- **`DailyMagnitudeLimit = 10`** — overridable as a constant on `CorruptionProcessor`.
+- **`EasterEggChanceDenominator = 20` (5%)** — overridable as a constant.
+- **Storage as stringified int in `characteristics`** — matches every other simple scalar in the Profile model. Override would be a typed `int corruption` slot if the value gets accessed in hot paths.
+- **`dailyMagnitudes` over timer-overload** — the spec originally suggested either approach; the typed dictionary won for clarity.
+- **`Profile.dailyMagnitudes`** is initialized in C# but defaults to `null` on legacy profiles loaded from MongoDB (the initializer doesn't run on deserialization). All callers null-check before use.
 
-## Files to create/modify
+## Files created / modified
 
+- `FChatDicebot/Model/ChateauDB.cs` *(modified — added `dailyMagnitudes` field on `Profile`)*
 - `FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs` *(new — registered for both `"corrupt"` and `"purify"`)*
-- `FChatDicebot/BotCommands/Corrupt.cs` *(new)*
-- `FChatDicebot/BotCommands/Purify.cs` *(new — thin wrapper that flips verb_sign)*
-- `FChatDicebot/Model/Profile.cs` *(modify — `dailyMagnitudes`)*
-- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modify — register both interaction types pointing to one processor instance)*
+- `FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs` *(new — shared command-side parse/wire/pre-clamp logic; placed outside `FChatDicebot.BotCommands` so the reflection loader skips it)*
+- `FChatDicebot/BotCommands/ChateauCorrupt.cs` *(new — thin shell delegating to `CorruptionCommandSupport`)*
+- `FChatDicebot/BotCommands/ChateauPurify.cs` *(new — thin shell delegating to `CorruptionCommandSupport`)*
 - `FChatDicebot/InteractionProcessors/StatusEffectContributors/CorruptionStatusContributor.cs` *(new)*
-- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modify — register)*
-- `FChatDicebot.Tests/Unit/CorruptionProcessorTests.cs` *(new)*
-- `FChatDicebot.Tests/Unit/CorruptionStatusContributorTests.cs` *(new)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs` *(modified — alias-registration overload + register both type keys)*
+- `FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs` *(modified — register contributor)*
+- `FChatDicebot/InteractionProcessors/IInteractionProcessor.cs` *(modified — `GetAndClearInitiatorPrivateMessage` on the interface)*
+- `FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs` *(modified — `_lastInitiatorPrivateMessage` field + drain accessor)*
+- `FChatDicebot/BotCommands/ChateauConsent.cs` *(modified — drain `GetAndClearInitiatorPrivateMessage` after each `ProcessInteraction`)*
+- `FChatDicebot/FChatDicebot.csproj` *(modified — `<Compile Include>` entries for new files)*
+- `FChatDicebot.Tests/Unit/Corruptionprocessortests.cs` *(new)*
+- `FChatDicebot.Tests/Unit/Corruptionstatuscontributortests.cs` *(new)*

--- a/wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md
+++ b/wiki-docs/specs/Future-Interactions/Infrastructure/Status-Effect-Hook.md
@@ -2,7 +2,7 @@
 
 Shared mechanism that lets passive status effects (odorize, dose, break, infest, corrupt, curse) surface text and validation gates in *other* interactions' consent and completion phases.
 
-**Status:** Implemented (initial infrastructure landed; registry seeded empty until the first consequence-interaction contributor lands).
+**Status:** Implemented. Registry currently seeded with `OdorizeStatusContributor` (Tier 3) and `CorruptionStatusContributor` (Tier 2 corrupt/purify); the remaining consequence interactions (dose / break / infest / curse) will add their own contributors as they land.
 
 ## Goal
 
@@ -100,7 +100,19 @@ if (relevantBlocker != null)
 
 ## Persistence
 
-No new collections. Status-effect state lives on the `Profile` of whichever interaction set it (e.g. `profile.characteristics["odorize_musk_uses"] = "3"` for odorize). Each contributor reads from there.
+No new collections. Status-effect state lives on the `Profile` of whichever interaction set it (e.g. `profile.characteristics["odorize_musk_uses"] = "3"` for odorize, `profile.characteristics["corruption"] = "-50"` for corrupt/purify). Each contributor reads from there.
+
+## Out-of-band private notifications to the initiator
+
+A separate channel for the case where a processor needs to message the initiator privately after a consent fires (e.g. corrupt/purify's TOCTOU "your queued interaction landed but daily quota was already spent" notice):
+
+```csharp
+// On InteractionProcessorBase
+protected string _lastInitiatorPrivateMessage = string.Empty;
+public string GetAndClearInitiatorPrivateMessage();   // also on IInteractionProcessor
+```
+
+`ChateauConsent` drains this after every `ProcessInteraction` and routes any non-empty result to a private message. Processors that don't need it leave the field empty; the channel adds no overhead.
 
 ## Tests
 

--- a/wiki-docs/specs/Future-Interactions/README.md
+++ b/wiki-docs/specs/Future-Interactions/README.md
@@ -32,16 +32,16 @@ Infrastructure must land before the features that depend on it. Within each tier
 
 | Spec | Reversal | Depends on |
 |------|----------|------------|
-| [Breed-and-Birth](Breed-and-Birth.md) | `!birth` (paired) | NPC-System (optional) |
+| [Breed-and-Birth](Breed-and-Birth.md) *(implemented)* | `!birth` (paired) | NPC-System (optional) |
 | [Train](Train.md) | — | — |
-| [Corrupt-and-Purify](Corrupt-and-Purify.md) | `!purify` (single processor) | Status-Effect-Hook |
+| [Corrupt-and-Purify](Corrupt-and-Purify.md) *(implemented)* | `!purify` (single processor) | Status-Effect-Hook |
 
 ### Tier 3 — Consequence interactions
 
 | Spec | Reversal | Depends on |
 |------|----------|------------|
 | [Infest-and-Purge](Infest-and-Purge.md) | `!purge` | Status-Effect-Hook, Conversational-Flows (custom parasites only) |
-| [Odorize-and-Wash](Odorize-and-Wash.md) | `!wash` | Status-Effect-Hook |
+| [Odorize-and-Wash](Odorize-and-Wash.md) *(implemented)* | `!wash` | Status-Effect-Hook |
 | [Curse-and-Cleanse](Curse-and-Cleanse.md) | `!cleanse` | Status-Effect-Hook |
 | [Break-and-Rest](Break-and-Rest.md) | `!rest` | Status-Effect-Hook |
 | [Dose-and-Detox](Dose-and-Detox.md) | `!detox` | Status-Effect-Hook |


### PR DESCRIPTION
## Summary

- Implements `!corrupt` and `!purify` (Tier 2 Commitment) per [the spec](wiki-docs/specs/Future-Interactions/Corrupt-and-Purify.md). A single `CorruptionProcessor` is registered under both interaction-type keys via a new alias-registration overload on `InteractionProcessorRegistry`; the effective verb is derived from `verb_sign × amount_sign` so `!corrupt -3` is equivalent to `!purify 3`.
- Adds a 10-per-UTC-day per-(initiator, recipient) magnitude quota stored on a new `Profile.dailyMagnitudes` dict. Quota is pre-clamped at command time (so the recipient never sees a consent prompt for a magnitude that can't fully land) and re-clamped at process time as a TOCTOU safety net.
- Adds `CorruptionStatusContributor` — completion-only — which emits "A {faint|strong|absolute} aura of {corruption|purity} {emanates|radiates} from {name}" fragments based on threshold bands (±10 / ±50 / ±100).
- Adds an initiator private-message channel on `IInteractionProcessor` (`GetAndClearInitiatorPrivateMessage`) drained by `ChateauConsent` after every `ProcessInteraction`. Used by corrupt/purify's rare TOCTOU exhaustion path to send the initiator a private heads-up identical to the command-time quota refusal, instead of spamming the channel.

## User-facing wording notes

- Consent / completion wording derives from end-state side (purity vs corruption), not verb direction. `!purify 5` on someone at -7 → -2 reads as "decreasing their corruption by 5"; the same call on someone at +2 → +7 reads as "increasing their purity by 5".
- Landing at exactly 0 gets a special trailing clause: *"leaving them once again neutral in the eternal tug of war of purity and corruption."*
- ~5% easter egg flips the verb to its un-inverse form ("un-purify" / "un-corrupt").

## Tests

693 tests pass (~50 new processor tests + ~15 new contributor tests). New coverage includes:

- All four verb × amount-sign combinations for effective-verb resolution
- Quota partial clamp (the spec's 6 + 5 → 4 case), cross-recipient and cross-initiator independence, daily date-pruning
- Self-target
- Completion wording across corrupt-side, purify-side, cross-zero, and lands-exactly-at-zero cases
- TOCTOU exhaustion: empty channel completion + initiator private note matching command-time wording
- `LevelChange.From` direction resolution across 10 representative combos
- Easter-egg substitution (forced via `AlwaysZeroRandom`) and statistical sanity over 200 trials
- All 6 status-fragment band tiers with exact-string assertions

## Test plan

- [ ] `dotnet test FChatDicebot.Tests/FChatDicebot.Tests.csproj` passes locally
- [ ] Manual: `!corrupt [user]Bob[/user] 3` from a neutral state → consent prompt → `!consent` → channel message reports "Their corruption has increased by 3, leaving them with 3 degrees of corruption"
- [ ] Manual: `!corrupt -3` on the same target behaves identically to `!purify 3`
- [ ] Manual: spam-attempt 11 magnitude in a day → second call's excess clamps, initiator gets a private heads-up
- [ ] Manual: fully-exhaust quota → command refuses with private message before sending a consent prompt
- [ ] Manual: subsequent `!kiss` on Bob (now at corruption -10 or worse) appends "A faint aura of corruption emanates from Bob." to the kiss completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)