### PR TITLE
Add !infest and !purge

### DIFF
--- a/FChatDicebot.Tests/Unit/Chateaupurgetests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaupurgetests.cs
@@ -1,0 +1,222 @@
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for !purge (ChateauPurge). Mirrors the ChateauDetox shape — pure ExecutePurge
+    /// against the database fixture. Cost-application paths are covered indirectly through
+    /// the channel message; per-cost-type unit tests live in PurgeCostApplierTests.
+    /// </summary>
+    [Collection("Database")]
+    public class ChateauPurgeTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public ChateauPurgeTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+
+            // Seed breakable parts so RandomBreak (used by tentacles) has something to pick.
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "arm",
+                description = "arm",
+                categories = new[] { "break" },
+            });
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "leg",
+                description = "leg",
+                categories = new[] { "break" },
+            });
+            // Seed parasite identifiers referenced by tests below — only needed for rendering
+            // lookups in error paths; purge itself doesn't read the identifier for the
+            // success case.
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "lustleeches",
+                description = "heart-shaped lust leeches",
+                categories = new[] { InfestProcessor.ParasiteCategory },
+            });
+        }
+
+        public void Dispose() { }
+
+        [Fact]
+        public void ExecutePurge_NoParasites_PrivateMessageOnly()
+        {
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", specifiedParasite: null);
+
+            Assert.Empty(result.ChannelMessage);
+            Assert.Contains("aren't currently infested", result.PrivateMessage);
+            Assert.Contains("!infest you", result.PrivateMessage);
+        }
+
+        [Fact]
+        public void ExecutePurge_LustLeeches_RendersWithColorTag()
+        {
+            SeedInfestedBob("lustleeches", spread: false);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "lustleeches", new Random(1));
+
+            // The rendered name should be the styled "lust leeches" phrase, not the raw token.
+            Assert.Contains("[color=purple]lust leeches[/color]", result.PrivateMessage);
+            Assert.DoesNotContain("purges lustleeches", result.PrivateMessage);
+        }
+
+        [Fact]
+        public void ExecutePurge_SingleParasite_NoArg_PurgesAtCost()
+        {
+            SeedInfestedBob("paraslime", spread: false);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", specifiedParasite: null, new Random(1));
+
+            // Purge outcomes go to the private message (detox precedent) — channel stays silent.
+            Assert.Empty(result.ChannelMessage);
+            Assert.Contains("purges paraslime", result.PrivateMessage);
+            // paraslime → MissedWork → "work" timer set.
+            var bob = _database.GetProfile("Bob");
+            Assert.True(bob.timers.ContainsKey("work"));
+            Assert.Empty(ParasiteInstance.LoadAll(bob));
+        }
+
+        [Fact]
+        public void ExecutePurge_MultipleParasites_NoArg_AsksWhich()
+        {
+            SeedInfestedBob("paraslime", spread: false);
+            ApplyAdditional("Bob", "tentacles");
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", specifiedParasite: null, new Random(1));
+
+            Assert.Empty(result.ChannelMessage);
+            Assert.Contains("more than one parasite", result.PrivateMessage);
+            Assert.Contains("paraslime", result.PrivateMessage);
+            Assert.Contains("tentacles", result.PrivateMessage);
+            // Nothing was purged.
+            Assert.Equal(2, ParasiteInstance.LoadAll(_database.GetProfile("Bob")).Count);
+        }
+
+        [Fact]
+        public void ExecutePurge_NamedParasite_PurgesAtParasiteSpecificCost()
+        {
+            SeedInfestedBob("paraslime", spread: false);
+            ApplyAdditional("Bob", "tentacles");
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "tentacles", new Random(1));
+
+            Assert.Contains("purges tentacles", result.PrivateMessage);
+            Assert.Empty(result.ChannelMessage);
+            // tentacles → RandomBreak → break instance appended.
+            var bob = _database.GetProfile("Bob");
+            Assert.NotEmpty(BreakInstance.LoadAllWithTick(bob));
+            // paraslime is still there.
+            var parasites = ParasiteInstance.LoadAll(bob);
+            Assert.Single(parasites);
+            Assert.Equal("paraslime", parasites[0].Parasite);
+        }
+
+        [Fact]
+        public void ExecutePurge_NamedParasite_NotPresent_ListsInventory()
+        {
+            SeedInfestedBob("paraslime", spread: false);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "tentacles", new Random(1));
+
+            Assert.Empty(result.ChannelMessage);
+            Assert.Contains("aren't currently infested with tentacles", result.PrivateMessage);
+            Assert.Contains("paraslime", result.PrivateMessage);
+        }
+
+        [Fact]
+        public void ExecutePurge_NamedParasite_CaseInsensitive()
+        {
+            SeedInfestedBob("paraslime", spread: false);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "PARASLIME", new Random(1));
+
+            Assert.Contains("purges paraslime", result.PrivateMessage);
+            Assert.Empty(result.ChannelMessage);
+            Assert.Empty(ParasiteInstance.LoadAll(_database.GetProfile("Bob")));
+        }
+
+        [Fact]
+        public void ExecutePurge_SpreadInfestation_WithinGrace_NoCost()
+        {
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            var bob = _database.GetProfile("Bob");
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: true, gracePeriod: TimeSpan.FromHours(24));
+            _database.SetProfile("Bob", bob);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "paraslime", new Random(1));
+
+            Assert.Contains("catches the paraslime infestation early", result.PrivateMessage);
+            Assert.Empty(result.ChannelMessage);
+            // No work timer was set since cost was skipped.
+            var bobAfter = _database.GetProfile("Bob");
+            Assert.False(bobAfter.timers.ContainsKey("work"));
+            Assert.Empty(ParasiteInstance.LoadAll(bobAfter));
+        }
+
+        [Fact]
+        public void ExecutePurge_SpreadInfestation_PastGrace_AppliesCost()
+        {
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            var bob = _database.GetProfile("Bob");
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: true, gracePeriod: TimeSpan.FromHours(24));
+            // Push GraceUntil into the past so we're outside the window.
+            var entries = ParasiteInstance.LoadAll(bob);
+            entries[0].GraceUntil = DateTime.UtcNow.AddHours(-1);
+            ParasiteInstance.SaveAll(bob, entries);
+            _database.SetProfile("Bob", bob);
+
+            var result = ChateauPurge.ExecutePurge(_database, "Bob", "paraslime", new Random(1));
+
+            // Cost applied — paraslime is MissedWork by default.
+            Assert.Contains("purges paraslime", result.PrivateMessage);
+            Assert.Empty(result.ChannelMessage);
+            var bobAfter = _database.GetProfile("Bob");
+            Assert.True(bobAfter.timers.ContainsKey("work"));
+        }
+
+        [Fact]
+        public void ExecutePurge_UnknownUser_PrivateMessage()
+        {
+            var result = ChateauPurge.ExecutePurge(_database, "Nobody", specifiedParasite: null);
+
+            Assert.Empty(result.ChannelMessage);
+            Assert.NotEmpty(result.PrivateMessage);
+        }
+
+        private void SeedInfestedBob(string parasite, bool spread)
+        {
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            var bob = _database.GetProfile("Bob");
+            InfestProcessor.ApplyInfestation(bob, parasite, "Alice",
+                spreadFromContact: spread,
+                gracePeriod: spread ? TimeSpan.FromHours(24) : TimeSpan.Zero);
+            _database.SetProfile("Bob", bob);
+        }
+
+        private void ApplyAdditional(string userName, string parasite)
+        {
+            var profile = _database.GetProfile(userName);
+            InfestProcessor.ApplyInfestation(profile, parasite, "Alice",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            _database.SetProfile(userName, profile);
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Infestprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Infestprocessortests.cs
@@ -1,0 +1,332 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Tests for InfestProcessor — validation, persistence shape, cooldown placement,
+    /// per-parasite cost lookup, and consent wording. Spread behavior lives in
+    /// ParasiteSpreadEffectTests; purge lives in ChateauPurgeTests.
+    /// </summary>
+    [Collection("Database")]
+    public class InfestProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly InfestProcessor _processor;
+
+        public InfestProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new InfestProcessor(_database);
+
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "paraslime",
+                description = "These parasitic slimes make their home inside your skull.",
+                categories = new[] { InfestProcessor.ParasiteCategory },
+            });
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "tentacles",
+                description = "Squirmy wriggling creatures.",
+                categories = new[] { InfestProcessor.ParasiteCategory },
+            });
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "musk",
+                description = "musk",
+                categories = new[] { "scent" },
+            });
+        }
+
+        public void Dispose() { }
+
+        [Fact]
+        public void InteractionType_ReturnsInfest()
+        {
+            Assert.Equal(InfestProcessor.InfestType, _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsConsequence()
+        {
+            Assert.Equal("consequence", _processor.InvestmentLevel);
+        }
+
+        [Fact]
+        public void ValidateInteraction_EmptyParasite_ReturnsFailure()
+        {
+            SeedPair();
+            var result = _processor.ValidateInteraction("Alice", "Bob", "");
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_UnknownParasite_ReturnsFailure()
+        {
+            SeedPair();
+            var result = _processor.ValidateInteraction("Alice", "Bob", "ghost-worm");
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_NonParasiteCategory_ReturnsFailure()
+        {
+            // "musk" is a scent, not a parasite — must be rejected.
+            SeedPair();
+            var result = _processor.ValidateInteraction("Alice", "Bob", "musk");
+            Assert.False(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_KnownParasite_Succeeds()
+        {
+            SeedPair();
+            var result = _processor.ValidateInteraction("Alice", "Bob", "paraslime");
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_AlreadyInfestedSameParasite_Rejects()
+        {
+            SeedPair();
+            var bob = _database.GetProfile("Bob");
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            _database.SetProfile("Bob", bob);
+
+            var result = _processor.ValidateInteraction("Alice", "Bob", "paraslime");
+
+            Assert.False(result.IsValid);
+            Assert.Contains("already a willing host of paraslime", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ProcessInteraction_FirstInfest_PersistsAsDirect()
+        {
+            SeedPair();
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "paraslime"));
+
+            var bob = _database.GetProfile("Bob");
+            var parasites = ParasiteInstance.LoadAll(bob);
+            Assert.Single(parasites);
+            Assert.Equal("paraslime", parasites[0].Parasite);
+            Assert.Equal("Alice", parasites[0].InfestedBy);
+            Assert.False(parasites[0].SpreadFromContact);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SetsCooldownOnInitiatorByParasiteAndRecipient()
+        {
+            SeedPair();
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "paraslime"));
+
+            var alice = _database.GetProfile("Alice");
+            string key = InfestProcessor.CooldownTimerKey("paraslime", "Bob");
+            Assert.True(alice.timers.ContainsKey(key));
+            Assert.True(alice.timers[key].timerEnd > DateTime.UtcNow.AddDays(6));
+            Assert.True(alice.timers[key].timerEnd <= DateTime.UtcNow.AddDays(7).AddMinutes(1));
+        }
+
+        [Fact]
+        public void ProcessInteraction_DifferentRecipient_DoesNotShareCooldown()
+        {
+            SeedPair();
+            new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+            _processor.ProcessInteraction(BuildPending("Alice", "Bob", "paraslime"));
+
+            var alice = _database.GetProfile("Alice");
+            Assert.True(alice.timers.ContainsKey(InfestProcessor.CooldownTimerKey("paraslime", "Bob")));
+            Assert.False(alice.timers.ContainsKey(InfestProcessor.CooldownTimerKey("paraslime", "Carol")));
+        }
+
+        [Fact]
+        public void ProcessInteraction_SelfInfest_PersistsOnSameProfile()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _processor.ProcessInteraction(BuildPending("Alice", "Alice", "paraslime"));
+
+            var alice = _database.GetProfile("Alice");
+            var parasites = ParasiteInstance.LoadAll(alice);
+            Assert.Single(parasites);
+            Assert.True(alice.timers.ContainsKey(InfestProcessor.CooldownTimerKey("paraslime", "Alice")));
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            SeedPair();
+            var pending = BuildPending("Alice", "Bob", "paraslime");
+            _database.AddPendingCommand(pending);
+
+            _processor.ProcessInteraction(pending);
+
+            Assert.Null(_database.GetPendingCommand(pending.Id));
+        }
+
+        [Fact]
+        public void PurgeCostFor_KnownParasite_ReturnsMappedCost()
+        {
+            Assert.Equal(PurgeCostType.LostTrainingPoint, InfestProcessor.PurgeCostFor("bimboslime"));
+            Assert.Equal(PurgeCostType.RandomBreak, InfestProcessor.PurgeCostFor("tentacles"));
+            Assert.Equal(PurgeCostType.RandomCurse, InfestProcessor.PurgeCostFor("lustleeches"));
+        }
+
+        [Fact]
+        public void PurgeCostFor_UnknownParasite_FallsBackToDefault()
+        {
+            Assert.Equal(InfestProcessor.DefaultPurgeCost, InfestProcessor.PurgeCostFor("unmapped-parasite"));
+        }
+
+        [Fact]
+        public void PurgeCostFor_CaseInsensitive()
+        {
+            Assert.Equal(PurgeCostType.LostTrainingPoint, InfestProcessor.PurgeCostFor("BIMBOSLIME"));
+        }
+
+        [Fact]
+        public void GetConsentWarning_MentionsParasiteCostAndGrace()
+        {
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string consent = _processor.GetConsentWarning(alice, bob, "paraslime");
+
+            // Includes the parasite name preceded by an article ("a paraslime"), the cost
+            // phrase, and the grace-period advertisement.
+            Assert.Contains("a paraslime", consent);
+            Assert.Contains("missing work to recover", consent);
+            Assert.Contains("24-hour", consent);
+            Assert.Contains("Do you !consent to being made into a new host?", consent);
+        }
+
+        [Fact]
+        public void GetConsentWarning_PluralParasite_NoArticle()
+        {
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string consent = _processor.GetConsentWarning(alice, bob, "tentacles");
+
+            // Plural-shaped name — no article, no "a tentacles".
+            Assert.Contains("with tentacles!", consent);
+            Assert.DoesNotContain("with a tentacles", consent);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_DirectInfest_UsesArticleAndFlavor()
+        {
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string completion = _processor.GetCompletionMessage(alice, bob, "paraslime");
+
+            Assert.Contains("Alice has infested Bob with a paraslime", completion);
+            Assert.Contains("Enjoy your future as a host", completion);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_InitiatorAlreadyCarries_SwitchesToSpreadFlavor()
+        {
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            // Alice is already a host — the completion should frame the infest as a direct
+            // spread instead of a fresh introduction.
+            InfestProcessor.ApplyInfestation(alice, "paraslime", "Carol",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            _database.SetProfile("Alice", alice);
+            alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string completion = _processor.GetCompletionMessage(alice, bob, "paraslime");
+
+            Assert.Contains("Alice spreads their paraslime directly to Bob", completion);
+            Assert.Contains("just like Alice has~", completion);
+        }
+
+        [Fact]
+        public void ApplyInfestation_DirectInfest_GraceUntilEqualsNow()
+        {
+            var bob = new ProfileBuilder().WithUserName("Bob").Build();
+            DateTime before = DateTime.UtcNow;
+
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: false, gracePeriod: TimeSpan.FromHours(24));
+
+            var parasites = ParasiteInstance.LoadAll(bob);
+            // Direct infestations don't get a grace window; we use InfestedAt for GraceUntil
+            // so a check against now is always false.
+            Assert.False(parasites[0].SpreadFromContact);
+            Assert.True(parasites[0].GraceUntil <= DateTime.UtcNow);
+            Assert.True(parasites[0].GraceUntil >= before);
+        }
+
+        [Fact]
+        public void ApplyInfestation_SpreadInfest_GraceUntilHonorsPeriod()
+        {
+            var bob = new ProfileBuilder().WithUserName("Bob").Build();
+
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: true, gracePeriod: TimeSpan.FromHours(24));
+
+            var parasites = ParasiteInstance.LoadAll(bob);
+            Assert.True(parasites[0].SpreadFromContact);
+            Assert.True(parasites[0].GraceUntil > DateTime.UtcNow.AddHours(23));
+            Assert.True(parasites[0].GraceUntil < DateTime.UtcNow.AddHours(25));
+        }
+
+        [Fact]
+        public void ApplyInfestation_AlreadyPresent_IsNoOp()
+        {
+            var bob = new ProfileBuilder().WithUserName("Bob").Build();
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Alice",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+
+            InfestProcessor.ApplyInfestation(bob, "paraslime", "Carol",
+                spreadFromContact: true, gracePeriod: TimeSpan.FromHours(24));
+
+            var parasites = ParasiteInstance.LoadAll(bob);
+            Assert.Single(parasites);
+            // The original Alice-attributed direct infestation stays put.
+            Assert.Equal("Alice", parasites[0].InfestedBy);
+            Assert.False(parasites[0].SpreadFromContact);
+        }
+
+        private void SeedPair()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+        }
+
+        private static PendingCommand BuildPending(string initiator, string recipient, string parasite)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = InfestProcessor.InfestType,
+                    identifier = parasite,
+                    investmentLevel = "consequence",
+                    interactionTime = DateTime.UtcNow,
+                },
+            };
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Parasiteflavorcontributortests.cs
+++ b/FChatDicebot.Tests/Unit/Parasiteflavorcontributortests.cs
@@ -1,0 +1,198 @@
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.InteractionProcessors.StatusEffectContributors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Tests for ParasiteFlavorContributor — the per-parasite completion flavor that fires
+    /// at <see cref="ParasiteFlavorContributor.FlavorChance"/> per parasite per interaction,
+    /// on every investment level except !infest itself.
+    /// </summary>
+    public class ParasiteFlavorContributorTests
+    {
+        [Fact]
+        public void Contribute_NoParasites_NoFragments()
+        {
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Contribute_ConsentPhase_SilentEvenWithParasites()
+        {
+            // Consent fragments could spoil the prompt — dose's precedent is completion-only.
+            var bob = BuildBobWith("paraslime");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Consent, "kiss", "", false);
+
+            Assert.Empty(result.ConsentWarnings);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Contribute_InfestInteraction_Skipped()
+        {
+            // The !infest completion already speaks about the parasite — flavor would be
+            // redundant text right on top of it.
+            var bob = BuildBobWith("paraslime");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion,
+                InfestProcessor.InfestType, "paraslime", false);
+
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Contribute_CasualInteraction_StillFires()
+        {
+            // Per spec: flavor surfaces on every investment level, including casual.
+            var bob = BuildBobWith("paraslime");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Single(result.CompletionAppendix);
+            Assert.Contains("Bob", result.CompletionAppendix[0]);
+            Assert.Contains("paraslime", result.CompletionAppendix[0]);
+        }
+
+        [Fact]
+        public void Contribute_RollMisses_NoFragment()
+        {
+            var bob = BuildBobWith("paraslime");
+            var contributor = new ParasiteFlavorContributor(new NeverFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Contribute_UnknownParasite_NoFragment()
+        {
+            // Parasites not in the flavor map (e.g. custom parasites added via the deferred
+            // !defineparasite flow) silently contribute nothing.
+            var bob = BuildBobWith("mystery-parasite");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void Contribute_MultipleParasites_AllRollIndependently()
+        {
+            var bob = BuildBobWith("paraslime");
+            InfestProcessor.ApplyInfestation(bob, "tentacles", "Carol",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            InfestProcessor.ApplyInfestation(bob, "love", "Carol",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            // All three should land a fragment when the roll always succeeds.
+            Assert.Equal(3, result.CompletionAppendix.Count);
+        }
+
+        [Fact]
+        public void Contribute_SubjectSubstituted_UsesDisplayNameWhenPresent()
+        {
+            var bob = BuildBobWith("paraslime", displayName: "Bobby");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Contains("Bobby", result.CompletionAppendix[0]);
+        }
+
+        [Fact]
+        public void Contribute_SubjectSubstituted_FallsBackToUserName()
+        {
+            var bob = BuildBobWith("paraslime", displayName: "");
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+
+            var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+
+            Assert.Contains("Bob", result.CompletionAppendix[0]);
+        }
+
+        [Fact]
+        public void Contribute_NullProfile_EmptyFragments()
+        {
+            var contributor = new ParasiteFlavorContributor(new AlwaysFireRandom());
+            var result = contributor.Contribute(null, StatusEffectCallSite.Completion, "kiss", "", false);
+            Assert.Empty(result.CompletionAppendix);
+        }
+
+        [Fact]
+        public void FlavorChance_OverManyTrials_StaysNearTarget()
+        {
+            // 25% baseline; expect 150–350 hits over 1000 trials with a real Random.
+            int hits = 0;
+            var contributor = new ParasiteFlavorContributor(new Random(42));
+            for (int i = 0; i < 1000; i++)
+            {
+                var bob = BuildBobWith("paraslime");
+                var result = contributor.Contribute(bob, StatusEffectCallSite.Completion, "kiss", "", false);
+                if (result.CompletionAppendix.Count > 0) hits++;
+            }
+            Assert.InRange(hits, 150, 350);
+        }
+
+        [Fact]
+        public void SymmetricInvocation_IsTrue()
+        {
+            // Both initiator and recipient can be carriers — symmetric invocation ensures
+            // both sides have their flavors surfaced at completion.
+            Assert.True(new ParasiteFlavorContributor().SymmetricInvocation);
+        }
+
+        [Theory]
+        [InlineData("paraslime", "[color=pink]paraslime[/color]")]
+        [InlineData("bimboslime", "[color=pink]slime[/color]")]
+        [InlineData("lustleeches", "[color=purple]lust leeches[/color]")]
+        [InlineData("love", "[color=pink]love")]
+        [InlineData("tentacles", "parasitic tentacles")]
+        [InlineData("nymites", "familial warmth")]
+        public void FlavorMap_AllCanonicalParasites_HaveDistinctiveText(string parasite, string distinctive)
+        {
+            // Spot-check that each canonical parasite has the right flavor wiring.
+            Assert.True(ParasiteFlavorContributor.FlavorMap.ContainsKey(parasite));
+            Assert.Contains(distinctive, ParasiteFlavorContributor.FlavorMap[parasite]);
+        }
+
+        private static Profile BuildBobWith(string parasite, string displayName = "Bob")
+        {
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName(displayName).Build();
+            InfestProcessor.ApplyInfestation(bob, parasite, "Alice",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            return bob;
+        }
+
+        /// <summary>Random where every roll succeeds.</summary>
+        private class AlwaysFireRandom : Random
+        {
+            public override double NextDouble() => 0.0;
+        }
+
+        /// <summary>Random where every roll fails.</summary>
+        private class NeverFireRandom : Random
+        {
+            public override double NextDouble() => 0.999999;
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Parasitespreadeffecttests.cs
+++ b/FChatDicebot.Tests/Unit/Parasitespreadeffecttests.cs
@@ -1,0 +1,338 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.InteractionProcessors.StatusEffectContributors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Tests for ParasiteSpreadEffect — the cross-party post-interaction hook that rolls
+    /// spread on non-casual non-infest interactions and adds a fresh ParasiteInstance with a
+    /// grace window to the partner. Direct unit tests use a seeded Random so spread is
+    /// deterministic; integration coverage drives spread through
+    /// InteractionProcessorBase.GetCompletionMessageWithStatusEffects.
+    /// </summary>
+    [Collection("Database")]
+    public class ParasiteSpreadEffectTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public ParasiteSpreadEffectTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        public void Dispose() { }
+
+        [Fact]
+        public void Spread_NonCasual_RollHits_AddsParasiteToPartner()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "involved", "", _database);
+
+            var bobParasites = ParasiteInstance.LoadAll(bob);
+            Assert.Single(bobParasites);
+            Assert.Equal("paraslime", bobParasites[0].Parasite);
+            Assert.True(bobParasites[0].SpreadFromContact);
+            Assert.True(bobParasites[0].GraceUntil > DateTime.UtcNow.AddHours(23));
+            Assert.Single(fragments);
+            // "Meanwhile, paraslime has taken the opportunity to spread from Alice to Bob!"
+            Assert.Contains("paraslime has taken the opportunity to spread from Alice to Bob", fragments[0]);
+            Assert.Contains("24 hour window", fragments[0]);
+        }
+
+        [Fact]
+        public void Spread_PluralParasite_UsesHaveVerb()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "tentacles");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "involved", "", _database);
+
+            // Plural-shaped name → "have" not "has".
+            Assert.Contains("tentacles have taken", fragments[0]);
+        }
+
+        [Fact]
+        public void Spread_RollMisses_DoesNothing()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new NeverSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "involved", "", _database);
+
+            Assert.Empty(ParasiteInstance.LoadAll(bob));
+            Assert.Empty(fragments);
+        }
+
+        [Fact]
+        public void Spread_Casual_SkipsRollEntirely()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+
+            // AlwaysSpreadRandom would otherwise transfer — the casual skip wins.
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "casual", "", _database);
+
+            Assert.Empty(ParasiteInstance.LoadAll(bob));
+            Assert.Empty(fragments);
+        }
+
+        [Fact]
+        public void Spread_InfestInteraction_SkippedToAvoidLoop()
+        {
+            // When !infest itself runs, the parent recipient has just been infested. A naive
+            // spread roll would catch that fresh parasite and send it right back to the
+            // initiator.
+            var (alice, bob) = BuildPair();
+            CarryParasite(bob, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, InfestProcessor.InfestType, "consequence", "paraslime", _database);
+
+            Assert.Empty(ParasiteInstance.LoadAll(alice));
+            Assert.Empty(fragments);
+        }
+
+        [Fact]
+        public void Spread_SelfTarget_NoSpread()
+        {
+            // initiator == recipient: nothing to spread to.
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            CarryParasite(alice, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, alice, "dose", "consequence", "musk", _database);
+
+            Assert.Single(ParasiteInstance.LoadAll(alice));
+            Assert.Empty(fragments);
+        }
+
+        [Fact]
+        public void Spread_PartnerAlreadyInfested_SameParasite_SkipsThatParasite()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+            CarryParasite(bob, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "involved", "", _database);
+
+            // Bob already had it — no second copy, no fragment.
+            Assert.Single(ParasiteInstance.LoadAll(bob));
+            Assert.Empty(fragments);
+        }
+
+        [Fact]
+        public void Spread_MultipleParasitesOnSource_AllRolledIndependently()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+            CarryParasite(alice, "tentacles");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            var fragments = effect.OnInteractionCompleted(
+                alice, bob, "kiss", "involved", "", _database);
+
+            var bobParasites = ParasiteInstance.LoadAll(bob);
+            Assert.Equal(2, bobParasites.Count);
+            Assert.Equal(2, fragments.Count);
+        }
+
+        [Fact]
+        public void Spread_SymmetricBothDirections_RecipientToInitiatorAndBack()
+        {
+            // Each side carries a different parasite — both spread.
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+            CarryParasite(bob, "tentacles");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            effect.OnInteractionCompleted(alice, bob, "kiss", "involved", "", _database);
+
+            var aliceParasites = ParasiteInstance.LoadAll(alice);
+            var bobParasites = ParasiteInstance.LoadAll(bob);
+            Assert.Equal(2, aliceParasites.Count);
+            Assert.Equal(2, bobParasites.Count);
+            Assert.Contains(aliceParasites, p => p.Parasite == "tentacles" && p.SpreadFromContact);
+            Assert.Contains(bobParasites, p => p.Parasite == "paraslime" && p.SpreadFromContact);
+        }
+
+        [Fact]
+        public void Spread_PersistsMutatedProfiles()
+        {
+            var (alice, bob) = BuildPair();
+            CarryParasite(alice, "paraslime");
+
+            var effect = new ParasiteSpreadEffect(new AlwaysSpreadRandom());
+            effect.OnInteractionCompleted(alice, bob, "kiss", "involved", "", _database);
+
+            // Reload from DB — the spread should have called SetProfile.
+            var bobReloaded = _database.GetProfile("Bob");
+            Assert.Single(ParasiteInstance.LoadAll(bobReloaded));
+        }
+
+        [Fact]
+        public void Spread_ChanceHonoredOverManyTrials()
+        {
+            // Drive 1000 trials with the production Random; expect 50–200 transfers at 10%
+            // (wide range so the test isn't flaky on a bad seed).
+            int spreads = 0;
+            var effect = new ParasiteSpreadEffect(new Random(42));
+            for (int i = 0; i < 1000; i++)
+            {
+                var initiator = new ProfileBuilder().WithUserName("Init" + i).Build();
+                var recipient = new ProfileBuilder().WithUserName("Recv" + i).Build();
+                CarryParasite(initiator, "paraslime");
+
+                effect.OnInteractionCompleted(initiator, recipient, "kiss", "involved", "", null);
+
+                if (ParasiteInstance.LoadAll(recipient).Count > 0) spreads++;
+            }
+            Assert.InRange(spreads, 50, 200);
+        }
+
+        // ===================================================================
+        // Integration: drive the spread through GetCompletionMessageWithStatusEffects
+        // ===================================================================
+
+        [Fact]
+        public void HookFiresInsideCompletionWrapper_AndFragmentsAppendToCompletionMessage()
+        {
+            // Set up: registered effect that always spreads, and a vanilla processor whose
+            // base completion message is non-empty. We use a real DoseProcessor against
+            // already-set-up DB state — but easier to use a TestProcessor with explicit
+            // investment level.
+            PostInteractionEffectRegistry.Clear();
+            StatusEffectRegistry.Clear();
+            try
+            {
+                PostInteractionEffectRegistry.RegisterEffect(new ParasiteSpreadEffect(new AlwaysSpreadRandom()));
+
+                var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+                var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+                CarryParasite(alice, "paraslime");
+
+                var processor = new HostProcessor(_database);
+                string output = processor.GetCompletionMessageWithStatusEffects(alice, bob, identifier: "");
+
+                Assert.Contains("paraslime has taken the opportunity to spread from Alice to Bob", output);
+                // Spread persisted to the database (the hook is meant to mutate, not just
+                // emit text).
+                Assert.Single(ParasiteInstance.LoadAll(_database.GetProfile("Bob")));
+            }
+            finally
+            {
+                PostInteractionEffectRegistry.Clear();
+                StatusEffectRegistry.Clear();
+            }
+        }
+
+        [Fact]
+        public void HookSwallowsExceptions_DoesNotBreakHostMessage()
+        {
+            PostInteractionEffectRegistry.Clear();
+            StatusEffectRegistry.Clear();
+            try
+            {
+                PostInteractionEffectRegistry.RegisterEffect(new ThrowingPostEffect());
+
+                var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+                var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+                var processor = new HostProcessor(_database);
+                string output = processor.GetCompletionMessageWithStatusEffects(alice, bob, identifier: "");
+
+                Assert.Contains("Alice test-interacts with Bob", output);
+            }
+            finally
+            {
+                PostInteractionEffectRegistry.Clear();
+                StatusEffectRegistry.Clear();
+            }
+        }
+
+        // ===================================================================
+        // Helpers
+        // ===================================================================
+
+        private (Profile, Profile) BuildPair()
+        {
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            return (alice, bob);
+        }
+
+        private void CarryParasite(Profile profile, string parasite)
+        {
+            InfestProcessor.ApplyInfestation(profile, parasite, "Carol",
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+            if (!string.IsNullOrEmpty(profile.userName))
+            {
+                _database.SetProfile(profile.userName, profile);
+            }
+        }
+
+        /// <summary>Random that always returns 0 — every spread roll succeeds.</summary>
+        private class AlwaysSpreadRandom : Random
+        {
+            public override double NextDouble() => 0.0;
+        }
+
+        /// <summary>Random that always returns 1 — no spread roll ever succeeds.</summary>
+        private class NeverSpreadRandom : Random
+        {
+            public override double NextDouble() => 0.999999;
+        }
+
+        private class ThrowingPostEffect : IPostInteractionEffect
+        {
+            public List<string> OnInteractionCompleted(
+                Profile initiator, Profile recipient,
+                string interactionType, string investmentLevel, string parentIdentifier,
+                IChateauDatabase database)
+            {
+                throw new InvalidOperationException("post-effect went sideways");
+            }
+        }
+
+        /// <summary>
+        /// Vanilla "involved" host so the wrapper composes a host message and then appends
+        /// effect fragments to it. Casual host would silently skip the spread roll.
+        /// </summary>
+        private class HostProcessor : InteractionProcessorBase
+        {
+            public override string InteractionType => "kiss";
+            public override string InvestmentLevel => "involved";
+
+            public HostProcessor(IChateauDatabase database) : base(database) { }
+
+            public override string ProcessInteraction(PendingCommand command) => InteractionType;
+
+            public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+                => initiatorProfile.displayName + " test-interacts with " + recipientProfile.displayName + ".";
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Parasitetexttests.cs
+++ b/FChatDicebot.Tests/Unit/Parasitetexttests.cs
@@ -1,0 +1,85 @@
+using FChatDicebot.Model;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for the ParasiteText rendering helpers — name styling overrides, a/an article
+    /// inflection, and verb agreement.
+    /// </summary>
+    public class ParasiteTextTests
+    {
+        [Theory]
+        [InlineData("paraslime", "paraslime")]
+        [InlineData("bimboslime", "bimboslime")]
+        [InlineData("love", "love")]
+        [InlineData("tentacles", "tentacles")]
+        [InlineData("nymites", "nymites")]
+        public void ParasiteName_DefaultParasites_RenderAsIs(string input, string expected)
+        {
+            Assert.Equal(expected, ParasiteText.ParasiteName(input));
+        }
+
+        [Fact]
+        public void ParasiteName_LustLeeches_RendersStyledPhrase()
+        {
+            Assert.Equal("[color=purple]lust leeches[/color]", ParasiteText.ParasiteName("lustleeches"));
+        }
+
+        [Fact]
+        public void ParasiteName_LustLeeches_CaseInsensitive()
+        {
+            Assert.Equal("[color=purple]lust leeches[/color]", ParasiteText.ParasiteName("LustLeeches"));
+        }
+
+        [Fact]
+        public void ParasiteName_NullOrEmpty_ReturnsEmpty()
+        {
+            Assert.Equal(string.Empty, ParasiteText.ParasiteName(null));
+            Assert.Equal(string.Empty, ParasiteText.ParasiteName(""));
+        }
+
+        [Theory]
+        [InlineData("paraslime", "a paraslime")]      // consonant-initial, singular
+        [InlineData("bimboslime", "a bimboslime")]    // consonant-initial, singular
+        [InlineData("love", "a love")]                 // consonant-initial, singular
+        public void ParasiteNameWithArticle_Singular_GetsArticle(string input, string expected)
+        {
+            Assert.Equal(expected, ParasiteText.ParasiteNameWithArticle(input));
+        }
+
+        [Theory]
+        [InlineData("tentacles", "tentacles")]
+        [InlineData("nymites", "nymites")]
+        public void ParasiteNameWithArticle_PluralShaped_NoArticle(string input, string expected)
+        {
+            Assert.Equal(expected, ParasiteText.ParasiteNameWithArticle(input));
+        }
+
+        [Fact]
+        public void ParasiteNameWithArticle_LustLeeches_NoArticleAndStyled()
+        {
+            // Plural-shaped AND special-cased name — no article, styled phrase only.
+            Assert.Equal("[color=purple]lust leeches[/color]", ParasiteText.ParasiteNameWithArticle("lustleeches"));
+        }
+
+        [Fact]
+        public void ParasiteNameWithArticle_VowelInitialSingular_GetsAn()
+        {
+            // No vowel-initial parasites exist in the catalog yet, but the helper should be
+            // ready for a future "ootheca" or similar custom addition.
+            Assert.Equal("an ootheca", ParasiteText.ParasiteNameWithArticle("ootheca"));
+        }
+
+        [Theory]
+        [InlineData("paraslime", "has")]
+        [InlineData("love", "has")]
+        [InlineData("tentacles", "have")]
+        [InlineData("nymites", "have")]
+        [InlineData("lustleeches", "have")]
+        public void HasOrHave_FollowsPlurality(string input, string expected)
+        {
+            Assert.Equal(expected, ParasiteText.HasOrHave(input));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauInfest.cs
+++ b/FChatDicebot/BotCommands/ChateauInfest.cs
@@ -1,0 +1,92 @@
+using System;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !infest hands the recipient a parasite that has a chance to spread on every
+    /// non-casual interaction they're part of. Mirrors !dose's command shape — a
+    /// consent-driven Consequence interaction with a per-(initiator, recipient, parasite)
+    /// 7-day cooldown on the initiator's timers. !purge is the self-targeted reversal,
+    /// free during the 24-hour spread grace window and costed otherwise.
+    /// </summary>
+    public class ChateauInfest : ChatBotCommand
+    {
+        public ChateauInfest()
+        {
+            Name = "infest";
+            Aliases = new string[] { };
+            Category = "Consequence Interaction";
+            ShortDescription = "Infest someone with new parasitic life.";
+            LongDescription = "Give someone a parasite to host and care for. This parasite has a chance of spreading on its own during any non-casual interaction, but can be removed without complication if they !purge within 24 hours. Otherwise, !purge will come with a cost (see !purge).";
+            Usage = "!infest [noparse][user]NameInUserTag[/user][/noparse] {parasite}";
+            RelatedCommands = new string[] { "purge", "consent", "dossier" };
+            CooldownDuration = "7 days";
+            CooldownAppliesTo = "initiator (per parasite per recipient)";
+            IdentifierCategory = InfestProcessor.ParasiteCategory;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string identifierType = InfestProcessor.ParasiteCategory;
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            string parasite = commandController.GetIdentifierFromCommandTerms(rawTerms, identifierType);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+                return;
+            }
+            if (parasite == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.typeNotFoundText(identifierType), characterName);
+                return;
+            }
+
+            string cooldownKey = InfestProcessor.CooldownTimerKey(parasite, recipient);
+            if (initiatorProfile.timers.ContainsKey(cooldownKey)
+                && initiatorProfile.timers[cooldownKey].timerEnd.CompareTo(DateTime.UtcNow) > 0)
+            {
+                string remaining = Utils.GetTimeSpanPrint(initiatorProfile.timers[cooldownKey].timerEnd - DateTime.UtcNow);
+                string parasitePhrase = ParasiteText.ParasiteName(parasite);
+                bot.SendPrivateMessage(
+                    "You've already infested " + recipientProfile.displayName + " with " + parasitePhrase
+                    + " too recently. Please respect that 'Consequence' interactions are meant to be meaningful, and not spammed. You'll be able to infest "
+                    + recipientProfile.displayName + " with " + parasitePhrase + " again in " + remaining + ".",
+                    characterName);
+                return;
+            }
+
+            Interaction infest = new Interaction
+            {
+                initiator = characterName,
+                recipient = recipient,
+                type = InfestProcessor.InfestType,
+                identifier = parasite,
+                investmentLevel = "consequence",
+                interactionTime = DateTime.UtcNow
+            };
+
+            PendingCommand pendingInfest = new PendingCommand
+            {
+                pendingInteraction = infest,
+                awaitingConsentFrom = recipient
+            };
+
+            MonDB.addPendingCommand(pendingInfest);
+
+            var processor = InteractionProcessorRegistry.GetProcessor(InfestProcessor.InfestType);
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, parasite);
+            bot.SendMessageInChannel(message, channel);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauPurge.cs
+++ b/FChatDicebot/BotCommands/ChateauPurge.cs
@@ -1,0 +1,169 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !purge is the self-targeted reversal for !infest. Removes one parasite at a cost,
+    /// unless the parasite was spread-acquired within the
+    /// <see cref="InfestProcessor.SpreadGracePeriod"/> grace window — in which case it
+    /// purges for free. With no argument the caller must have exactly one parasite to
+    /// disambiguate the target; zero parasites yields a polite refusal, two or more yields
+    /// a "name it" error.
+    /// </summary>
+    public class ChateauPurge : ChatBotCommand
+    {
+        public ChateauPurge()
+        {
+            Name = "purge";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Purge a parasite from your body, at a cost (unless caught early).";
+            LongDescription = "Remove one of your active parasites. Each parasite has a specific cost of removal, which could be missing a day of work, losing training prowess, exhausting a body part (see !break and !rest), or suffering a curse. Look at the details for a specific parasite with !whatis {parasite} to see what that cost is specifically.";
+            Usage = "!purge\n!purge {parasite}";
+            RelatedCommands = new string[] { "infest", "dossier" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = InfestProcessor.ParasiteCategory;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string specifiedParasite = commandController.GetIdentifierFromCommandTerms(rawTerms, InfestProcessor.ParasiteCategory);
+            PurgeResult result = ExecutePurge(MonDB.GetDatabase(), characterName, specifiedParasite);
+
+            if (!string.IsNullOrEmpty(result.ChannelMessage))
+            {
+                bot.SendMessageInChannel(result.ChannelMessage, channel);
+            }
+            if (!string.IsNullOrEmpty(result.PrivateMessage))
+            {
+                bot.SendPrivateMessage(result.PrivateMessage, characterName);
+            }
+        }
+
+        public class PurgeResult
+        {
+            public string ChannelMessage { get; set; } = string.Empty;
+            public string PrivateMessage { get; set; } = string.Empty;
+        }
+
+        /// <summary>
+        /// Pure purge logic, factored out for testability. ChannelMessage is non-empty on a
+        /// successful purge; PrivateMessage is non-empty when the caller has nothing to purge,
+        /// named a parasite they don't carry, or has multiple parasites and didn't specify which.
+        /// </summary>
+        /// <param name="specifiedParasite">Empty/null forces the single-parasite shortcut:
+        /// purges when the caller carries exactly one, otherwise asks which.</param>
+        public static PurgeResult ExecutePurge(IChateauDatabase database, string characterName, string specifiedParasite)
+        {
+            return ExecutePurge(database, characterName, specifiedParasite, new Random());
+        }
+
+        /// <summary>
+        /// Test seam: caller supplies the rng used by the cost applier (which break part is
+        /// picked, which training is decremented).
+        /// </summary>
+        public static PurgeResult ExecutePurge(
+            IChateauDatabase database,
+            string characterName,
+            string specifiedParasite,
+            Random rng)
+        {
+            var result = new PurgeResult();
+            Profile caller = database.GetProfile(characterName);
+            if (caller == null)
+            {
+                result.PrivateMessage = ChateauInteractionHandler.notFoundText(characterName);
+                return result;
+            }
+
+            List<ParasiteInstance> parasites = ParasiteInstance.LoadAll(caller);
+            if (parasites.Count == 0)
+            {
+                result.PrivateMessage = "You aren't currently infested with any parasites. If you'd like to change that, see if someone is willing to !infest you...";
+                return result;
+            }
+
+            ParasiteInstance target;
+            if (!string.IsNullOrEmpty(specifiedParasite))
+            {
+                target = parasites.FirstOrDefault(p =>
+                    string.Equals(p.Parasite, specifiedParasite, StringComparison.OrdinalIgnoreCase));
+                if (target == null)
+                {
+                    result.PrivateMessage = "You aren't currently infested with "
+                        + ParasiteText.ParasiteName(specifiedParasite)
+                        + ", but you are infested with " + DescribeCarriedParasites(parasites)
+                        + ". Maybe you'd like to !purge one of those instead?";
+                    return result;
+                }
+            }
+            else if (parasites.Count == 1)
+            {
+                target = parasites[0];
+            }
+            else
+            {
+                result.PrivateMessage = "You're infested with more than one parasite — "
+                    + DescribeCarriedParasites(parasites)
+                    + ". Specify which to purge: !purge {parasite}.";
+                return result;
+            }
+
+            string callerName = string.IsNullOrEmpty(caller.displayName) ? caller.userName : caller.displayName;
+            string parasiteName = target.Parasite;
+            string parasitePhrase = ParasiteText.ParasiteName(parasiteName);
+            DateTime now = DateTime.UtcNow;
+            bool inGrace = target.SpreadFromContact && now < target.GraceUntil;
+
+            parasites.Remove(target);
+            ParasiteInstance.SaveAll(caller, parasites);
+            database.SetProfile(characterName, caller);
+
+            // Detox precedent: purge outcomes are private to the caller — nobody else
+            // needs to see who's being eaten from the inside by withdrawal.
+            if (inGrace)
+            {
+                result.PrivateMessage = callerName + " catches the " + parasitePhrase
+                    + " infestation early and purges it before it can take hold.";
+                return result;
+            }
+
+            PurgeCostType costType = InfestProcessor.PurgeCostFor(parasiteName);
+            PurgeCostResult cost = PurgeCostApplier.Apply(database, caller, costType, rng);
+
+            string suffix = string.IsNullOrEmpty(cost.Description) ? string.Empty : " " + cost.Description;
+            result.PrivateMessage = callerName + " purges " + parasitePhrase + " from their body." + suffix;
+            return result;
+        }
+
+        /// <summary>
+        /// Render the user's current parasite inventory as a comma-separated phrase — used
+        /// when the !purge target is ambiguous or when they named one they don't carry, so
+        /// the error points at real options.
+        /// </summary>
+        private static string DescribeCarriedParasites(List<ParasiteInstance> parasites)
+        {
+            var parts = parasites
+                .Select(p => p.Parasite)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(ParasiteText.ParasiteName)
+                .ToList();
+            if (parts.Count == 0) return string.Empty;
+            if (parts.Count == 1) return parts[0];
+            if (parts.Count == 2) return parts[0] + " and " + parts[1];
+            return string.Join(", ", parts.GetRange(0, parts.Count - 1)) + ", and " + parts[parts.Count - 1];
+        }
+    }
+}

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -205,6 +205,8 @@
     <Compile Include="BotCommands\ChateauRest.cs" />
     <Compile Include="BotCommands\ChateauDose.cs" />
     <Compile Include="BotCommands\ChateauDetox.cs" />
+    <Compile Include="BotCommands\ChateauInfest.cs" />
+    <Compile Include="BotCommands\ChateauPurge.cs" />
     <Compile Include="BotCommands\ChateauCorrupt.cs" />
     <Compile Include="BotCommands\ChateauPurify.cs" />
     <Compile Include="BotCommands\ChateauRename.cs" />
@@ -355,6 +357,8 @@
     <Compile Include="InteractionProcessors\IStatusEffectContributor.cs" />
     <Compile Include="InteractionProcessors\StatusEffectFragments.cs" />
     <Compile Include="InteractionProcessors\StatusEffectRegistry.cs" />
+    <Compile Include="InteractionProcessors\IPostInteractionEffect.cs" />
+    <Compile Include="InteractionProcessors\PostInteractionEffectRegistry.cs" />
     <Compile Include="InteractionProcessors\Involved\DressupProcessor.cs" />
     <Compile Include="InteractionProcessors\Involved\FeedProcessor.cs" />
     <Compile Include="InteractionProcessors\Involved\MilkProcessor.cs" />
@@ -364,9 +368,12 @@
     <Compile Include="InteractionProcessors\Consequence\OdorizeProcessor.cs" />
     <Compile Include="InteractionProcessors\Consequence\BreakProcessor.cs" />
     <Compile Include="InteractionProcessors\Consequence\DoseProcessor.cs" />
+    <Compile Include="InteractionProcessors\Consequence\InfestProcessor.cs" />
     <Compile Include="InteractionProcessors\StatusEffectContributors\OdorizeStatusContributor.cs" />
     <Compile Include="InteractionProcessors\StatusEffectContributors\BreakStatusContributor.cs" />
     <Compile Include="InteractionProcessors\StatusEffectContributors\DoseStatusContributor.cs" />
+    <Compile Include="InteractionProcessors\StatusEffectContributors\ParasiteSpreadEffect.cs" />
+    <Compile Include="InteractionProcessors\StatusEffectContributors\ParasiteFlavorContributor.cs" />
     <Compile Include="InteractionProcessors\PurgeCostType.cs" />
     <Compile Include="InteractionProcessors\PurgeCostApplier.cs" />
     <Compile Include="Model\ScentLayer.cs" />
@@ -374,6 +381,8 @@
     <Compile Include="Model\ScentText.cs" />
     <Compile Include="Model\ViceInstance.cs" />
     <Compile Include="Model\ViceText.cs" />
+    <Compile Include="Model\ParasiteInstance.cs" />
+    <Compile Include="Model\ParasiteText.cs" />
     <Compile Include="InteractionProcessors\Commitment\PetrifyProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\PlantProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\ObjectifyProcessor.cs" />

--- a/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
@@ -1,0 +1,264 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.InteractionProcessors.Consequence
+{
+    /// <summary>
+    /// Processor for the !infest interaction. Plants a parasite on the recipient that then
+    /// has a chance to spread to subsequent non-casual partners via
+    /// <see cref="StatusEffectContributors.ParasiteSpreadEffect"/>. The recipient (or any
+    /// spread-to victim) clears the parasite with <c>!purge</c> at a parasite-specific cost
+    /// — see <see cref="PurgeCostFor"/>.
+    ///
+    /// Cooldown is per-(initiator → recipient → parasite) tuple on the initiator's timers,
+    /// mirroring <see cref="OdorizeProcessor"/> and <see cref="DoseProcessor"/>: an initiator
+    /// can spread different parasites to different victims freely, but can't infest the same
+    /// (target, parasite) combo twice in a week.
+    /// </summary>
+    public class InfestProcessor : InteractionProcessorBase
+    {
+        public const string InfestType = "infest";
+        public const string ParasiteCategory = "parasite";
+
+        /// <summary>Default cost used when a parasite identifier has no explicit mapping
+        /// in <see cref="CostMap"/>. Bites at productivity; aligns with the spec's
+        /// MissedWork default.</summary>
+        public const PurgeCostType DefaultPurgeCost = PurgeCostType.MissedWork;
+
+        /// <summary>
+        /// How long a spread-acquired infestation can be purged for free. Direct-infest
+        /// instances purge at full cost immediately and do not consult this window.
+        /// </summary>
+        public static readonly TimeSpan SpreadGracePeriod = TimeSpan.FromHours(24);
+
+        /// <summary>
+        /// Cooldown the initiator's (recipient, parasite) pair sits under after a successful
+        /// infest, matching the consequence-tier default used by odorize and dose.
+        /// </summary>
+        public static readonly TimeSpan InfestCooldown = TimeSpan.FromDays(7);
+
+        /// <summary>
+        /// Per-parasite purge cost. Keys are identifier names (lowercase). Unmapped parasites
+        /// fall back to <see cref="DefaultPurgeCost"/>. Mapping reflects the existing
+        /// identifier catalog's flavor — see the !infest design notes for rationale.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, PurgeCostType> CostMap =
+            new Dictionary<string, PurgeCostType>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "paraslime", PurgeCostType.MissedWork },
+                { "bimboslime", PurgeCostType.LostTrainingPoint },
+                { "lustleeches", PurgeCostType.RandomCurse },
+                { "love", PurgeCostType.MissedWork },
+                { "tentacles", PurgeCostType.RandomBreak },
+                { "nymites", PurgeCostType.MissedWork },
+            };
+
+        public override string InteractionType => InfestType;
+        public override string InvestmentLevel => "consequence";
+
+        public InfestProcessor(IChateauDatabase database) : base(database) { }
+        public InfestProcessor() : base() { }
+
+        public static string CooldownTimerKey(string parasite, string recipientUserName)
+        {
+            return "infest_" + parasite + "_" + recipientUserName;
+        }
+
+        /// <summary>
+        /// Resolve a parasite identifier's purge cost. Unmapped parasites fall back to
+        /// <see cref="DefaultPurgeCost"/> so user-added identifiers in the parasite category
+        /// still cost something.
+        /// </summary>
+        public static PurgeCostType PurgeCostFor(string parasiteName)
+        {
+            if (string.IsNullOrEmpty(parasiteName)) return DefaultPurgeCost;
+            return CostMap.TryGetValue(parasiteName, out var mapped) ? mapped : DefaultPurgeCost;
+        }
+
+        /// <summary>
+        /// Human-readable phrase for the cost shown in the !infest consent warning and the
+        /// !purge confirmation. Kept in sync with PurgeCostApplier's after-the-fact
+        /// descriptions but written in forward-looking voice for the consent prompt.
+        /// </summary>
+        public static string CostPhrase(PurgeCostType cost)
+        {
+            switch (cost)
+            {
+                case PurgeCostType.MissedWork:
+                    return "missing work to recover";
+                case PurgeCostType.RandomBreak:
+                    return "a broken body part for one to three days";
+                case PurgeCostType.LostTrainingPoint:
+                    return "a point of training in a random skill";
+                case PurgeCostType.RandomCurse:
+                    return "a curse from a witch's help";
+                default:
+                    return "an unknown cost";
+            }
+        }
+
+        public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
+        {
+            var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
+            if (!baseValidation.IsValid) return baseValidation;
+
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.typeNotFoundText(ParasiteCategory));
+            }
+
+            Identifier parasiteIdentifier = Database.GetIdentifier(identifier);
+            if (parasiteIdentifier == null)
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.notFoundText(identifier));
+            }
+            if (parasiteIdentifier.categories == null
+                || !parasiteIdentifier.categories.Contains(ParasiteCategory, StringComparer.OrdinalIgnoreCase))
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.typeNotFoundText(ParasiteCategory));
+            }
+
+            Profile recipientProfile = Database.GetProfile(recipient);
+            var existing = ParasiteInstance.LoadAll(recipientProfile);
+            if (existing.Any(p => string.Equals(p.Parasite, identifier, StringComparison.OrdinalIgnoreCase)))
+            {
+                string recipientName = string.IsNullOrEmpty(recipientProfile?.displayName)
+                    ? recipient
+                    : recipientProfile.displayName;
+                return ValidationResult.Failure(recipientName + " is already a willing host of "
+                    + ParasiteText.ParasiteName(identifier)
+                    + "! No need to infest them again, but feel free to try with a different parasite.");
+            }
+
+            return ValidationResult.Success();
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+            string parasite = command.pendingInteraction.identifier;
+
+            Database.AddInteraction(command.pendingInteraction);
+
+            bool isSelfInfest = string.Equals(initiator, recipient, StringComparison.Ordinal);
+            Profile recipientProfile = Database.GetProfile(recipient);
+            Profile initiatorProfile = isSelfInfest ? recipientProfile : Database.GetProfile(initiator);
+
+            string infesterName = string.IsNullOrEmpty(initiatorProfile?.displayName)
+                ? initiator
+                : initiatorProfile.displayName;
+            ApplyInfestation(recipientProfile, parasite, infesterName,
+                spreadFromContact: false, gracePeriod: TimeSpan.Zero);
+
+            DateTime now = DateTime.UtcNow;
+            if (initiatorProfile.timers == null)
+            {
+                initiatorProfile.timers = new Dictionary<string, CoolDown>();
+            }
+            initiatorProfile.timers[CooldownTimerKey(parasite, recipient)] = new CoolDown
+            {
+                timerStart = now,
+                timerEnd = now.Add(InfestCooldown),
+            };
+
+            Database.SetProfile(recipient, recipientProfile);
+            if (!isSelfInfest)
+            {
+                Database.SetProfile(initiator, initiatorProfile);
+            }
+
+            Database.DeletePendingCommand(command.Id);
+
+            return InfestType;
+        }
+
+        /// <summary>
+        /// Add a parasite to a profile. New parasite → fresh ParasiteInstance.
+        /// Same parasite already present → no-op (the validator already rejected on direct
+        /// infest; spread also checks before calling). Mutates the profile but does not
+        /// save — callers own persistence.
+        /// </summary>
+        /// <param name="spreadFromContact">True when this came from spread, false for direct
+        /// !infest. Only spread instances honor <paramref name="gracePeriod"/>.</param>
+        /// <param name="gracePeriod">How long the recipient has to !purge for free. Ignored
+        /// for direct infestations.</param>
+        public static void ApplyInfestation(
+            Profile recipientProfile,
+            string parasite,
+            string infesterName,
+            bool spreadFromContact,
+            TimeSpan gracePeriod)
+        {
+            if (recipientProfile == null || string.IsNullOrEmpty(parasite)) return;
+
+            var entries = ParasiteInstance.LoadAll(recipientProfile);
+            if (entries.Any(p => string.Equals(p.Parasite, parasite, StringComparison.OrdinalIgnoreCase)))
+            {
+                return;
+            }
+
+            DateTime now = DateTime.UtcNow;
+            entries.Add(new ParasiteInstance
+            {
+                Parasite = parasite.ToLowerInvariant(),
+                InfestedBy = infesterName,
+                InfestedAt = now,
+                SpreadFromContact = spreadFromContact,
+                GraceUntil = spreadFromContact ? now.Add(gracePeriod) : now,
+            });
+
+            ParasiteInstance.SaveAll(recipientProfile, entries);
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            // Two flavors of completion: when the initiator was already carrying the
+            // parasite, the message frames the infest as a direct spread (rather than a
+            // fresh introduction) so the player sees the continuity with their own
+            // infestation.
+            bool initiatorAlreadyCarried = false;
+            if (initiatorProfile != null)
+            {
+                var initiatorParasites = ParasiteInstance.LoadAll(initiatorProfile);
+                initiatorAlreadyCarried = initiatorParasites.Any(p =>
+                    string.Equals(p.Parasite, identifier, StringComparison.OrdinalIgnoreCase));
+            }
+
+            string parasitePhrase = ParasiteText.ParasiteName(identifier);
+            if (initiatorAlreadyCarried)
+            {
+                return initiatorProfile.displayName + " spreads their " + parasitePhrase + " directly to "
+                    + recipientProfile.displayName + "! "
+                    + "Enjoy your future as a host, and see if you can help it spread, just like "
+                    + initiatorProfile.displayName + " has~";
+            }
+
+            string parasiteWithArticle = ParasiteText.ParasiteNameWithArticle(identifier);
+            return initiatorProfile.displayName + " has infested " + recipientProfile.displayName
+                + " with " + parasiteWithArticle + "! "
+                + "Enjoy your future as a host, and see if you can help it spread~";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            string costPhrase = CostPhrase(PurgeCostFor(identifier));
+            int graceHours = (int)SpreadGracePeriod.TotalHours;
+            string parasiteWithArticle = ParasiteText.ParasiteNameWithArticle(identifier);
+
+            string baseWarning = initiatorProfile.displayName + " wants to infest "
+                + recipientProfile.displayName + " with " + parasiteWithArticle + "! "
+                + "[b]This should not be taken lightly, and can not be done frequently. "
+                + "This parasite has a chance to spread to anyone you have a non-casual interaction with, "
+                + "and signs of your infection might be noticeable in any interaction. "
+                + "You can !purge at the cost of " + costPhrase + ", "
+                + "with a " + graceHours + "-hour grace period during which !purge has no cost.[/b] "
+                + "Do you !consent to being made into a new host?";
+            var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
+            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/IPostInteractionEffect.cs
+++ b/FChatDicebot/InteractionProcessors/IPostInteractionEffect.cs
@@ -1,0 +1,56 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Cross-party side effect that runs after a parent interaction has been processed.
+    /// Unlike <see cref="IStatusEffectContributor"/> (which inspects one profile at a time
+    /// and emits fragments only), a post-interaction effect receives BOTH initiator and
+    /// recipient profiles and may mutate either or both. Used for spread-style mechanics
+    /// where one party's state can transfer to the other (parasites today; potentially
+    /// future contagion effects).
+    ///
+    /// Effects are registered in <see cref="PostInteractionEffectRegistry"/>. They fire
+    /// from <see cref="InteractionProcessorBase.GetCompletionMessageWithStatusEffects"/>,
+    /// after status-effect aggregation but before the final message is composed, so any
+    /// returned fragments append to the completion text alongside the contributor fragments.
+    ///
+    /// Effects own their own persistence — when they mutate a profile they should call
+    /// <see cref="IChateauDatabase.SetProfile"/> themselves; the base class doesn't write
+    /// on their behalf.
+    /// </summary>
+    public interface IPostInteractionEffect
+    {
+        /// <summary>
+        /// Fire after the parent interaction's <c>ProcessInteraction</c> has run.
+        /// Implementations may mutate <paramref name="initiator"/> and/or
+        /// <paramref name="recipient"/> and persist via <paramref name="database"/>.
+        ///
+        /// Returns completion-message fragments to append (empty list when no text).
+        /// Fragments should NOT include leading whitespace — the caller inserts a single
+        /// space between the host message and each fragment, matching
+        /// <see cref="InteractionProcessorBase.AppendStatusFragments"/>.
+        /// </summary>
+        /// <param name="initiator">Initiator of the parent interaction.</param>
+        /// <param name="recipient">Recipient of the parent interaction. Same reference as
+        /// <paramref name="initiator"/> for self-target interactions; implementations should
+        /// be ready for that.</param>
+        /// <param name="interactionType">The parent interaction type (e.g. "kiss", "dose").
+        /// Lets an effect skip self-referential cases (e.g. parasite spread skips
+        /// <c>!infest</c>).</param>
+        /// <param name="investmentLevel">Investment level of the parent interaction
+        /// ("casual"/"involved"/"commitment"/"consequence"). Lets an effect filter casual-
+        /// interaction targets that shouldn't trigger spread.</param>
+        /// <param name="parentIdentifier">The parent interaction's identifier or empty.</param>
+        /// <param name="database">Database handle for persisting mutations.</param>
+        List<string> OnInteractionCompleted(
+            Profile initiator,
+            Profile recipient,
+            string interactionType,
+            string investmentLevel,
+            string parentIdentifier,
+            IChateauDatabase database);
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -161,7 +161,41 @@ namespace FChatDicebot.InteractionProcessors
             Profile subject = GetStatusEffectSubject(initiatorProfile, recipientProfile, identifier);
             var effects = AggregateCompletionStatusEffects(
                 initiatorProfile, recipientProfile, subject, identifier);
-            return AppendStatusFragments(baseMessage, effects.CompletionAppendix);
+            var postEffectFragments = RunPostInteractionEffects(
+                initiatorProfile, recipientProfile, identifier);
+
+            string withStatusFragments = AppendStatusFragments(baseMessage, effects.CompletionAppendix);
+            return AppendStatusFragments(withStatusFragments, postEffectFragments);
+        }
+
+        /// <summary>
+        /// Walk <see cref="PostInteractionEffectRegistry"/> after the parent interaction has
+        /// been processed, letting each effect inspect both profiles, mutate them, and emit
+        /// completion-time fragments. A misbehaving effect must not break the parent
+        /// interaction — exceptions are swallowed, same contract as
+        /// <see cref="GetActiveStatusEffects"/>.
+        /// </summary>
+        private List<string> RunPostInteractionEffects(
+            Profile initiatorProfile, Profile recipientProfile, string parentIdentifier)
+        {
+            var fragments = new List<string>();
+            string safeIdentifier = parentIdentifier ?? string.Empty;
+            foreach (var effect in PostInteractionEffectRegistry.GetAllEffects())
+            {
+                List<string> produced;
+                try
+                {
+                    produced = effect.OnInteractionCompleted(
+                        initiatorProfile, recipientProfile,
+                        InteractionType, InvestmentLevel, safeIdentifier, Database);
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+                if (produced != null) fragments.AddRange(produced);
+            }
+            return fragments;
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
@@ -68,6 +68,7 @@ namespace FChatDicebot.InteractionProcessors
             RegisterProcessor(new OdorizeProcessor());
             RegisterProcessor(new BreakProcessor());
             RegisterProcessor(new DoseProcessor());
+            RegisterProcessor(new InfestProcessor());
 
             _initialized = true;
         }

--- a/FChatDicebot/InteractionProcessors/PostInteractionEffectRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/PostInteractionEffectRegistry.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using FChatDicebot.InteractionProcessors.StatusEffectContributors;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Registry of <see cref="IPostInteractionEffect"/> instances. Parallels
+    /// <see cref="StatusEffectRegistry"/> but for cross-party side effects that mutate both
+    /// initiator and recipient (currently parasite spread; future contagion mechanics).
+    ///
+    /// Order of invocation is registration order. Tests can call <see cref="Clear"/> and
+    /// <see cref="RegisterEffect"/> to inject fakes in isolation.
+    /// </summary>
+    public static class PostInteractionEffectRegistry
+    {
+        private static readonly List<IPostInteractionEffect> _effects = new List<IPostInteractionEffect>();
+        private static bool _initialized = false;
+
+        /// <summary>
+        /// Seed the registry with all built-in effects. Idempotent. Called automatically
+        /// the first time the registry is queried.
+        /// </summary>
+        public static void Initialize()
+        {
+            if (_initialized) return;
+
+            RegisterEffect(new ParasiteSpreadEffect());
+
+            _initialized = true;
+        }
+
+        /// <summary>
+        /// Append an effect. Public so consequence-interaction wiring and tests can both
+        /// register; production callers should prefer adding their entry to
+        /// <see cref="Initialize"/> so the effect is on for every run.
+        /// </summary>
+        public static void RegisterEffect(IPostInteractionEffect effect)
+        {
+            if (effect == null) return;
+            _effects.Add(effect);
+        }
+
+        /// <summary>
+        /// Drop all effects and reset the initialized flag. Intended for test isolation only —
+        /// production code never needs this.
+        /// </summary>
+        public static void Clear()
+        {
+            _effects.Clear();
+            _initialized = false;
+        }
+
+        /// <summary>
+        /// Snapshot of currently-registered effects, in registration order. Triggers
+        /// <see cref="Initialize"/> if it hasn't run yet.
+        /// </summary>
+        public static IReadOnlyList<IPostInteractionEffect> GetAllEffects()
+        {
+            Initialize();
+            return _effects.AsReadOnly();
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteFlavorContributor.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteFlavorContributor.cs
@@ -1,0 +1,96 @@
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors.StatusEffectContributors
+{
+    /// <summary>
+    /// Surfaces a profile's active parasites as flavor fragments in subsequent interactions'
+    /// completion messages. Independent from <see cref="ParasiteSpreadEffect"/>: flavor
+    /// fires whether or not spread fires, and at a higher rate, so the host's infection is
+    /// visibly present even when it's not jumping to a partner this round.
+    ///
+    /// SymmetricInvocation = true — both initiator's and recipient's flavors surface, because
+    /// either side might be hosting. Self-target collapses to a single invocation per the
+    /// base class.
+    ///
+    /// Flavor fires on every investment level (including casual) — per spec, the host's
+    /// signs are noticeable everywhere. The only skip is the !infest interaction itself,
+    /// because the completion already speaks about the parasite and a second flavor line
+    /// piled on top would read redundantly.
+    /// </summary>
+    public class ParasiteFlavorContributor : IStatusEffectContributor
+    {
+        /// <summary>Per-parasite probability of flavor fragment firing on a single
+        /// completion call. Independent rolls per parasite carried.</summary>
+        public const double FlavorChance = 0.25;
+
+        /// <summary>
+        /// Per-parasite flavor templates, keyed by lowercase parasite name. <c>{subject}</c>
+        /// is substituted with the host's display name (falling back to userName).
+        /// Parasites without an entry contribute nothing — graceful degradation for custom
+        /// parasites added through the deferred <c>!defineparasite</c> flow.
+        /// </summary>
+        public static readonly IReadOnlyDictionary<string, string> FlavorMap =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                { "paraslime", "{subject} lets out a little gasp as their [color=pink]paraslime[/color] hits a sensitive spot" },
+                { "bimboslime", "{subject} gets a vacant look, their eyes flashing pink as [color=pink]slime[/color] drips from their ear" },
+                { "lustleeches", "{subject} looks utterly blissful, hearts in their eyes as their [color=purple]lust leeches[/color] spoil them`[eicon]qcpurplehearts[/eicon]`" },
+                { "love", "{subject} feels full to the brim with [color=pink]love ♥[/color]" },
+                { "tentacles", "{subject} can't help but squirm as their parasitic tentacles readjust inside them" },
+                { "nymites", "A creeping familial warmth worms its way through the thoughts of {subject}, flushing their cheeks" },
+            };
+
+        private readonly Random _rng;
+
+        public ParasiteFlavorContributor() : this(new Random()) { }
+
+        /// <summary>Test seam: caller supplies a deterministic Random.</summary>
+        public ParasiteFlavorContributor(Random rng)
+        {
+            _rng = rng ?? new Random();
+        }
+
+        public bool SymmetricInvocation => true;
+
+        public StatusEffectFragments Contribute(
+            Profile profile,
+            StatusEffectCallSite callSite,
+            string interactionType,
+            string parentIdentifier,
+            bool isInitiator)
+        {
+            var result = new StatusEffectFragments();
+            if (profile == null) return result;
+
+            // Consent-phase fragments would spoil the consent prompt. Per Dose's precedent
+            // we keep flavor strictly to completion.
+            if (callSite != StatusEffectCallSite.Completion) return result;
+
+            // The !infest completion already speaks about the parasite — stacking flavor
+            // on top reads redundant. Every other interaction type is fair game.
+            if (string.Equals(interactionType, InfestProcessor.InfestType, StringComparison.OrdinalIgnoreCase))
+            {
+                return result;
+            }
+
+            var parasites = ParasiteInstance.LoadAll(profile);
+            if (parasites.Count == 0) return result;
+
+            string subjectName = string.IsNullOrEmpty(profile.displayName) ? profile.userName : profile.displayName;
+
+            foreach (var parasite in parasites)
+            {
+                if (string.IsNullOrEmpty(parasite.Parasite)) continue;
+                if (!FlavorMap.TryGetValue(parasite.Parasite, out string template)) continue;
+                if (_rng.NextDouble() >= FlavorChance) continue;
+
+                result.CompletionAppendix.Add(template.Replace("{subject}", subjectName));
+            }
+
+            return result;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteSpreadEffect.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectContributors/ParasiteSpreadEffect.cs
@@ -1,0 +1,139 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.InteractionProcessors.StatusEffectContributors
+{
+    /// <summary>
+    /// Cross-party spread effect for parasites. On every non-casual interaction that isn't
+    /// !infest itself, each parasite carried by either party rolls independently against
+    /// <see cref="SpreadChance"/>; on success, the parasite is added to whichever partner
+    /// doesn't already have it, with a grace window equal to
+    /// <see cref="InfestProcessor.SpreadGracePeriod"/>.
+    ///
+    /// Skipping !infest avoids the loop where a freshly-applied parasite immediately
+    /// spreads back to the initiator. Casual interactions skip entirely so a kiss can't
+    /// silently dose someone with their partner's bimboslime — per spec, spread requires
+    /// the players to opt into a non-casual interaction.
+    /// </summary>
+    public class ParasiteSpreadEffect : IPostInteractionEffect
+    {
+        /// <summary>Per-parasite, per-interaction probability of spread. 10% baseline.</summary>
+        public const double SpreadChance = 0.10;
+
+        private readonly Random _rng;
+
+        public ParasiteSpreadEffect() : this(new Random()) { }
+
+        /// <summary>Test seam: caller supplies a deterministic Random.</summary>
+        public ParasiteSpreadEffect(Random rng)
+        {
+            _rng = rng ?? new Random();
+        }
+
+        public List<string> OnInteractionCompleted(
+            Profile initiator,
+            Profile recipient,
+            string interactionType,
+            string investmentLevel,
+            string parentIdentifier,
+            IChateauDatabase database)
+        {
+            var fragments = new List<string>();
+            if (initiator == null || recipient == null) return fragments;
+
+            // Casual interactions don't carry the weight to spread an infestation.
+            if (string.Equals(investmentLevel, "casual", StringComparison.OrdinalIgnoreCase))
+            {
+                return fragments;
+            }
+
+            // !infest's own completion would otherwise see the freshly-added parasite on the
+            // recipient and roll spread back to the initiator on the same interaction.
+            if (string.Equals(interactionType, InfestProcessor.InfestType, StringComparison.OrdinalIgnoreCase))
+            {
+                return fragments;
+            }
+
+            bool isSelfTarget = ReferenceEquals(initiator, recipient)
+                || string.Equals(initiator.userName, recipient.userName, StringComparison.Ordinal);
+
+            // Self-target: there's no partner to spread to, so the spread roll is meaningless.
+            if (isSelfTarget) return fragments;
+
+            bool initiatorMutated = TrySpread(
+                source: recipient, target: initiator,
+                sourceLabel: SafeDisplayName(recipient), targetLabel: SafeDisplayName(initiator),
+                fragments);
+            bool recipientMutated = TrySpread(
+                source: initiator, target: recipient,
+                sourceLabel: SafeDisplayName(initiator), targetLabel: SafeDisplayName(recipient),
+                fragments);
+
+            if (initiatorMutated && database != null && !string.IsNullOrEmpty(initiator.userName))
+            {
+                database.SetProfile(initiator.userName, initiator);
+            }
+            if (recipientMutated && database != null && !string.IsNullOrEmpty(recipient.userName))
+            {
+                database.SetProfile(recipient.userName, recipient);
+            }
+
+            return fragments;
+        }
+
+        /// <summary>
+        /// For each parasite the source carries, roll spread to the target. Returns true if
+        /// the target's parasite list changed (caller persists). Each parasite spreads
+        /// independently, so a single interaction can transfer multiple.
+        /// </summary>
+        private bool TrySpread(
+            Profile source, Profile target,
+            string sourceLabel, string targetLabel,
+            List<string> fragments)
+        {
+            var sourceParasites = ParasiteInstance.LoadAll(source);
+            if (sourceParasites.Count == 0) return false;
+
+            var targetParasites = ParasiteInstance.LoadAll(target);
+            var targetNames = new HashSet<string>(
+                targetParasites.Select(p => p.Parasite ?? string.Empty),
+                StringComparer.OrdinalIgnoreCase);
+
+            bool mutated = false;
+            int graceHours = (int)InfestProcessor.SpreadGracePeriod.TotalHours;
+            foreach (var parasite in sourceParasites)
+            {
+                if (string.IsNullOrEmpty(parasite.Parasite)) continue;
+                if (targetNames.Contains(parasite.Parasite)) continue;
+                if (_rng.NextDouble() >= SpreadChance) continue;
+
+                InfestProcessor.ApplyInfestation(
+                    target,
+                    parasite.Parasite,
+                    infesterName: sourceLabel,
+                    spreadFromContact: true,
+                    gracePeriod: InfestProcessor.SpreadGracePeriod);
+                targetNames.Add(parasite.Parasite);
+                mutated = true;
+
+                string parasitePhrase = ParasiteText.ParasiteName(parasite.Parasite);
+                string verb = ParasiteText.HasOrHave(parasite.Parasite);
+                fragments.Add("Meanwhile, " + parasitePhrase + " " + verb
+                    + " taken the opportunity to spread from " + sourceLabel + " to " + targetLabel + "! "
+                    + "[b]If that's not a desired outcome, you have a " + graceHours
+                    + " hour window to !purge the parasite without consequence.[/b]");
+            }
+            return mutated;
+        }
+
+        private static string SafeDisplayName(Profile profile)
+        {
+            if (profile == null) return string.Empty;
+            return string.IsNullOrEmpty(profile.displayName) ? profile.userName : profile.displayName;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectRegistry.cs
@@ -31,6 +31,7 @@ namespace FChatDicebot.InteractionProcessors
             RegisterContributor(new CorruptionStatusContributor());
             RegisterContributor(new BreakStatusContributor());
             RegisterContributor(new DoseStatusContributor(MonDB.GetDatabase()));
+            RegisterContributor(new ParasiteFlavorContributor());
 
             _initialized = true;
         }

--- a/FChatDicebot/Model/ParasiteInstance.cs
+++ b/FChatDicebot/Model/ParasiteInstance.cs
@@ -1,0 +1,84 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.Model
+{
+    /// <summary>
+    /// One parasite currently active on a profile, applied via <c>!infest</c> (or spread from
+    /// a partner who already had it) and removed via <c>!purge</c>. Stored JSON-encoded inside
+    /// <c>Profile.lists["parasites"]</c>, mirroring the <see cref="ViceInstance"/> pattern so
+    /// the existing <c>Dictionary&lt;string, List&lt;string&gt;&gt;</c> shape doesn't grow a
+    /// new typed field.
+    ///
+    /// <see cref="SpreadFromContact"/> distinguishes direct infestations (which purge at the
+    /// parasite's full cost immediately) from spread infestations (which purge for free
+    /// during the <see cref="GraceUntil"/> window — 24 hours by default). See
+    /// <see cref="InteractionProcessors.StatusEffectContributors.ParasiteSpreadEffect"/> for
+    /// the spread logic and <see cref="BotCommands.ChateauPurge"/> for the reversal.
+    /// </summary>
+    public class ParasiteInstance
+    {
+        public string Parasite { get; set; }
+        public string InfestedBy { get; set; }
+        public DateTime InfestedAt { get; set; }
+        public bool SpreadFromContact { get; set; }
+        public DateTime GraceUntil { get; set; }
+
+        public const string ParasitesListKey = "parasites";
+
+        /// <summary>
+        /// Read all ParasiteInstance entries off a profile, deserializing each JSON string in
+        /// <c>profile.lists["parasites"]</c>. Returns an empty list (never null) and silently
+        /// drops malformed entries so a single corrupt blob can't break the whole status
+        /// surface.
+        /// </summary>
+        public static List<ParasiteInstance> LoadAll(Profile profile)
+        {
+            var result = new List<ParasiteInstance>();
+            if (profile?.lists == null) return result;
+            if (!profile.lists.ContainsKey(ParasitesListKey)) return result;
+
+            foreach (string raw in profile.lists[ParasitesListKey])
+            {
+                if (string.IsNullOrEmpty(raw)) continue;
+                ParasiteInstance entry;
+                try
+                {
+                    entry = JsonConvert.DeserializeObject<ParasiteInstance>(raw);
+                }
+                catch (JsonException)
+                {
+                    continue;
+                }
+                if (entry == null || string.IsNullOrEmpty(entry.Parasite)) continue;
+                result.Add(entry);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Persist a full ParasiteInstance list back into <c>profile.lists["parasites"]</c>,
+        /// replacing prior contents. Removes the key entirely when the list is empty so a
+        /// freshly-purged profile doesn't carry an empty array forever.
+        /// </summary>
+        public static void SaveAll(Profile profile, List<ParasiteInstance> entries)
+        {
+            if (profile == null) return;
+            if (profile.lists == null) profile.lists = new Dictionary<string, List<string>>();
+
+            if (entries == null || entries.Count == 0)
+            {
+                profile.lists.Remove(ParasitesListKey);
+                return;
+            }
+
+            var encoded = new List<string>();
+            foreach (var entry in entries)
+            {
+                encoded.Add(JsonConvert.SerializeObject(entry));
+            }
+            profile.lists[ParasitesListKey] = encoded;
+        }
+    }
+}

--- a/FChatDicebot/Model/ParasiteText.cs
+++ b/FChatDicebot/Model/ParasiteText.cs
@@ -1,0 +1,71 @@
+using System;
+
+namespace FChatDicebot.Model
+{
+    /// <summary>
+    /// User-facing rendering helpers for parasite names. Centralizes the per-parasite
+    /// styling (colors, spacing) and the a/an article inflection used in consent and
+    /// completion messages.
+    ///
+    /// Special-case rendering lives here because the underlying identifier name is a single
+    /// lowercase token (<c>lustleeches</c>) that we want to surface as a styled phrase
+    /// (<c>[color=purple]lust leeches[/color]</c>). Most parasites render as their bare
+    /// identifier name — only the explicit cases below override.
+    /// </summary>
+    public static class ParasiteText
+    {
+        /// <summary>
+        /// Render a parasite name with any per-parasite styling. Returns the bare name when
+        /// no override applies. Null/empty inputs return <see cref="string.Empty"/>.
+        /// </summary>
+        public static string ParasiteName(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return string.Empty;
+            if (string.Equals(name, "lustleeches", StringComparison.OrdinalIgnoreCase))
+            {
+                return "[color=purple]lust leeches[/color]";
+            }
+            return name;
+        }
+
+        /// <summary>
+        /// Render a parasite name preceded by the appropriate indefinite article
+        /// ("a"/"an"). Plural-shaped names (those ending in 's' — tentacles, nymites,
+        /// lustleeches) take no article. Vowel-initial names take "an"; otherwise "a".
+        /// </summary>
+        public static string ParasiteNameWithArticle(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return string.Empty;
+            string rendered = ParasiteName(name);
+            if (TreatAsPlural(name)) return rendered;
+            string article = StartsWithVowelSound(name) ? "an " : "a ";
+            return article + rendered;
+        }
+
+        /// <summary>
+        /// True when the parasite name should be treated as a plural for grammar purposes —
+        /// drives both article suppression ("a tentacles" reads wrong) and verb agreement
+        /// ("tentacles have" vs "paraslime has") in flavor/spread fragments.
+        /// </summary>
+        public static bool TreatAsPlural(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return false;
+            return name.EndsWith("s", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Verb agreement helper for parasite name as subject: "have" for plural-shaped
+        /// names, "has" otherwise.
+        /// </summary>
+        public static string HasOrHave(string name)
+        {
+            return TreatAsPlural(name) ? "have" : "has";
+        }
+
+        private static bool StartsWithVowelSound(string name)
+        {
+            char first = char.ToLowerInvariant(name[0]);
+            return first == 'a' || first == 'e' || first == 'i' || first == 'o' || first == 'u';
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New `!infest` Consequence interaction + `!purge` self-reversal, implementing the parasite system from `wiki-docs/specs/Future-Interactions/Infest-and-Purge.md`.
- New cross-cutting `IPostInteractionEffect` hook (sibling to `IStatusEffectContributor`) that receives both initiator and recipient profiles — used by `ParasiteSpreadEffect` to roll spread on non-casual interactions and mutate the partner's parasite list.
- New `ParasiteFlavorContributor` surfaces per-parasite flavor on every interaction (25% per parasite carried) for the six existing parasite identifiers.

## Design notes for reviewers

- **Storage:** parasite definitions live in the existing `Identifiers` collection (`categories=["parasite"]`), not a new `Parasites` collection. The spec table is illustrative; actual parasites are paraslime / bimboslime / lustleeches / love / tentacles / nymites. Per-parasite cost mapping lives in `InfestProcessor.CostMap` — unmapped parasites fall back to `MissedWork`.
- **New hook vs. extending the contributor:** spread is inherently cross-party, so it can't fit inside `IStatusEffectContributor.Contribute` (which gets one profile at a time). `IPostInteractionEffect` is the smaller, additive way to expose both profiles without touching every existing contributor.
- **`!purge` is private DM**, matching `!detox` precedent. Channel stays silent.
- **`ParasiteText`** centralizes name rendering (`lustleeches → "[color=purple]lust leeches[/color]"`) and "a/an" / "has/have" inflection.
- **Self-spread guard:** `ParasiteSpreadEffect` skips `interactionType=="infest"` so a freshly-applied parasite can't loop back to the initiator on the same interaction.
- **`!defineparasite` deferred** until Conversational-Flows ships (spec explicitly green-lights this fallback).

## Test plan

- [x] `dotnet test` — 1125/1125 passing (+43 new across `Infestprocessortests`, `Parasitespreadeffecttests`, `Parasiteflavorcontributortests`, `Chateaupurgetests`, `Parasitetexttests`).
- [ ] Manual smoke test in-channel: `!infest`, observe consent prompt, `!consent`, observe completion + flavor on next interaction, observe spread fragment after several non-casual interactions, `!purge` both in and out of grace window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)