### PR TITLE
Interaction-system consistency pass: levels, helpers, status hooks, tests

### DIFF
--- a/FChatDicebot.Tests/Unit/Bondprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Bondprocessortests.cs
@@ -5,6 +5,7 @@ using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
 using MongoDB.Bson;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace FChatDicebot.Tests.Unit.InteractionProcessors
@@ -140,6 +141,163 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.True(bobProfile.timers.ContainsKey("bond"));
             Assert.True(aliceProfile.timers["bond"].timerEnd > DateTime.UtcNow);
             Assert.True(bobProfile.timers["bond"].timerEnd > DateTime.UtcNow);
+        }
+
+        // -------------------------------------------------------------------
+        // ValidateInteraction — base-class coverage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ValidateInteraction_NonExistentInitiator_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("NonExistentUser", "Bob", "soul");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_NonExistentRecipient_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "NonExistentUser", "soul");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_BothUsersAndIdentifier_ReturnsSuccess()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "soul");
+
+            Assert.True(result.IsValid);
+        }
+
+        // -------------------------------------------------------------------
+        // ProcessInteraction — persistence + accumulation
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "soul");
+            _processor.ProcessInteraction(pending);
+
+            var saved = _database.GetInteractionsByInitiator("Alice");
+            Assert.Single(saved);
+            Assert.Equal("bond", saved[0].type);
+            Assert.Equal("soul", saved[0].identifier);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "soul");
+            _database.AddPendingCommand(pending);
+            _processor.ProcessInteraction(pending);
+
+            Assert.Null(_database.GetPendingCommand(pending.Id));
+        }
+
+        [Fact]
+        public void ProcessInteraction_DifferentBondTypes_StoredInSeparateLists()
+        {
+            // The list name format is "bond{type}initiated" / "bond{type}received", so a
+            // soul bond and a pet bond live in independent slots and don't collide.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "soul"));
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "pet"));
+
+            var alice = _database.GetProfile("Alice");
+            Assert.True(alice.lists.ContainsKey("bondsoulinitiated"));
+            Assert.True(alice.lists.ContainsKey("bondpetinitiated"));
+            Assert.Single(alice.lists["bondsoulinitiated"]);
+            Assert.Single(alice.lists["bondpetinitiated"]);
+        }
+
+        // -------------------------------------------------------------------
+        // GetCompletionMessage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothDisplayNames()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Brave").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").Build();
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "soul");
+
+            Assert.Contains("Alice the Brave", message);
+            Assert.Contains("Bob the Bold", message);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_ContainsBondVerbiage()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "soul");
+
+            // Mutual-bond phrasing — both directions of the relationship.
+            Assert.Contains("is now", message);
+            Assert.Contains("bright future together", message);
+        }
+
+        // -------------------------------------------------------------------
+        // GetConsentWarning
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetConsentWarning_IncludesNotTakenLightlyWarning()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, "soul");
+
+            Assert.Contains("Alice", warning);
+            Assert.Contains("Bob", warning);
+            Assert.Contains("[b]", warning);
+            Assert.Contains("not be taken lightly", warning);
+            Assert.Contains("!consent", warning);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private static PendingCommand BuildPending(string initiator, string recipient, string bondType)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    Id = ObjectId.GenerateNewId(),
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "bond",
+                    identifier = bondType,
+                    investmentLevel = "commitment",
+                    interactionTime = DateTime.UtcNow,
+                }
+            };
         }
 
         public void Dispose()

--- a/FChatDicebot.Tests/Unit/Consumeprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Consumeprocessortests.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void InvestmentLevel_ReturnsConsequence()
+        public void InvestmentLevel_ReturnsCommitment()
         {
-            Assert.Equal("consequence", _processor.InvestmentLevel);
+            Assert.Equal("commitment", _processor.InvestmentLevel);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Employprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Employprocessortests.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void InvestmentLevel_ReturnsConsequence()
+        public void InvestmentLevel_ReturnsCommitment()
         {
-            Assert.Equal("consequence", _processor.InvestmentLevel);
+            Assert.Equal("commitment", _processor.InvestmentLevel);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Identifierpayloadtests.cs
+++ b/FChatDicebot.Tests/Unit/Identifierpayloadtests.cs
@@ -1,0 +1,165 @@
+using FChatDicebot.InteractionProcessors;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Unit tests for the shared <see cref="IdentifierPayload"/> encoder/decoder. The
+    /// per-processor façades (Corruption/Milk/Climaxfor) have their own round-trip tests
+    /// that also exercise this helper through delegation; these tests cover the primitive
+    /// directly so the contract documented on the helper itself stays guaranteed.
+    /// </summary>
+    public class IdentifierPayloadTests
+    {
+        // -------------------------------------------------------------------
+        // Compose
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Compose_StandardHeadAndTail_JoinsWithPipe()
+        {
+            Assert.Equal("corrupt|5", IdentifierPayload.Compose("corrupt", 5));
+        }
+
+        [Fact]
+        public void Compose_NullHead_TreatedAsEmpty()
+        {
+            // Round-trip must still work — extract should return empty string for the head.
+            string payload = IdentifierPayload.Compose(null, 3);
+            Assert.Equal("|3", payload);
+        }
+
+        [Fact]
+        public void Compose_NegativeTail_PreservedVerbatim()
+        {
+            // Negative tails are legal in the payload itself (e.g. corruption sign carriage);
+            // it's the parsing helpers that apply per-processor sign rules.
+            Assert.Equal("purify|-2", IdentifierPayload.Compose("purify", -2));
+        }
+
+        // -------------------------------------------------------------------
+        // ExtractHead
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ExtractHead_NullInput_ReturnsNull()
+        {
+            Assert.Null(IdentifierPayload.ExtractHead(null));
+        }
+
+        [Fact]
+        public void ExtractHead_EmptyInput_ReturnsNull()
+        {
+            Assert.Null(IdentifierPayload.ExtractHead(string.Empty));
+        }
+
+        [Fact]
+        public void ExtractHead_NoSeparator_ReturnsWholeInput()
+        {
+            // Command-time shape: the processor hasn't stamped the tail yet, so the
+            // identifier is just the head verb/substance.
+            Assert.Equal("musk", IdentifierPayload.ExtractHead("musk"));
+        }
+
+        [Fact]
+        public void ExtractHead_WithSeparator_ReturnsHeadPortion()
+        {
+            Assert.Equal("corrupt", IdentifierPayload.ExtractHead("corrupt|7"));
+        }
+
+        [Fact]
+        public void ExtractHead_EmptyHead_ReturnsEmptyString()
+        {
+            // "|7" has a present-but-empty head — distinct from no-separator. Callers
+            // generally coalesce to a default with ?? so the empty case is harmless.
+            Assert.Equal(string.Empty, IdentifierPayload.ExtractHead("|7"));
+        }
+
+        // -------------------------------------------------------------------
+        // TryExtractTail
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void TryExtractTail_NullInput_ReturnsFalse()
+        {
+            Assert.False(IdentifierPayload.TryExtractTail(null, out int tail));
+            Assert.Equal(0, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_NoSeparator_ReturnsFalse()
+        {
+            Assert.False(IdentifierPayload.TryExtractTail("musk", out int tail));
+            Assert.Equal(0, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_TrailingSeparator_ReturnsFalse()
+        {
+            // "corrupt|" — separator is the last character, no integer to parse.
+            Assert.False(IdentifierPayload.TryExtractTail("corrupt|", out int tail));
+            Assert.Equal(0, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_NonNumericTail_ReturnsFalse()
+        {
+            Assert.False(IdentifierPayload.TryExtractTail("corrupt|bogus", out int tail));
+            Assert.Equal(0, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_ValidPositiveInteger_Succeeds()
+        {
+            Assert.True(IdentifierPayload.TryExtractTail("corrupt|7", out int tail));
+            Assert.Equal(7, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_ValidNegativeInteger_Succeeds()
+        {
+            // The primitive accepts any integer; per-processor logic decides whether a
+            // negative tail is meaningful.
+            Assert.True(IdentifierPayload.TryExtractTail("purify|-3", out int tail));
+            Assert.Equal(-3, tail);
+        }
+
+        [Fact]
+        public void TryExtractTail_ZeroTail_Succeeds()
+        {
+            // Zero is a legitimate stamped value (e.g. milk's TOCTOU clamp-to-zero path).
+            // Callers distinguish it from "no tail recorded" by checking the return bool.
+            Assert.True(IdentifierPayload.TryExtractTail("cum|0", out int tail));
+            Assert.Equal(0, tail);
+        }
+
+        // -------------------------------------------------------------------
+        // ExtractTailOr
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ExtractTailOr_MissingTail_ReturnsDefault()
+        {
+            Assert.Equal(-1, IdentifierPayload.ExtractTailOr("cum", -1));
+        }
+
+        [Fact]
+        public void ExtractTailOr_ValidTail_ReturnsParsed()
+        {
+            Assert.Equal(3, IdentifierPayload.ExtractTailOr("cum|3", -1));
+        }
+
+        // -------------------------------------------------------------------
+        // Round-trip
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void RoundTrip_PreservesBothPortions()
+        {
+            string composed = IdentifierPayload.Compose("monsterize", 42);
+            Assert.Equal("monsterize", IdentifierPayload.ExtractHead(composed));
+            Assert.True(IdentifierPayload.TryExtractTail(composed, out int tail));
+            Assert.Equal(42, tail);
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Monsterizeprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Monsterizeprocessortests.cs
@@ -5,6 +5,7 @@ using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
 using MongoDB.Bson;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace FChatDicebot.Tests.Unit.InteractionProcessors
@@ -116,6 +117,153 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             var bobProfile = _database.GetProfile("Bob");
             Assert.Equal("dragon", bobProfile.characteristics["monster"]);
             Assert.True(bobProfile.timers.ContainsKey("monsterize"));
+        }
+
+        // -------------------------------------------------------------------
+        // ValidateInteraction — base-class coverage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ValidateInteraction_NonExistentInitiator_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("NonExistentUser", "Bob", "dragon");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_NonExistentRecipient_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "NonExistentUser", "dragon");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_BothUsersAndIdentifier_ReturnsSuccess()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "dragon");
+
+            Assert.True(result.IsValid);
+        }
+
+        // -------------------------------------------------------------------
+        // ProcessInteraction — persistence + cooldown
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ProcessInteraction_SetsSevenDayCooldown()
+        {
+            // Spec: monsterize locks the recipient for 7 days from the next UTC midnight.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "dragon");
+            _processor.ProcessInteraction(pending);
+
+            var bob = _database.GetProfile("Bob");
+            Assert.True(bob.timers.ContainsKey(MonsterizeProcessor.CooldownTimerKey));
+            // Cooldown lands between 6 and 8 days out (allowing for date-rounding slack).
+            Assert.True(bob.timers[MonsterizeProcessor.CooldownTimerKey].timerEnd > DateTime.UtcNow.AddDays(6));
+            Assert.True(bob.timers[MonsterizeProcessor.CooldownTimerKey].timerEnd <= DateTime.UtcNow.AddDays(8));
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "dragon"));
+
+            var saved = _database.GetInteractionsByInitiator("Alice");
+            Assert.Single(saved);
+            Assert.Equal("monsterize", saved[0].type);
+            Assert.Equal("dragon", saved[0].identifier);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "dragon");
+            _database.AddPendingCommand(pending);
+            _processor.ProcessInteraction(pending);
+
+            Assert.Null(_database.GetPendingCommand(pending.Id));
+        }
+
+        // -------------------------------------------------------------------
+        // GetCompletionMessage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothDisplayNamesAndMonsterText()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Brave").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").Build();
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "dragon");
+
+            Assert.Contains("Alice the Brave", message);
+            Assert.Contains("Bob the Bold", message);
+            Assert.Contains("dragon", message);
+            Assert.Contains("monsterkind", message);
+        }
+
+        // -------------------------------------------------------------------
+        // GetConsentWarning
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetConsentWarning_IncludesNotTakenLightlyAndWorkCheckWarning()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, "dragon");
+
+            Assert.Contains("Alice", warning);
+            Assert.Contains("Bob", warning);
+            Assert.Contains("dragon", warning);
+            Assert.Contains("[b]", warning);
+            Assert.Contains("not be taken lightly", warning);
+            // The Consequence-tier warning calls out !work integration.
+            Assert.Contains("!work", warning);
+            Assert.Contains("!consent", warning);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private static PendingCommand BuildPending(string initiator, string recipient, string monsterType)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    Id = ObjectId.GenerateNewId(),
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "monsterize",
+                    identifier = monsterType,
+                    investmentLevel = "consequence",
+                    interactionTime = DateTime.UtcNow,
+                }
+            };
         }
 
         public void Dispose()

--- a/FChatDicebot.Tests/Unit/Monsterizeprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Monsterizeprocessortests.cs
@@ -37,6 +37,50 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
+        public void ValidateInteraction_NoMonsterTypeProvided_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "");
+
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_RecipientOnActiveCooldown_ReturnsFailure()
+        {
+            // The processor's own cooldown gate (relocated from the command) — a stray
+            // pending that races past the command-time check must still be rejected here.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithDisplayName("Bob")
+                .WithTimer(MonsterizeProcessor.CooldownTimerKey, DateTime.UtcNow.AddDays(3))
+                .BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "dragon");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("monsterize", result.ErrorMessage);
+            Assert.Contains("Bob", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_RecipientExpiredCooldown_Allowed()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithTimer(MonsterizeProcessor.CooldownTimerKey, DateTime.UtcNow.AddDays(-1))
+                .BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "dragon");
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
         public void ProcessInteraction_SetsMonsterType()
         {
             // Arrange

--- a/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
@@ -37,6 +37,50 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
+        public void ValidateInteraction_NoObjectTypeProvided_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "");
+
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_RecipientOnActiveCooldown_ReturnsFailure()
+        {
+            // The processor's own cooldown gate (relocated from the command) — a stray
+            // pending that races past the command-time check must still be rejected here.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithDisplayName("Bob")
+                .WithTimer(ObjectifyProcessor.CooldownTimerKey, DateTime.UtcNow.AddHours(6))
+                .BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "chair");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("objectify", result.ErrorMessage);
+            Assert.Contains("Bob", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_RecipientExpiredCooldown_Allowed()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithTimer(ObjectifyProcessor.CooldownTimerKey, DateTime.UtcNow.AddHours(-2))
+                .BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "chair");
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
         public void ProcessInteraction_SetsObjectType()
         {
             // Arrange

--- a/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
@@ -5,6 +5,7 @@ using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
 using MongoDB.Bson;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace FChatDicebot.Tests.Unit.InteractionProcessors
@@ -116,6 +117,152 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             var bobProfile = _database.GetProfile("Bob");
             Assert.Equal("chair", bobProfile.characteristics["objectType"]);
             Assert.True(bobProfile.timers.ContainsKey("objectify"));
+        }
+
+        // -------------------------------------------------------------------
+        // ValidateInteraction — base-class coverage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ValidateInteraction_NonExistentInitiator_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("NonExistentUser", "Bob", "chair");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_NonExistentRecipient_ReturnsFailure()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "NonExistentUser", "chair");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("NonExistentUser", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_BothUsersAndIdentifier_ReturnsSuccess()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "chair");
+
+            Assert.True(result.IsValid);
+        }
+
+        // -------------------------------------------------------------------
+        // ProcessInteraction — persistence + cooldown
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ProcessInteraction_SetsOneDayCooldown()
+        {
+            // Spec: objectify locks the recipient for 1 day from the next UTC midnight.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "chair");
+            _processor.ProcessInteraction(pending);
+
+            var bob = _database.GetProfile("Bob");
+            Assert.True(bob.timers.ContainsKey(ObjectifyProcessor.CooldownTimerKey));
+            // Cooldown lands between 0 and 2 days out (UTC-midnight rounding can give >1d
+            // when the test runs early in the day, or just under 1d on later runs).
+            Assert.True(bob.timers[ObjectifyProcessor.CooldownTimerKey].timerEnd > DateTime.UtcNow);
+            Assert.True(bob.timers[ObjectifyProcessor.CooldownTimerKey].timerEnd <= DateTime.UtcNow.AddDays(2));
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "chair"));
+
+            var saved = _database.GetInteractionsByInitiator("Alice");
+            Assert.Single(saved);
+            Assert.Equal("objectify", saved[0].type);
+            Assert.Equal("chair", saved[0].identifier);
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var pending = BuildPending("Alice", "Bob", "chair");
+            _database.AddPendingCommand(pending);
+            _processor.ProcessInteraction(pending);
+
+            Assert.Null(_database.GetPendingCommand(pending.Id));
+        }
+
+        // -------------------------------------------------------------------
+        // GetCompletionMessage
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothDisplayNamesAndObjectText()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Brave").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").Build();
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "chair");
+
+            Assert.Contains("Alice the Brave", message);
+            Assert.Contains("Bob the Bold", message);
+            Assert.Contains("chair", message);
+            Assert.Contains("some sort of", message);
+        }
+
+        // -------------------------------------------------------------------
+        // GetConsentWarning
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void GetConsentWarning_IncludesNotTakenLightlyWarning()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string warning = _processor.GetConsentWarning(initiator, recipient, "chair");
+
+            Assert.Contains("Alice", warning);
+            Assert.Contains("Bob", warning);
+            Assert.Contains("chair", warning);
+            Assert.Contains("[b]", warning);
+            Assert.Contains("not be taken lightly", warning);
+            Assert.Contains("!consent", warning);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private static PendingCommand BuildPending(string initiator, string recipient, string objectType)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    Id = ObjectId.GenerateNewId(),
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "objectify",
+                    identifier = objectType,
+                    investmentLevel = "commitment",
+                    interactionTime = DateTime.UtcNow,
+                }
+            };
         }
 
         public void Dispose()

--- a/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Objectifyprocessortests.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void InvestmentLevel_ReturnsConsequence()
+        public void InvestmentLevel_ReturnsCommitment()
         {
-            Assert.Equal("consequence", _processor.InvestmentLevel);
+            Assert.Equal("commitment", _processor.InvestmentLevel);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Petrifyprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Petrifyprocessortests.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void InvestmentLevel_ReturnsConsequence()
+        public void InvestmentLevel_ReturnsCommitment()
         {
-            Assert.Equal("consequence", _processor.InvestmentLevel);
+            Assert.Equal("commitment", _processor.InvestmentLevel);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Plantprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Plantprocessortests.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void InvestmentLevel_ReturnsConsequence()
+        public void InvestmentLevel_ReturnsCommitment()
         {
-            Assert.Equal("consequence", _processor.InvestmentLevel);
+            Assert.Equal("commitment", _processor.InvestmentLevel);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
+++ b/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
@@ -285,6 +285,74 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.True(result.IsValid);
         }
 
+        // -------------------------------------------------------------------
+        // GetCompletionMessageWithStatusEffects wrapper
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void CompletionWrapper_AppendsCompletionFragments_WithSingleSpace()
+        {
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(completionAppendix: "[aura]"));
+
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string result = _processor.GetCompletionMessageWithStatusEffects(initiator, recipient, identifier: "");
+
+            // Base test-processor message ends with "." — fragment should follow on the same line.
+            Assert.EndsWith("test-interacts with Bob. [aura]", result);
+        }
+
+        [Fact]
+        public void CompletionWrapper_EmptyBaseMessage_StaysEmpty_NoLeadingSpace()
+        {
+            // Some processors (e.g. milk's TOCTOU clamp-to-zero path) intentionally suppress
+            // channel output by returning empty from GetCompletionMessage. The wrapper must
+            // honor that — surfacing a stray "[aura]" with no host sentence would be a bug.
+            StatusEffectRegistry.RegisterContributor(new FakeContributor(completionAppendix: "[aura]"));
+
+            var initiator = new ProfileBuilder().WithUserName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").Build();
+            var suppressing = new SuppressingProcessor(_database);
+
+            string result = suppressing.GetCompletionMessageWithStatusEffects(initiator, recipient, identifier: "");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        public void CompletionWrapper_DefaultSubject_IsRecipient()
+        {
+            // The contributor checks whose userName it was handed and only fires for "Bob".
+            // If the wrapper defaulted to the initiator we'd see an empty result instead.
+            StatusEffectRegistry.RegisterContributor(
+                new UserNameGatedContributor(expectedUserName: "Bob", completionAppendix: "[bob-aura]"));
+
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+
+            string result = _processor.GetCompletionMessageWithStatusEffects(initiator, recipient, identifier: "");
+
+            Assert.EndsWith("[bob-aura]", result);
+        }
+
+        [Fact]
+        public void CompletionWrapper_OverrideRedirectsToInitiator()
+        {
+            // Subclass override of GetStatusEffectSubject swaps the default recipient
+            // subject for the initiator — verifies the climaxer-style override pattern.
+            StatusEffectRegistry.RegisterContributor(
+                new UserNameGatedContributor(expectedUserName: "Alice", completionAppendix: "[alice-aura]"));
+
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+            var initiatorSubjectProcessor = new InitiatorSubjectProcessor(_database);
+
+            string result = initiatorSubjectProcessor.GetCompletionMessageWithStatusEffects(initiator, recipient, identifier: "");
+
+            Assert.EndsWith("[alice-aura]", result);
+        }
+
         // ===================================================================
         // Test doubles
         // ===================================================================
@@ -417,6 +485,71 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
                 });
                 return fragments;
             }
+        }
+
+        /// <summary>
+        /// Contributor that fires only when the profile it's handed has a specific userName.
+        /// Used by the wrapper subject-selection tests to assert that the wrapper routed the
+        /// right profile to contributors.
+        /// </summary>
+        private class UserNameGatedContributor : IStatusEffectContributor
+        {
+            private readonly string _expectedUserName;
+            private readonly string _completionAppendix;
+
+            public UserNameGatedContributor(string expectedUserName, string completionAppendix)
+            {
+                _expectedUserName = expectedUserName;
+                _completionAppendix = completionAppendix;
+            }
+
+            public StatusEffectFragments Contribute(
+                Profile profile, StatusEffectCallSite callSite, string interactionType, bool isInitiator)
+            {
+                var fragments = new StatusEffectFragments();
+                if (profile == null || profile.userName != _expectedUserName) return fragments;
+                if (callSite != StatusEffectCallSite.Completion) return fragments;
+                fragments.CompletionAppendix.Add(_completionAppendix);
+                return fragments;
+            }
+        }
+
+        /// <summary>
+        /// Processor whose GetCompletionMessage returns empty — mirrors milk's TOCTOU
+        /// clamp-to-zero path. The wrapper should leave this empty (no leading whitespace,
+        /// no stray fragment).
+        /// </summary>
+        private class SuppressingProcessor : InteractionProcessorBase
+        {
+            public override string InteractionType => "suppressing";
+            public override string InvestmentLevel => "casual";
+
+            public SuppressingProcessor(IChateauDatabase database) : base(database) { }
+
+            public override string ProcessInteraction(PendingCommand command) => InteractionType;
+            public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+                => string.Empty;
+        }
+
+        /// <summary>
+        /// Processor that overrides GetStatusEffectSubject to return the initiator. Used to
+        /// verify the climax-style override pattern routes status effects away from the
+        /// default recipient.
+        /// </summary>
+        private class InitiatorSubjectProcessor : InteractionProcessorBase
+        {
+            public override string InteractionType => "initiatorsubject";
+            public override string InvestmentLevel => "casual";
+
+            public InitiatorSubjectProcessor(IChateauDatabase database) : base(database) { }
+
+            public override string ProcessInteraction(PendingCommand command) => InteractionType;
+            public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+                => $"{initiatorProfile.displayName} acts on {recipientProfile.displayName}.";
+
+            protected override Profile GetStatusEffectSubject(
+                Profile initiatorProfile, Profile recipientProfile, string identifier)
+                => initiatorProfile;
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauBond.cs
+++ b/FChatDicebot/BotCommands/ChateauBond.cs
@@ -52,8 +52,6 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " would like to declare that " + recipientProfile.displayName + " is their " + Utils.BondToText(bond, true) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to this new bond?";
-
                 Interaction bondInteraction = new Interaction();
                 bondInteraction.initiator = characterName;
                 bondInteraction.recipient = recipient;
@@ -68,6 +66,9 @@ namespace FChatDicebot.BotCommands
 
                 MonDB.addPendingCommand(pendingBond);
 
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("bond");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, bond);
                 bot.SendMessageInChannel(message, channel);
             }
         }

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -76,7 +76,7 @@ namespace FChatDicebot.BotCommands
                         //get completion message
                         Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
                         Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
-                        channelMessage += processor.GetCompletionMessage(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
+                        channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
                         channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
 
                         // Drain any out-of-band private note the processor wants sent to
@@ -116,7 +116,7 @@ namespace FChatDicebot.BotCommands
                     // Get the completion message
                     Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
                     Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
-                    channelMessage += processor.GetCompletionMessage(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
+                    channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
                     channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
 
                     // Drain any out-of-band private note the processor wants sent to

--- a/FChatDicebot/BotCommands/ChateauKiss.cs
+++ b/FChatDicebot/BotCommands/ChateauKiss.cs
@@ -39,26 +39,25 @@ namespace FChatDicebot.BotCommands
             if (recipientProfile == null)
             {
                 bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+                return;
             }
-            else
-            {
-                string message = initiatorProfile.displayName + " wants to give you a kiss, " + recipientProfile.displayName + ". Do you !consent to a smooch?";
 
-                Interaction kiss = new Interaction();
-                kiss.initiator = characterName;
-                kiss.recipient = recipient;
-                kiss.type = "kiss";
-                kiss.investmentLevel = "casual";
+            Interaction kiss = new Interaction();
+            kiss.initiator = characterName;
+            kiss.recipient = recipient;
+            kiss.type = "kiss";
+            kiss.investmentLevel = "casual";
 
-                PendingCommand pendingKiss = new PendingCommand();
-                pendingKiss.pendingInteraction = kiss;
-                pendingKiss.awaitingConsentFrom = recipient;
+            PendingCommand pendingKiss = new PendingCommand();
+            pendingKiss.pendingInteraction = kiss;
+            pendingKiss.awaitingConsentFrom = recipient;
 
-                MonDB.addPendingCommand(pendingKiss);
+            MonDB.addPendingCommand(pendingKiss);
 
-                bot.SendMessageInChannel(message, channel);
-            }
-            
+            // Delegate consent wording to the processor so it stays in one place.
+            var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("kiss");
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, "");
+            bot.SendMessageInChannel(message, channel);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauMonsterize.cs
+++ b/FChatDicebot/BotCommands/ChateauMonsterize.cs
@@ -36,49 +36,46 @@ namespace FChatDicebot.BotCommands
         {
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             string monsterType = commandController.GetIdentifierFromCommandTerms(rawTerms, "monster");
-            Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);
-            Boolean valid = true;
-            if (recipientProfile == null)
-            {
-                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
-                valid = false;
-            } 
-            else if (monsterType == null)
+
+            // Delegate validation to the processor so the command-time check uses the same
+            // rules (profile existence, monster-identifier required, recipient-cooldown
+            // recheck) as the consent-time path. Validation can fail because the recipient
+            // was not found OR because monster-identifier was not supplied — keep the
+            // pre-check on the identifier separately so the typed error wording matches.
+            if (monsterType == null)
             {
                 bot.SendPrivateMessage(ChateauInteractionHandler.typeNotFoundText("monster"), characterName);
-                valid = false;
+                return;
             }
-            else if (recipientProfile.timers.ContainsKey("monsterize")) { 
 
-                if (recipientProfile.timers["monsterize"].timerEnd.CompareTo(DateTime.UtcNow) > 0) //recipient was monsterized too recently
-                {
-                    string tooSoonText = "You're trying to monsterize " + recipientProfile.displayName + " but they only recently changed to the monster they currently are! Please respect that 'Commitment' interactions are meant to be just that - a commitment. Wait a little longer before you change their form again. \n\n"
-                      + recipientProfile.displayName + " will be available to monsterize in " + Utils.GetTimeSpanPrint(recipientProfile.timers["monsterize"].timerEnd - DateTime.UtcNow);
-                    bot.SendPrivateMessage(tooSoonText, characterName);
-                    valid = false;
-                } 
-            }
-            if (valid)
+            var processor = (InteractionProcessors.Consequence.MonsterizeProcessor)
+                InteractionProcessors.InteractionProcessorRegistry.GetProcessor("monsterize");
+            var validation = processor.ValidateInteraction(characterName, recipient, monsterType);
+            if (!validation.IsValid)
             {
-                string message = initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(monsterType) + " " + monsterType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to your new form?";
-
-                Interaction monsterize = new Interaction();
-                monsterize.initiator = characterName;
-                monsterize.recipient = recipient;
-                monsterize.type = "monsterize";
-                monsterize.identifier = monsterType;
-                monsterize.investmentLevel = "consequence";
-                monsterize.interactionTime = DateTime.UtcNow;
-
-                PendingCommand pendingMonsterize = new PendingCommand();
-                pendingMonsterize.pendingInteraction = monsterize;
-                pendingMonsterize.awaitingConsentFrom = recipient;
-
-                MonDB.addPendingCommand(pendingMonsterize);
-
-                bot.SendMessageInChannel(message, channel);
+                bot.SendPrivateMessage(validation.ErrorMessage, characterName);
+                return;
             }
+
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            string message = initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(monsterType) + " " + monsterType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to your new form?";
+
+            Interaction monsterize = new Interaction();
+            monsterize.initiator = characterName;
+            monsterize.recipient = recipient;
+            monsterize.type = "monsterize";
+            monsterize.identifier = monsterType;
+            monsterize.investmentLevel = "consequence";
+            monsterize.interactionTime = DateTime.UtcNow;
+
+            PendingCommand pendingMonsterize = new PendingCommand();
+            pendingMonsterize.pendingInteraction = monsterize;
+            pendingMonsterize.awaitingConsentFrom = recipient;
+
+            MonDB.addPendingCommand(pendingMonsterize);
+
+            bot.SendMessageInChannel(message, channel);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauMonsterize.cs
+++ b/FChatDicebot/BotCommands/ChateauMonsterize.cs
@@ -68,7 +68,7 @@ namespace FChatDicebot.BotCommands
                 monsterize.recipient = recipient;
                 monsterize.type = "monsterize";
                 monsterize.identifier = monsterType;
-                monsterize.investmentLevel = "commitment";
+                monsterize.investmentLevel = "consequence";
                 monsterize.interactionTime = DateTime.UtcNow;
 
                 PendingCommand pendingMonsterize = new PendingCommand();

--- a/FChatDicebot/BotCommands/ChateauMonsterize.cs
+++ b/FChatDicebot/BotCommands/ChateauMonsterize.cs
@@ -59,7 +59,6 @@ namespace FChatDicebot.BotCommands
             }
 
             Profile recipientProfile = MonDB.getProfile(recipient);
-            string message = initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(monsterType) + " " + monsterType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to your new form?";
 
             Interaction monsterize = new Interaction();
             monsterize.initiator = characterName;
@@ -75,6 +74,8 @@ namespace FChatDicebot.BotCommands
 
             MonDB.addPendingCommand(pendingMonsterize);
 
+            // Delegate consent wording to the processor so it stays in one place.
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, monsterType);
             bot.SendMessageInChannel(message, channel);
         }
     }

--- a/FChatDicebot/BotCommands/ChateauObjectify.cs
+++ b/FChatDicebot/BotCommands/ChateauObjectify.cs
@@ -62,7 +62,6 @@ namespace FChatDicebot.BotCommands
             }
 
             Profile recipientProfile = MonDB.getProfile(recipient);
-            string message = initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into some sort of " + objectType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming an object?";
 
             Interaction objectifyInteraction = new Interaction();
             objectifyInteraction.initiator = characterName;
@@ -78,6 +77,8 @@ namespace FChatDicebot.BotCommands
 
             MonDB.addPendingCommand(pendingObjectify);
 
+            // Delegate consent wording to the processor so it stays in one place.
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, objectType);
             bot.SendMessageInChannel(message, channel);
         }
     }

--- a/FChatDicebot/BotCommands/ChateauObjectify.cs
+++ b/FChatDicebot/BotCommands/ChateauObjectify.cs
@@ -35,52 +35,50 @@ namespace FChatDicebot.BotCommands
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
             string identifierType = "object";
-            string timerString = "objectify";
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             string objectType = commandController.GetIdentifierFromCommandTerms(rawTerms, identifierType);
-            Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);
-            Boolean valid = true;
-            if (recipientProfile == null)
-            {
-                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
-                valid = false;
-            } 
-            else if (objectType == null)
+
+            // Object-identifier pre-check stays at the command level so its error wording
+            // matches the user-facing "object" type label (the processor's own missing-
+            // identifier failure uses the same text via typeNotFoundText, but the command
+            // checks first to avoid even attempting processor lookup with a missing type).
+            if (objectType == null)
             {
                 bot.SendPrivateMessage(ChateauInteractionHandler.typeNotFoundText(identifierType), characterName);
-                valid = false;
+                return;
             }
-            else if (recipientProfile.timers.ContainsKey(timerString)) { 
 
-                if (recipientProfile.timers[timerString].timerEnd.CompareTo(DateTime.UtcNow) > 0) //recipient was plantified too recently
-                {
-                    string tooSoonText = "You're trying to objectify " + recipientProfile.displayName + " but they were recently objectified! Please respect that 'Commitment' interactions are meant to be just that - a commitment. Wait a little longer for them to recover before you objectify them again. \n\n"
-                      + recipientProfile.displayName + " will be available to objectify no sooner than " + recipientProfile.timers[timerString].timerEnd + " (the current time is " + DateTime.UtcNow + ")";
-                    bot.SendPrivateMessage(tooSoonText, characterName);
-                    valid = false;
-                } 
-            }
-            if (valid)
+            // ObjectifyProcessor's namespace is Consequence (the file lives under
+            // InteractionProcessors/Commitment but the namespace declaration predates
+            // the folder reshuffle) — using the actual declared namespace here.
+            var processor = (InteractionProcessors.Consequence.ObjectifyProcessor)
+                InteractionProcessors.InteractionProcessorRegistry.GetProcessor("objectify");
+            var validation = processor.ValidateInteraction(characterName, recipient, objectType);
+            if (!validation.IsValid)
             {
-                string message = initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into some sort of " + objectType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming an object?";
-
-                Interaction objectifyInteraction = new Interaction();
-                objectifyInteraction.initiator = characterName;
-                objectifyInteraction.recipient = recipient;
-                objectifyInteraction.type = timerString;
-                objectifyInteraction.identifier = objectType;
-                objectifyInteraction.investmentLevel = "commitment";
-                objectifyInteraction.interactionTime = DateTime.UtcNow;
-
-                PendingCommand pendingObjectify = new PendingCommand();
-                pendingObjectify.pendingInteraction = objectifyInteraction;
-                pendingObjectify.awaitingConsentFrom = recipient;
-
-                MonDB.addPendingCommand(pendingObjectify);
-
-                bot.SendMessageInChannel(message, channel);
+                bot.SendPrivateMessage(validation.ErrorMessage, characterName);
+                return;
             }
+
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            string message = initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into some sort of " + objectType + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming an object?";
+
+            Interaction objectifyInteraction = new Interaction();
+            objectifyInteraction.initiator = characterName;
+            objectifyInteraction.recipient = recipient;
+            objectifyInteraction.type = "objectify";
+            objectifyInteraction.identifier = objectType;
+            objectifyInteraction.investmentLevel = "commitment";
+            objectifyInteraction.interactionTime = DateTime.UtcNow;
+
+            PendingCommand pendingObjectify = new PendingCommand();
+            pendingObjectify.pendingInteraction = objectifyInteraction;
+            pendingObjectify.awaitingConsentFrom = recipient;
+
+            MonDB.addPendingCommand(pendingObjectify);
+
+            bot.SendMessageInChannel(message, channel);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauOdorize.cs
+++ b/FChatDicebot/BotCommands/ChateauOdorize.cs
@@ -1,5 +1,6 @@
 using System;
 using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors;
 using FChatDicebot.InteractionProcessors.Consequence;
 using FChatDicebot.Model;
 
@@ -58,10 +59,6 @@ namespace FChatDicebot.BotCommands
                 return;
             }
 
-            string message = initiatorProfile.displayName + " is going to saturate " + recipientProfile.displayName + " with " + scentPhrase + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently.[/b] "
-                + "The scent will follow them into other interactions for some time. Do you !consent to this lingering aroma?";
-
             Interaction odorize = new Interaction
             {
                 initiator = characterName,
@@ -79,6 +76,10 @@ namespace FChatDicebot.BotCommands
             };
 
             MonDB.addPendingCommand(pendingOdorize);
+
+            // Delegate consent wording to the processor so it stays in one place.
+            var processor = InteractionProcessorRegistry.GetProcessor("odorize");
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, scent);
             bot.SendMessageInChannel(message, channel);
         }
     }

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -344,6 +344,7 @@
     <Compile Include="InteractionProcessors\Casual\SpankProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\EntitleProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\MarkProcessor.cs" />
+    <Compile Include="InteractionProcessors\IdentifierPayload.cs" />
     <Compile Include="InteractionProcessors\IInteractionProcessor.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorBase.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorRegistry.cs" />

--- a/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
@@ -10,7 +10,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
     public class ConsumeProcessor : InteractionProcessorBase
     {
         public override string InteractionType => "consume";
-        public override string InvestmentLevel => "consequence";
+        public override string InvestmentLevel => "commitment";
 
         public ConsumeProcessor(IChateauDatabase database) : base(database)
         {

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
@@ -401,32 +401,29 @@ namespace FChatDicebot.InteractionProcessors.Commitment
         // -----------------------------------------------------------------------
         // Identifier payload helpers.
         //
-        // The Interaction model has no per-call magnitude slot, so we piggyback the
-        // identifier field as a compact "{verb}|{magnitude}" payload. The command writes
-        // the *requested* magnitude there; ProcessInteraction overwrites it with the
-        // *applied* magnitude so GetCompletionMessage (called immediately after with the
-        // same in-memory PendingCommand) reports the truthful clamped value.
+        // Thin façade over the shared <see cref="IdentifierPayload"/> encoder, applying
+        // corruption-specific defaults (missing verb → "corrupt", missing or negative
+        // magnitude → 1). New processors that need to carry a per-call number alongside
+        // a verb should reuse <see cref="IdentifierPayload"/> directly rather than
+        // recreating this pipe encoder.
         // -----------------------------------------------------------------------
 
         public static string ComposeIdentifier(string verb, int magnitude)
         {
-            return verb + "|" + magnitude.ToString();
+            return IdentifierPayload.Compose(verb, magnitude);
         }
 
         public static string ParseVerbFromIdentifier(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return CorruptType;
-            int pipe = identifier.IndexOf('|');
-            return pipe < 0 ? identifier : identifier.Substring(0, pipe);
+            return IdentifierPayload.ExtractHead(identifier) ?? CorruptType;
         }
 
         public static int ParseMagnitudeFromIdentifier(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return 1;
-            int pipe = identifier.IndexOf('|');
-            if (pipe < 0 || pipe >= identifier.Length - 1) return 1;
-            string magPart = identifier.Substring(pipe + 1);
-            return int.TryParse(magPart, out int value) && value >= 0 ? value : 1;
+            // Corruption rejects negative magnitudes (direction lives on the verb), so a
+            // stray negative tail collapses back to the default 1.
+            if (!IdentifierPayload.TryExtractTail(identifier, out int value) || value < 0) return 1;
+            return value;
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
@@ -10,7 +10,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
     public class EmployProcessor : InteractionProcessorBase
     {
         public override string InteractionType => "employ";
-        public override string InvestmentLevel => "consequence";
+        public override string InvestmentLevel => "commitment";
 
         public EmployProcessor(IChateauDatabase database) : base(database)
         {

--- a/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
@@ -35,6 +35,13 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             }
         }
 
+        /// <summary>
+        /// Profile-key under which the 1-day re-objectify lock is stored on the recipient.
+        /// Exposed so the command's pre-check and the processor's recheck consult the same
+        /// timer and can't drift.
+        /// </summary>
+        public const string CooldownTimerKey = "objectify";
+
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
         {
             var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
@@ -46,6 +53,22 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             if (string.IsNullOrEmpty(identifier))
             {
                 return ValidationResult.Failure(ChateauInteractionHandler.typeNotFoundText("object"));
+            }
+
+            // Recipient already objectified too recently — rejection lives here (not in
+            // the command) so a stray pending that races past the command-time check
+            // still gets gated at consent time.
+            Profile recipientProfile = Database.GetProfile(recipient);
+            if (recipientProfile?.timers != null
+                && recipientProfile.timers.TryGetValue(CooldownTimerKey, out var timer)
+                && timer.timerEnd > DateTime.UtcNow)
+            {
+                string recipientName = recipientProfile.displayName ?? recipient;
+                return ValidationResult.Failure(
+                    "You're trying to objectify " + recipientName + " but they were recently objectified! "
+                    + "Please respect that 'Commitment' interactions are meant to be just that - a commitment. Wait a little longer for them to recover before you objectify them again. \n\n"
+                    + recipientName + " will be available to objectify no sooner than " + timer.timerEnd
+                    + " (the current time is " + DateTime.UtcNow + ")");
             }
 
             return ValidationResult.Success();

--- a/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
@@ -10,7 +10,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
     public class ObjectifyProcessor : InteractionProcessorBase
     {
         public override string InteractionType => "objectify";
-        public override string InvestmentLevel => "consequence";
+        public override string InvestmentLevel => "commitment";
 
         public ObjectifyProcessor(IChateauDatabase database) : base(database)
         {

--- a/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
@@ -10,7 +10,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
     public class PetrifyProcessor : InteractionProcessorBase
     {
         public override string InteractionType => "petrify";
-        public override string InvestmentLevel => "consequence";
+        public override string InvestmentLevel => "commitment";
 
         public PetrifyProcessor(IChateauDatabase database) : base(database)
         {

--- a/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
@@ -11,7 +11,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
     public class PlantProcessor : InteractionProcessorBase
     {
         public override string InteractionType => "plant";
-        public override string InvestmentLevel => "consequence";
+        public override string InvestmentLevel => "commitment";
 
         public PlantProcessor(IChateauDatabase database) : base(database)
         {

--- a/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
@@ -52,7 +52,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 string remaining = Utils.GetTimeSpanPrint(timer.timerEnd - DateTime.UtcNow);
                 return ValidationResult.Failure(
                     "You're trying to monsterize " + recipientName + " but they only recently changed to the monster they currently are! "
-                    + "Please respect that 'Commitment' interactions are meant to be just that - a commitment. Wait a little longer before you change their form again. \n\n"
+                    + "Please respect that 'Consequence' interactions are also a Commitment. Wait a little longer before you change their form again. \n\n"
                     + recipientName + " will be available to monsterize in " + remaining);
             }
 
@@ -101,7 +101,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Identifier monsterIdentifier = MonDB.getIdentifier(identifier);
             string monsterText = monsterIdentifier != null ? monsterIdentifier.description : identifier;
 
-            return initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(identifier) + " " + identifier + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to your new form?";
+            return initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(identifier) + " " + identifier + "! [b]This should not be taken lightly, and can not be done frequently. The capabilities of your new body might be referenced in flavor text and !work checks.[/b] Do you !consent to your new form?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
@@ -20,6 +20,13 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         {
         }
 
+        /// <summary>
+        /// Profile-key under which the 7-day re-monsterize lock is stored on the recipient.
+        /// Exposed so the command's pre-check and the processor's recheck consult the same
+        /// timer and can't drift.
+        /// </summary>
+        public const string CooldownTimerKey = "monsterize";
+
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
         {
             var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
@@ -31,6 +38,22 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             if (string.IsNullOrEmpty(identifier))
             {
                 return ValidationResult.Failure(ChateauInteractionHandler.typeNotFoundText("monster"));
+            }
+
+            // Recipient already monsterized too recently — rejection lives here (not in
+            // the command) so a stray pending that races past the command-time check
+            // still gets gated at consent time.
+            Profile recipientProfile = Database.GetProfile(recipient);
+            if (recipientProfile?.timers != null
+                && recipientProfile.timers.TryGetValue(CooldownTimerKey, out var timer)
+                && timer.timerEnd > DateTime.UtcNow)
+            {
+                string recipientName = recipientProfile.displayName ?? recipient;
+                string remaining = Utils.GetTimeSpanPrint(timer.timerEnd - DateTime.UtcNow);
+                return ValidationResult.Failure(
+                    "You're trying to monsterize " + recipientName + " but they only recently changed to the monster they currently are! "
+                    + "Please respect that 'Commitment' interactions are meant to be just that - a commitment. Wait a little longer before you change their form again. \n\n"
+                    + recipientName + " will be available to monsterize in " + remaining);
             }
 
             return ValidationResult.Success();

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -58,6 +58,14 @@ namespace FChatDicebot.InteractionProcessors
         string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier);
 
         /// <summary>
+        /// Channel-bound entry point: returns <see cref="GetCompletionMessage"/> with any
+        /// active status-effect completion fragments appended. The consent pipeline calls
+        /// this so every interaction surfaces e.g. corruption auras / scent layers
+        /// uniformly without each processor having to wire it in itself.
+        /// </summary>
+        string GetCompletionMessageWithStatusEffects(Profile initiatorProfile, Profile recipientProfile, string identifier);
+
+        /// <summary>
         /// Drain any out-of-band private note the processor wants delivered to the
         /// initiator after <see cref="ProcessInteraction"/> ran (e.g. corrupt/purify's
         /// "your queued interaction landed but daily quota was already spent" notice).

--- a/FChatDicebot/InteractionProcessors/IdentifierPayload.cs
+++ b/FChatDicebot/InteractionProcessors/IdentifierPayload.cs
@@ -1,0 +1,92 @@
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Shared encoder/decoder for the <c>"{head}|{tail}"</c> payload pattern that several
+    /// processors stamp onto <see cref="Model.Interaction.identifier"/>.
+    ///
+    /// The <see cref="Model.Interaction"/> model has no dedicated per-call slot for things
+    /// like "applied magnitude" / "rolled quantity" / "post-bump daily count" — but a
+    /// processor needs to carry that number from <c>ProcessInteraction</c> into the
+    /// follow-up <c>GetCompletionMessage</c> call (which receives only the in-memory
+    /// PendingCommand). Piggy-backing on the identifier as a compact pipe-separated
+    /// payload solves that. The command-time shape is the head alone (no pipe); the
+    /// processor overwrites with the full composite before the completion message runs
+    /// so the channel text reports the truthful clamped/rolled value.
+    ///
+    /// <para>
+    /// Three processors currently use this pattern (Corrupt, Milk, Climaxfor). New
+    /// processors that need to ferry a per-call integer alongside a verb/substance/type
+    /// should call <see cref="Compose"/>, <see cref="ExtractHead"/>, and
+    /// <see cref="TryExtractTail"/> here instead of inventing a fourth pipe encoder.
+    /// </para>
+    ///
+    /// <para>
+    /// Per-processor defaults (e.g. "if the verb is missing fall back to <c>corrupt</c>",
+    /// "if the magnitude is unparseable fall back to 1") are the processor's business, so
+    /// each processor keeps a small façade method that calls into here and applies its own
+    /// default. See <see cref="Commitment.CorruptionProcessor.ParseVerbFromIdentifier"/>,
+    /// <see cref="Involved.MilkProcessor.ParseSubstanceFromIdentifier"/>, and
+    /// <see cref="Involved.ClimaxforProcessor.ParseTypeFromIdentifier"/> for examples.
+    /// </para>
+    /// </summary>
+    public static class IdentifierPayload
+    {
+        /// <summary>Pipe character separating the head and tail portions.</summary>
+        public const char Separator = '|';
+
+        /// <summary>
+        /// Encode a payload as <c>"{head}|{tail}"</c>. A null head is treated as the empty
+        /// string so the round-trip can still be parsed.
+        /// </summary>
+        public static string Compose(string head, int tail)
+        {
+            return (head ?? string.Empty) + Separator + tail.ToString();
+        }
+
+        /// <summary>
+        /// Pull the head portion out of a payload. Returns:
+        /// <list type="bullet">
+        ///   <item><c>null</c> when the input is null or empty.</item>
+        ///   <item>The entire input when no separator is present (command-time shape — the
+        ///         processor hasn't stamped the tail yet).</item>
+        ///   <item>The substring before the separator otherwise.</item>
+        /// </list>
+        /// Callers wanting a non-null default should coalesce: <c>ExtractHead(x) ?? "default"</c>.
+        /// </summary>
+        public static string ExtractHead(string identifier)
+        {
+            if (string.IsNullOrEmpty(identifier)) return null;
+            int pipe = identifier.IndexOf(Separator);
+            return pipe < 0 ? identifier : identifier.Substring(0, pipe);
+        }
+
+        /// <summary>
+        /// Try to parse the integer tail from a payload. Returns false (with
+        /// <paramref name="tail"/>=0) when the input is null/empty, when the separator is
+        /// missing, when the separator is the last character, or when the tail portion
+        /// isn't a valid integer.
+        ///
+        /// Use this directly when callers need to distinguish "no tail recorded" from
+        /// "tail recorded as 0" (e.g. milk's TOCTOU clamp path). When a numeric fallback
+        /// is acceptable, prefer the convenience overload that accepts a default.
+        /// </summary>
+        public static bool TryExtractTail(string identifier, out int tail)
+        {
+            tail = 0;
+            if (string.IsNullOrEmpty(identifier)) return false;
+            int pipe = identifier.IndexOf(Separator);
+            if (pipe < 0 || pipe >= identifier.Length - 1) return false;
+            string tailPart = identifier.Substring(pipe + 1);
+            return int.TryParse(tailPart, out tail);
+        }
+
+        /// <summary>
+        /// Convenience overload: returns the parsed tail, or <paramref name="defaultValue"/>
+        /// when <see cref="TryExtractTail"/> would have returned false.
+        /// </summary>
+        public static int ExtractTailOr(string identifier, int defaultValue)
+        {
+            return TryExtractTail(identifier, out int value) ? value : defaultValue;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -125,8 +125,57 @@ namespace FChatDicebot.InteractionProcessors
 
         /// <summary>
         /// Get the completion message. Override this to customize the message.
+        ///
+        /// This returns the processor's own message body. Callers in the consent pipeline
+        /// should use <see cref="GetCompletionMessageWithStatusEffects"/> instead, which
+        /// wraps this with the registered status-effect contributors so every interaction
+        /// surfaces e.g. corruption auras and scent layers uniformly. Tests that want to
+        /// pin a processor's bare wording (without contributor fragments) can keep calling
+        /// this directly.
         /// </summary>
         public abstract string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier);
+
+        /// <summary>
+        /// Channel-bound entry point used by <see cref="BotCommands.ChateauConsent"/> when a
+        /// consented interaction lands: composes the processor's own
+        /// <see cref="GetCompletionMessage"/> output and then appends any active
+        /// status-effect completion fragments for the relevant subject profile.
+        ///
+        /// Default subject is the recipient (most interactions act on them, so their auras
+        /// / scents / etc. are the natural ones to surface). Processors where the relevant
+        /// party is someone else — e.g. <see cref="Involved.ClimaxforProcessor"/>, whose
+        /// climaxer can be either side depending on the typed verb — override
+        /// <see cref="GetStatusEffectSubject"/> to redirect.
+        ///
+        /// When the base message is empty (e.g. milk's TOCTOU clamp-to-zero path
+        /// suppresses channel output), status fragments are skipped — appending them would
+        /// leave a stray leading space and surface fragments that no longer have a host
+        /// sentence to attach to.
+        /// </summary>
+        public string GetCompletionMessageWithStatusEffects(
+            Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            string baseMessage = GetCompletionMessage(initiatorProfile, recipientProfile, identifier);
+            if (string.IsNullOrEmpty(baseMessage)) return baseMessage;
+
+            Profile subject = GetStatusEffectSubject(initiatorProfile, recipientProfile, identifier);
+            if (subject == null) return baseMessage;
+
+            bool subjectIsInitiator = ReferenceEquals(subject, initiatorProfile);
+            var effects = GetActiveStatusEffects(subject, StatusEffectCallSite.Completion, subjectIsInitiator);
+            return AppendStatusFragments(baseMessage, effects.CompletionAppendix);
+        }
+
+        /// <summary>
+        /// Returns the profile whose status effects should be surfaced on the completion
+        /// message. Default: the recipient. Override when the interaction's natural
+        /// subject is the initiator (or some other party derived from the identifier).
+        /// </summary>
+        protected virtual Profile GetStatusEffectSubject(
+            Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            return recipientProfile;
+        }
 
         /// <summary>
         /// Basic validation - checks that profiles exist and honors any recipient-blocking

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -177,8 +177,10 @@ namespace FChatDicebot.InteractionProcessors.Involved
 
             // Re-read after the count helper wrote so the completion message picks up the
             // freshly-bumped totals (used by some flavor branches that key off counts).
+            // Use the status-effect-wrapped path so a self-climax surfaces the climaxer's
+            // corruption aura / scent layers just like an other-target consent flow does.
             Profile freshInitiator = Database.GetProfile(initiator);
-            return GetCompletionMessage(freshInitiator, freshInitiator, interaction.identifier);
+            return GetCompletionMessageWithStatusEffects(freshInitiator, freshInitiator, interaction.identifier);
         }
 
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
@@ -249,31 +251,30 @@ namespace FChatDicebot.InteractionProcessors.Involved
             int dailyCount = ParseDailyCountFromIdentifier(identifier);
             bool isSelf = string.Equals(initiatorProfile.userName, recipientProfile.userName, StringComparison.Ordinal);
 
-            // Climaxer profile is used for corruption flavor and (future) vice-craving
-            // suppression — both should attach to the person actually having the orgasm,
-            // not to whoever typed the command.
-            Profile climaxerProfile = string.Equals(
+            string descriptor = PickFlavorDescriptor(dailyCount);
+            // Status-effect fragments (corruption aura on the climaxer, etc.) are appended
+            // by the base wrapper GetCompletionMessageWithStatusEffects via the climaxer-
+            // aware GetStatusEffectSubject override below.
+            return ComposeOpeningSentence(typeKey, isSelf, initiatorProfile, recipientProfile, descriptor);
+        }
+
+        /// <summary>
+        /// Status-effect fragments for a climax attach to the climaxer (the person
+        /// actually having the orgasm), not whoever typed the command. For <c>!climaxfor</c>
+        /// that's the initiator; for <c>!climax</c> (the inverted reskin) that's the
+        /// recipient. Self-targets resolve to the initiator either way.
+        /// </summary>
+        protected override Profile GetStatusEffectSubject(
+            Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            if (initiatorProfile == null || recipientProfile == null) return recipientProfile;
+            string typeKey = ParseTypeFromIdentifier(identifier);
+            return string.Equals(
                 ResolveClimaxer(typeKey, initiatorProfile.userName, recipientProfile.userName),
                 initiatorProfile.userName,
                 StringComparison.Ordinal)
                 ? initiatorProfile
                 : recipientProfile;
-
-            string descriptor = PickFlavorDescriptor(dailyCount);
-            string sentence = ComposeOpeningSentence(typeKey, isSelf, initiatorProfile, recipientProfile, descriptor);
-
-            // Status-effect contributors (e.g. dose-craving once that lands) decorate the
-            // completion message. Per spec, the climaxer is the relevant profile here:
-            // their corruption supplies the wicked-moan flavor, and their vices are the
-            // ones briefly satisfied by the climax.
-            bool climaxerIsInitiator = ReferenceEquals(climaxerProfile, initiatorProfile);
-            var effects = GetActiveStatusEffects(
-                climaxerProfile,
-                StatusEffectCallSite.Completion,
-                isInitiator: climaxerIsInitiator);
-            sentence = AppendStatusFragments(sentence, effects.CompletionAppendix);
-
-            return sentence;
         }
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -409,35 +409,31 @@ namespace FChatDicebot.InteractionProcessors.Involved
         // -----------------------------------------------------------------------
         // Identifier payload helpers.
         //
-        // The Interaction model has no dedicated typeKey/daily-count slot, so we use
-        // the identifier field as a "{typeKey}|{dailyCount}" payload. The command-time
-        // shape is the typeKey alone (no pipe); the processor overwrites with the full
-        // composite before GetCompletionMessage runs so the message can render the
-        // right wording for whichever verb the user typed.
+        // Thin façade over the shared <see cref="IdentifierPayload"/> encoder, applying
+        // climax-specific normalization (the head is constrained to either ClimaxforType
+        // or ClimaxType, missing daily count → 1). New processors that need to carry a
+        // per-call number alongside a verb should reuse <see cref="IdentifierPayload"/>
+        // directly rather than recreating this pipe encoder.
         // -----------------------------------------------------------------------
 
         public static string ComposeIdentifier(string typeKey, int dailyCount)
         {
             string safeType = string.IsNullOrEmpty(typeKey) ? ClimaxforType : typeKey;
-            return safeType + "|" + dailyCount.ToString();
+            return IdentifierPayload.Compose(safeType, dailyCount);
         }
 
         public static string ParseTypeFromIdentifier(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return ClimaxforType;
-            int pipe = identifier.IndexOf('|');
-            string raw = pipe < 0 ? identifier : identifier.Substring(0, pipe);
+            string raw = IdentifierPayload.ExtractHead(identifier);
             if (string.Equals(raw, ClimaxType, StringComparison.OrdinalIgnoreCase)) return ClimaxType;
             return ClimaxforType;
         }
 
         public static int ParseDailyCountFromIdentifier(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return 1;
-            int pipe = identifier.IndexOf('|');
-            if (pipe < 0 || pipe >= identifier.Length - 1) return 1;
-            string countPart = identifier.Substring(pipe + 1);
-            return int.TryParse(countPart, out int value) && value > 0 ? value : 1;
+            // Daily count is always positive; non-positive values are treated as missing.
+            if (!IdentifierPayload.TryExtractTail(identifier, out int value) || value <= 0) return 1;
+            return value;
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
@@ -273,34 +273,30 @@ namespace FChatDicebot.InteractionProcessors.Involved
         // -----------------------------------------------------------------------
         // Identifier payload helpers.
         //
-        // The Interaction model has no dedicated quantity slot. The command writes
-        // just the substance name; the processor overwrites with "substance|qty"
-        // so GetCompletionMessage can read the truthful clamped quantity.
-        // Same pattern as CorruptionProcessor.
+        // Thin façade over the shared <see cref="InteractionProcessors.IdentifierPayload"/>
+        // encoder, applying milk-specific defaults (missing substance → empty string,
+        // missing quantity → -1 sentinel meaning "not yet stamped" — the TOCTOU no-op
+        // path in <see cref="GetCompletionMessage"/> distinguishes a real 0 from this
+        // pre-process shape). New processors that need to carry a per-call number
+        // alongside a substance/verb should reuse <see cref="IdentifierPayload"/>
+        // directly rather than recreating this pipe encoder.
         // -----------------------------------------------------------------------
 
         public static string ComposeIdentifier(string substance, int quantity)
         {
-            return (substance ?? string.Empty) + "|" + quantity.ToString();
+            return IdentifierPayload.Compose(substance, quantity);
         }
 
         public static string ParseSubstanceFromIdentifier(string identifier)
         {
-            if (string.IsNullOrEmpty(identifier)) return string.Empty;
-            int pipe = identifier.IndexOf('|');
-            return pipe < 0 ? identifier : identifier.Substring(0, pipe);
+            return IdentifierPayload.ExtractHead(identifier) ?? string.Empty;
         }
 
         public static int ParseQuantityFromIdentifier(string identifier)
         {
-            // No pipe means the identifier still carries only the substance (the
-            // command-time / pre-process shape), so quantity is unknown — return -1
-            // so callers can distinguish "no quantity recorded" from "quantity zero".
-            if (string.IsNullOrEmpty(identifier)) return -1;
-            int pipe = identifier.IndexOf('|');
-            if (pipe < 0 || pipe >= identifier.Length - 1) return -1;
-            string qtyPart = identifier.Substring(pipe + 1);
-            return int.TryParse(qtyPart, out int value) ? value : -1;
+            // -1 sentinel distinguishes "no quantity recorded" (command-time shape)
+            // from "quantity recorded as 0" (TOCTOU clamp-to-zero path).
+            return IdentifierPayload.ExtractTailOr(identifier, -1);
         }
     }
 }


### PR DESCRIPTION
## Summary

Audited the eight in-scope interactions (kiss, bond, monsterize, objectify, odorize, milk, climax, corrupt) for cross-cutting consistency and fixed the gaps surfaced. Six focused commits — each independently reviewable — with the behavioral change in commit 5 being the load-bearing one.

## What changed

**`b6f9a28` — Align investmentLevel with canonical doc.** Five Commitment-tier processors (consume, employ, objectify, petrify, plant) declared `"consequence"`; flipped to `"commitment"` to match the canonical wiki doc and the original commands. Conversely, `ChateauMonsterize` saved `"commitment"` on the Interaction while `MonsterizeProcessor` declared `"consequence"`; fixed the command to match the processor. Identity tests updated.

**`c3f9f23` — Extract `IdentifierPayload` helper.** `CorruptionProcessor`, `MilkProcessor`, and `ClimaxforProcessor` each carried near-identical `"{head}|{tail}"` encoders for stamping per-call state onto `Interaction.identifier`. Replaced the three inline encoders with a shared static class; each processor keeps a small façade applying its own defaults so call-sites and existing tests don't change. Class docstring explicitly steers future contributors to the helper. +21 direct tests.

**`3959c5e` — Move Monsterize/Objectify cooldown checks into processor.** Both interactions previously enforced their per-recipient cooldown in the command — a stray pending could race past the check. Relocated the rejection into each processor's `ValidateInteraction` so the same rule is consulted at both command and consent time. Pure refactor; +6 tests covering the active/expired branches.

**`21014df` — Monsterize cooldown rejection and consent wording.** Cooldown rejection now reads *"'Consequence' interactions are also a Commitment."* (matching Rename) instead of the old copy-pasted Commitment wording. Consent prompt picks up a second bolded sentence: *"The capabilities of your new body might be referenced in flavor text and !work checks."*

**`84dfe68` — Route consent messages through `processor.GetConsentWarning`.** Kiss/Bond/Monsterize/Objectify/Odorize commands all built their consent message inline, duplicating what the processor already returned. Routed each through the processor so it stays the single source of truth. Text identical byte-for-byte for Kiss/Bond/Objectify/Odorize; Monsterize naturally picks up the previously-approved !work-checks wording from the previous commit.

**`d089c02` — Wire status-effect fragments into every interaction's completion.** Previously only `ClimaxforProcessor` called `AppendStatusFragments` on its completion. Moved the wiring into `InteractionProcessorBase` via a new `GetCompletionMessageWithStatusEffects` wrapper; `ChateauConsent` (and Climax's self-target path) call the wrapper. Processors override `GetStatusEffectSubject` to redirect away from the default recipient (Climax does this for the climaxer). Empty base messages still suppress (no stray fragments). **Behavioral impact**: every consented interaction now surfaces the recipient's corruption aura band and scent layer descriptors; scent layers fade one mention per interaction (any type) instead of one per climax. Matches the spec. +4 wrapper tests.

**`2176d13` — Expand Bond/Monsterize/Objectify test coverage.** Each interaction had 5–6 tests; brought to 14 each. Each now exercises base-class validation paths (missing initiator/recipient), interaction-history persistence, pending deletion, cooldown duration, completion message content, and consent warning content. Monsterize consent test pins the new !work-checks wording.

## Test plan

- [x] `dotnet build FChatDicebot.sln` — 0 errors
- [x] `dotnet test FChatDicebot.Tests` — 882/882 pass (was 826 at branch base, +56 new)
- [x] User-facing text diffs surfaced inline during the session and confirmed before each text-touching commit
- [ ] Spot-check a few interactions in chat post-merge to confirm the corruption aura and scent fragments render as expected on, say, a kiss or feed against a corrupted or scented recipient

🤖 Generated with [Claude Code](https://claude.com/claude-code)