### PR TITLE
Add natural-language command aliases (alias audit)

### DIFF
--- a/FChatDicebot/BotCommands/ChateauBalance.cs
+++ b/FChatDicebot/BotCommands/ChateauBalance.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauBalance : ChatBotCommand
+    {
+        public ChateauBalance()
+        {
+            Name = "balance";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !bank";
+            LongDescription = "Alternative wording for the !bank command. See !help bank for full details.";
+            Usage = "!balance\nor\n!balance [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "bank", "work", "volunteer" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauBank bank = new ChateauBank();
+            bank.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauBank.cs
+++ b/FChatDicebot/BotCommands/ChateauBank.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
         public ChateauBank()
         {
             Name = "bank";
-            Aliases = new string[] { };
+            Aliases = new string[] { "balance", "money" };
             Category = "General";
             ShortDescription = "See what currencies you or another resident have accumulated";
             LongDescription = "View the currencies stored in the Chateau's vault for yourself or another resident. Currencies don't have any inherent value beyond the worth other residents place in it.";

--- a/FChatDicebot/BotCommands/ChateauBio.cs
+++ b/FChatDicebot/BotCommands/ChateauBio.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauBio : ChatBotCommand
+    {
+        public ChateauBio()
+        {
+            Name = "bio";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !dossier";
+            LongDescription = "Alternative wording for the !dossier command. See !help dossier for full details.";
+            Usage = "!bio\nor\n!bio [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "dossier", "bank", "pledges" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauDossier dossier = new ChateauDossier();
+            dossier.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauCommands.cs
+++ b/FChatDicebot/BotCommands/ChateauCommands.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauCommands : ChatBotCommand
+    {
+        public ChateauCommands()
+        {
+            Name = "commands";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !help";
+            LongDescription = "Alternative wording for the !help command. See !help for the full command list.";
+            Usage = "!commands\nor\n!commands {commandname}";
+            RelatedCommands = new string[] { "help", "botinfo", "dossier" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauHelp help = new ChateauHelp();
+            help.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -16,7 +16,7 @@ namespace FChatDicebot.BotCommands
         public ChateauConsent()
         {
             Name = "consent";
-            Aliases = new string[] { "c" };
+            Aliases = new string[] { "c", "accept" };
             Category = "General";
             ShortDescription = "Consent to a pending interaction";
             LongDescription = "Give your consent to a pending interaction request from another character. When someone requests an interaction with you, you must !consent for it to actually happen and be recorded.\n\nPending requests expire after 10 minutes. If more than one interaction is awaiting your consent, you will be messaged a numbered list of the interactions, and can choose which interaction to consent to, or '!consent all' to consent to every interaction awaiting your consent.";

--- a/FChatDicebot/BotCommands/ChateauCuddle.cs
+++ b/FChatDicebot/BotCommands/ChateauCuddle.cs
@@ -16,7 +16,7 @@ namespace FChatDicebot.BotCommands
         public ChateauCuddle()
         {
             Name = "cuddle";
-            Aliases = new string[] { };
+            Aliases = new string[] { "hug" };
             Category = "Casual Interaction";
             ShortDescription = "Cuddle with another resident";
             LongDescription = "Cuddle with another character as soon as they !consent. Whether it's spooning or a warm embrace, this is a favorite past time of Chateau residents.";

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -131,7 +131,7 @@ namespace FChatDicebot.BotCommands
         {
             _database = database;
             Name = "dossier";
-            Aliases = new string[] { "profile" };
+            Aliases = new string[] { "profile", "bio" };
             Category = "General";
             ShortDescription = "View a character's dossier, a public facing document summarizing their interactions in the Chateau";
             LongDescription = "View a detailed dossier for yourself or another character. If no character name is provided, shows your own dossier. The dossier shows:\n- Display name, titles, specializations (most performed interaction of each category)\n- Current job and employer\n- Casual interaction counts (kisses, cuddles, etc.)\n- Marks on their body\n- Bonds\n- Full job experience\n- Recent interactions\n";

--- a/FChatDicebot/BotCommands/ChateauDress.cs
+++ b/FChatDicebot/BotCommands/ChateauDress.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauDress : ChatBotCommand
+    {
+        public ChateauDress()
+        {
+            Name = "dress";
+            Aliases = new string[] { };
+            Category = "Involved Interaction";
+            ShortDescription = "Alias for !dressup";
+            LongDescription = "Alternative wording for the !dressup command. See !help dressup for full details.";
+            Usage = "!dress [noparse][user]NameInUserTag[/user][/noparse] {attire}\n(use your own username to dress yourself)";
+            RelatedCommands = new string[] { "dressup", "volunteer", "work" };
+            CooldownDuration = "30 Minutes";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = "attire";
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauDressup dressup = new ChateauDressup();
+            dressup.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauDressup.cs
+++ b/FChatDicebot/BotCommands/ChateauDressup.cs
@@ -17,7 +17,7 @@ namespace FChatDicebot.BotCommands
         public ChateauDressup()
         {
             Name = "dressup";
-            Aliases = new string[] { };
+            Aliases = new string[] { "dress" };
             Category = "Involved Interaction";
             ShortDescription = "Dress another resident, or yourself, in specific attire";
             LongDescription = "Dress someone up in specific attire. The recipient must !consent for their outfit to actually change. Some jobs might have unique outcomes only available based on your attire!";

--- a/FChatDicebot/BotCommands/ChateauEmploy.cs
+++ b/FChatDicebot/BotCommands/ChateauEmploy.cs
@@ -17,7 +17,7 @@ namespace FChatDicebot.BotCommands
         public ChateauEmploy()
         {
             Name = "employ";
-            Aliases = new string[] { };
+            Aliases = new string[] { "hire" };
             Category = "Commitment Interaction";
             ShortDescription = "Employ yourself or another resident to do jobs for the Chateau";
             LongDescription = "Employ yourself or another resident to do jobs for the Chateau. Once employed, residents can use !work once a day to earn currency and job experience. On top of working their primary job, residents can also !volunteer once a day to explore other careers.";

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -12,7 +12,7 @@ namespace FChatDicebot.BotCommands
         public ChateauHelp()
         {
             Name = "help";
-            Aliases = new string[] { };
+            Aliases = new string[] { "commands" };
             Category = "General";
             ShortDescription = "Get help about bot commands";
             LongDescription = "View general help for all commands, or get detailed help for a specific command.\n\nWithout arguments: Shows a categorized list of all available commands.\nWith a command name: Shows detailed help for that specific command including usage, cooldown, and related commands.";
@@ -53,10 +53,10 @@ namespace FChatDicebot.BotCommands
             // Original general help display
             List<string> generalCommands = new List<string>()
             {
-                "!dossier [sub]!profile[/sub] ",
+                "!dossier [sub]!profile, !bio[/sub] ",
                 "!work [sub]!w[/sub]",
                 "!volunteer [sub]!v[/sub]",
-                "!bank",
+                "!bank [sub]!balance, !money[/sub]",
                 "!titles",
                 "!settitle",
                 "!category [sub]!list[/sub] ",
@@ -75,7 +75,7 @@ namespace FChatDicebot.BotCommands
                 "!joinchateau",
                 "!modmessage",
                 "!setmark",
-                "!help",
+                "!help [sub]!commands[/sub]",
                 "!botinfo",
                 "!uptime"
             };
@@ -91,7 +91,7 @@ namespace FChatDicebot.BotCommands
 
             List<string> roomCommands = new List<string>()
             {
-                "!consent [sub]!c[/sub] ",
+                "!consent [sub]!c, !accept[/sub] ",
                 "!pledge",
                 "!fulfill"
             };
@@ -100,14 +100,14 @@ namespace FChatDicebot.BotCommands
             {
                 "!kiss",
                 "!handhold",
-                "!cuddle",
+                "!cuddle [sub]!hug[/sub]",
                 "!spank",
                 "!bully"
             };
 
             List<string> involvedCommands = new List<string>()
             {
-                "!dressup",
+                "!dressup [sub]!dress[/sub]",
                 "!feed",
                 "!golden",
                 "!pay",
@@ -123,7 +123,7 @@ namespace FChatDicebot.BotCommands
                 "!objectify",
                 "!consume",
                 "!mark",
-                "!employ",
+                "!employ [sub]!hire[/sub]",
                 "!bond",
                 "!entitle",
                 "!corrupt",
@@ -143,7 +143,7 @@ namespace FChatDicebot.BotCommands
                 "!odorize",
                 "!break"
             };
-            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]May 27th 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
+            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 21st 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
                     "[u]Does not require channel[/u]\n" +
                     Utils.sortedListDisplayText(generalCommands) + "\n" +
                     "[i]Recovery Commands:[/i] " + Utils.sortedListDisplayText(recoveryCommands) + "\n\n" +

--- a/FChatDicebot/BotCommands/ChateauHire.cs
+++ b/FChatDicebot/BotCommands/ChateauHire.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauHire : ChatBotCommand
+    {
+        public ChateauHire()
+        {
+            Name = "hire";
+            Aliases = new string[] { };
+            Category = "Commitment Interaction";
+            ShortDescription = "Alias for !employ";
+            LongDescription = "Alternative wording for the !employ command. See !help employ for full details.";
+            Usage = "!hire [noparse][user]NameInUserTag[/user][/noparse] {job}\n(use your own username to self-employ)";
+            RelatedCommands = new string[] { "employ", "work", "bank" };
+            CooldownDuration = "1 Day";
+            CooldownAppliesTo = "recipient";
+            IdentifierCategory = "job";
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauEmploy employ = new ChateauEmploy();
+            employ.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHug.cs
+++ b/FChatDicebot/BotCommands/ChateauHug.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauHug : ChatBotCommand
+    {
+        public ChateauHug()
+        {
+            Name = "hug";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Alias for !cuddle";
+            LongDescription = "Alternative wording for the !cuddle command. See !help cuddle for full details.";
+            Usage = "!hug [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "cuddle", "kiss", "handhold" };
+            CooldownDuration = "30 Minutes";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauCuddle cuddle = new ChateauCuddle();
+            cuddle.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauMoney.cs
+++ b/FChatDicebot/BotCommands/ChateauMoney.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauMoney : ChatBotCommand
+    {
+        public ChateauMoney()
+        {
+            Name = "money";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !bank";
+            LongDescription = "Alternative wording for the !bank command. See !help bank for full details.";
+            Usage = "!money\nor\n!money [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "bank", "work", "volunteer" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauBank bank = new ChateauBank();
+            bank.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauStats.cs
+++ b/FChatDicebot/BotCommands/ChateauStats.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauStats : ChatBotCommand
+    {
+        public ChateauStats()
+        {
+            Name = "stats";
+            Aliases = new string[] { };
+            Category = "Information";
+            ShortDescription = "Alias for !statistics";
+            LongDescription = "Alternative wording for the !statistics command. See !help statistics for full details.";
+            Usage = "!stats";
+            RelatedCommands = new string[] { "statistics", "populations", "economics" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauStatistics statistics = new ChateauStatistics();
+            statistics.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds eight natural-language alias commands so residents can use the wording that first comes to mind:

| `!alias` | routes to |
|---|---|
| `!hug` | `!cuddle` |
| `!hire` | `!employ` |
| `!stats` | `!statistics` |
| `!balance`, `!money` | `!bank` |
| `!commands` | `!help` |
| `!dress` | `!dressup` |
| `!bio` | `!dossier` |

## Why

Per an alias audit against the owner's philosophy: single-letter aliases stay reserved for the high-frequency system commands (`!c`/`!w`/`!v`), while full-word aliases should catch the obvious "it should really be named what I typed" cases — not a full spread on every command. The set above was selected and approved on that basis.

Two cleanups came along for the ride:
- **`!stats` was a dead alias.** `!statistics` declared `Aliases = { "stats" }`, but command dispatch matches on `Name` only (the `Aliases` array is display-only), and no `stats` command class existed — so `!stats` silently did nothing. It now routes.
- **`!accept` was undocumented.** It already worked (`Accept.cs` delegates to `!consent`) but never appeared in `!help`. It's now listed.

## How

Dispatch is `Name`-only, so each alias is its **own delegating `ChatBotCommand`** whose `Run` instantiates the canonical command and calls its `.Run(...)`. Each alias class mirrors the target's gating metadata (`RequireChannel`, cooldown, identifier category) — important because the delegating `Run` bypasses the dispatcher's channel gate, so e.g. `!hug` carries `RequireChannel = true` like `!cuddle`. This follows the existing `ChateauV`/`ChateauProfile` pattern.

Help integration (all three touchpoints):
1. Delegating class (routing).
2. Alias added to the canonical command's `Aliases` array — drives `!help <cmd>` subtext and `!help <alias>` lookup.
3. Inline `[sub]!alias[/sub]` entry in the broad `!help` command list (matching the existing `!dossier [sub]!profile[/sub]` convention). The list's "as of" date was bumped to June 21st 2026.

## Reviewer notes

- New user-facing strings are boilerplate mirroring the existing `ChateauProfile` alias ("Alias for !X" / "Alternative wording for the !X command. See !help X for full details.").
- Full rebuild passes with 0 errors (pre-existing warnings unchanged).
- Out of scope, but noticed: two classes both declare `Name = "work"` (legacy `Work.cs` and `ChateauWork.cs`), a pre-existing duplicate-Name collision resolved by `FirstOrDefault` load order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)