### PR TITLE
Add boobhat, lick, and lapsit casual interactions

### DIFF
--- a/FChatDicebot.Tests/Unit/Boobhatprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Boobhatprocessortests.cs
@@ -1,0 +1,138 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Casual;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for BoobhatProcessor (directional casual: boobhatgive / boobhattake).
+    /// </summary>
+    [Collection("Database")]
+    public class BoobhatProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly BoobhatProcessor _processor;
+
+        public BoobhatProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new BoobhatProcessor(_database);
+        }
+
+        [Fact]
+        public void InteractionType_ReturnsBoobhat()
+        {
+            Assert.Equal("boobhat", _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsCasual()
+        {
+            Assert.Equal("casual", _processor.InvestmentLevel);
+        }
+
+        [Fact]
+        public void ProcessInteraction_ValidBoobhat_ReturnsBoobhatString()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            string result = _processor.ProcessInteraction(pendingCommand);
+
+            Assert.Equal("boobhat", result);
+        }
+
+        [Fact]
+        public void ProcessInteraction_FirstBoobhat_IncrementsDifferentCounts()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            // Initiator provides the hat (boobhatgive); recipient wears it (boobhattake).
+            Assert.Equal(1, alice.counts["boobhatgive"]);
+            Assert.Equal(1, bob.counts["boobhattake"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var interactions = _database.GetInteractionsByInitiator("Alice");
+            Assert.Contains(interactions, i => i.type == "boobhat");
+        }
+
+        [Fact]
+        public void ProcessInteraction_DeletesPendingCommand()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var pendingAfter = _database.GetPendingCommandAwaitingConsent("Bob");
+            Assert.Null(pendingAfter);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothNames()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Adventurer").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").BuildAndSave(_database);
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "");
+
+            Assert.Contains("Alice the Adventurer", message);
+            Assert.Contains("Bob the Bold", message);
+        }
+
+        private static PendingCommand MakePending(string initiator, string recipient)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "boobhat",
+                    identifier = "",
+                    investmentLevel = "casual"
+                },
+                awaitingConsentFrom = recipient
+            };
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Lapsitprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Lapsitprocessortests.cs
@@ -1,0 +1,164 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Casual;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for LapsitProcessor — the shared processor behind !lap and !sit. The
+    /// typed verb (carried on Interaction.type / identifier) decides which side the
+    /// initiator plays: !lap → initiator is the lap (lapsittake); !sit → initiator is the
+    /// sitter (lapsitgive).
+    /// </summary>
+    [Collection("Database")]
+    public class LapsitProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly LapsitProcessor _processor;
+
+        public LapsitProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new LapsitProcessor(_database);
+        }
+
+        [Fact]
+        public void InteractionType_ReturnsLap()
+        {
+            Assert.Equal("lap", _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsCasual()
+        {
+            Assert.Equal("casual", _processor.InvestmentLevel);
+        }
+
+        [Theory]
+        [InlineData("sit", true)]
+        [InlineData("SIT", true)]
+        [InlineData("lap", false)]
+        [InlineData("anything-else", false)]
+        public void InitiatorIsSitter_DependsOnVerb(string verb, bool expected)
+        {
+            Assert.Equal(expected, LapsitProcessor.InitiatorIsSitter(verb));
+        }
+
+        [Fact]
+        public void ProcessInteraction_Lap_InitiatorIsTheLap()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob", "lap");
+            _database.AddPendingCommand(pendingCommand);
+
+            string result = _processor.ProcessInteraction(pendingCommand);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            // !lap: initiator is the lap (lapsittake), recipient sits (lapsitgive).
+            Assert.Equal("lap", result);
+            Assert.Equal(1, alice.counts["lapsittake"]);
+            Assert.Equal(1, bob.counts["lapsitgive"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_Sit_InitiatorIsTheSitter()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob", "sit");
+            _database.AddPendingCommand(pendingCommand);
+
+            string result = _processor.ProcessInteraction(pendingCommand);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            // !sit: initiator sits (lapsitgive), recipient is the lap (lapsittake).
+            Assert.Equal("sit", result);
+            Assert.Equal(1, alice.counts["lapsitgive"]);
+            Assert.Equal(1, bob.counts["lapsittake"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory_AndDeletesPending()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob", "lap");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var interactions = _database.GetInteractionsByInitiator("Alice");
+            Assert.Contains(interactions, i => i.type == "lap");
+            Assert.Null(_database.GetPendingCommandAwaitingConsent("Bob"));
+        }
+
+        [Fact]
+        public void GetCompletionMessage_Lap_UsesLapOpener()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            string message = _processor.GetCompletionMessage(initiator, recipient, "lap");
+
+            Assert.Contains("Alice", message);
+            Assert.Contains("Bob", message);
+            Assert.Contains("onto their lap", message);
+            Assert.DoesNotContain("{lapsitgiver}", message);
+        }
+
+        [Fact]
+        public void GetCompletionMessage_Sit_UsesSitOpener()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            // Run several times: the sit opener has two variants and the descriptor pool is
+            // random, so exercise both and confirm no raw token survives.
+            for (int i = 0; i < 50; i++)
+            {
+                string message = _processor.GetCompletionMessage(initiator, recipient, "sit");
+                Assert.Contains("Alice", message);
+                Assert.Contains("Bob", message);
+                Assert.Contains("lap", message);
+                Assert.DoesNotContain("{lapsitgiver}", message);
+            }
+        }
+
+        private static PendingCommand MakePending(string initiator, string recipient, string verb)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = verb,
+                    identifier = verb,
+                    investmentLevel = "casual"
+                },
+                awaitingConsentFrom = recipient
+            };
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Lickprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Lickprocessortests.cs
@@ -1,0 +1,128 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Casual;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for LickProcessor (directional casual: lickgive / licktake).
+    /// </summary>
+    [Collection("Database")]
+    public class LickProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly LickProcessor _processor;
+
+        public LickProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new LickProcessor(_database);
+        }
+
+        [Fact]
+        public void InteractionType_ReturnsLick()
+        {
+            Assert.Equal("lick", _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsCasual()
+        {
+            Assert.Equal("casual", _processor.InvestmentLevel);
+        }
+
+        [Fact]
+        public void ProcessInteraction_ValidLick_ReturnsLickString()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            string result = _processor.ProcessInteraction(pendingCommand);
+
+            Assert.Equal("lick", result);
+        }
+
+        [Fact]
+        public void ProcessInteraction_FirstLick_IncrementsDifferentCounts()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            // Initiator is the licker (lickgive); recipient is the licked (licktake).
+            Assert.Equal(1, alice.counts["lickgive"]);
+            Assert.Equal(1, bob.counts["licktake"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var interactions = _database.GetInteractionsByInitiator("Alice");
+            Assert.Contains(interactions, i => i.type == "lick");
+        }
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothNames_AndResolvesTokens()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Adventurer").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").BuildAndSave(_database);
+
+            // Run enough times to exercise the token-bearing descriptors and confirm no
+            // raw {token} placeholder ever survives into the rendered message.
+            for (int i = 0; i < 50; i++)
+            {
+                string message = _processor.GetCompletionMessage(initiator, recipient, "");
+                Assert.Contains("Alice the Adventurer", message);
+                Assert.DoesNotContain("{lickgiver}", message);
+                Assert.DoesNotContain("{licktaker}", message);
+            }
+        }
+
+        private static PendingCommand MakePending(string initiator, string recipient)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "lick",
+                    identifier = "",
+                    investmentLevel = "casual"
+                },
+                awaitingConsentFrom = recipient
+            };
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauBoobhat.cs
+++ b/FChatDicebot/BotCommands/ChateauBoobhat.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauBoobhat : ChatBotCommand
+    {
+        public ChateauBoobhat()
+        {
+            Name = "boobhat";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Wear another resident as... well, wear them";
+            LongDescription = "Rest your chest atop another resident's head like a hat, as soon as they !consent. A Chateau classic for the well-endowed and the easily-shaded alike.";
+            Usage = "!boobhat [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "lick", "cuddle", "consent", "dossier" };
+            CooldownDuration = "30 minutes (but can still interact without incrementing count)";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+            }
+            else
+            {
+                string message = initiatorProfile.displayName + " wants to rest their chest atop " + recipientProfile.displayName + ". Do you !consent to the temporary headwear?";
+
+                Interaction boobhat = new Interaction();
+                boobhat.initiator = characterName;
+                boobhat.recipient = recipient;
+                boobhat.type = "boobhat";
+                boobhat.investmentLevel = "casual";
+
+                PendingCommand pendingBoobhat = new PendingCommand();
+                pendingBoobhat.pendingInteraction = boobhat;
+                pendingBoobhat.awaitingConsentFrom = recipient;
+
+                MonDB.addPendingCommand(pendingBoobhat);
+
+                bot.SendMessageInChannel(message, channel);
+            }
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -214,6 +214,12 @@ namespace FChatDicebot.BotCommands
                 case "handhold": return ("handhold", "handhold");
                 case "spank": return ("spankgive", "spanktake");
                 case "bully": return ("bullygive", "bullytake");
+                case "boobhat": return ("boobhatgive", "boobhattake");
+                case "lick": return ("lickgive", "licktake");
+                // lapsit: !lap → initiator is the lap (lapsittake), recipient sits (lapsitgive)
+                case "lap": return ("lapsittake", "lapsitgive");
+                // !sit → initiator sits (lapsitgive), recipient is the lap (lapsittake)
+                case "sit": return ("lapsitgive", "lapsittake");
                 case "feed": return ("feedgive", "feedtake");
                 case "golden": return ("goldengive", "goldentake");
                 case "dressup": return ("dressupgive", "dressuptake");

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -33,6 +33,12 @@ namespace FChatDicebot.BotCommands
             { "spankgive", "Spanks Delivered" },
             { "bullygive", "Big Bullies" },
             { "bullytake", "Boolied" },
+            { "boobhatgive", "Boobhats Given" },
+            { "boobhattake", "Boobhats Worn" },
+            { "lickgive", "Licks Given" },
+            { "licktake", "Licks Received" },
+            { "lapsitgive", "Laps Sat On" },
+            { "lapsittake", "Sitters Supported" },
             { "climaxtake", "Orgasms" },
             { "breaktake", "Bodyparts Exhausted" },
             { "cursetake", "Curses Endured" },
@@ -59,7 +65,13 @@ namespace FChatDicebot.BotCommands
             { "spanktake", "Spankbaiting" },
             { "spankgive", "Spanking" },
             { "bullygive", "Bullying" },
-            { "bullytake", "Bullybaiting" }
+            { "bullytake", "Bullybaiting" },
+            { "boobhatgive", "Boobhat" },
+            { "boobhattake", "Boob Wearing" },
+            { "lickgive", "Licking" },
+            { "licktake", "Living Lollipop" },
+            { "lapsitgive", "Lap Sitting" },
+            { "lapsittake", "Lap Providing" }
         };
 
         private static readonly Dictionary<string, string> InvolvedSpecialistText = new Dictionary<string, string>

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -102,7 +102,11 @@ namespace FChatDicebot.BotCommands
                 "!handhold",
                 "!cuddle",
                 "!spank",
-                "!bully"
+                "!bully",
+                "!boobhat",
+                "!lick",
+                "!lap",
+                "!sit"
             };
 
             List<string> involvedCommands = new List<string>()

--- a/FChatDicebot/BotCommands/ChateauLap.cs
+++ b/FChatDicebot/BotCommands/ChateauLap.cs
@@ -1,0 +1,36 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors.Casual;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!lap</c> — the initiator is the lap (the one being sat on); the recipient takes a
+    /// seat. Pairs with <c>!sit</c> (initiator is the sitter): both share
+    /// <see cref="LapsitProcessor"/>. Single-target form; the lap-stack (3+) is future work.
+    /// </summary>
+    public class ChateauLap : ChatBotCommand
+    {
+        public ChateauLap()
+        {
+            Name = "lap";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Offer your lap to another resident";
+            LongDescription = "Pull another resident onto your lap once they !consent. You're the foundation — they get the comfy seat. Pairs with !sit, where you're the one taking a seat instead.";
+            Usage = "!lap [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "sit", "cuddle", "consent", "dossier" };
+            CooldownDuration = "30 minutes (but can still interact without incrementing count)";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            LapsitCommandSupport.Run(bot, commandController, rawTerms, characterName, channel, LapsitProcessor.LapType);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauLick.cs
+++ b/FChatDicebot/BotCommands/ChateauLick.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauLick : ChatBotCommand
+    {
+        public ChateauLick()
+        {
+            Name = "lick";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Give another resident a lick";
+            LongDescription = "Give another character a lick once they !consent. Grooming, tasting, or just being a menace — it's all fair game in the Chateau.";
+            Usage = "!lick [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "boobhat", "kiss", "consent", "dossier" };
+            CooldownDuration = "30 minutes (but can still interact without incrementing count)";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+            }
+            else
+            {
+                string message = initiatorProfile.displayName + " wants to give " + recipientProfile.displayName + " a lick. Do you !consent to being lapped at?";
+
+                Interaction lick = new Interaction();
+                lick.initiator = characterName;
+                lick.recipient = recipient;
+                lick.type = "lick";
+                lick.investmentLevel = "casual";
+
+                PendingCommand pendingLick = new PendingCommand();
+                pendingLick.pendingInteraction = lick;
+                pendingLick.awaitingConsentFrom = recipient;
+
+                MonDB.addPendingCommand(pendingLick);
+
+                bot.SendMessageInChannel(message, channel);
+            }
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauSit.cs
+++ b/FChatDicebot/BotCommands/ChateauSit.cs
@@ -1,0 +1,36 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors.Casual;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!sit</c> — the initiator is the sitter; the recipient is the lap (the one being sat
+    /// on). Pairs with <c>!lap</c> (initiator is the lap): both share
+    /// <see cref="LapsitProcessor"/>. Single-target form; the lap-stack (3+) is future work.
+    /// </summary>
+    public class ChateauSit : ChatBotCommand
+    {
+        public ChateauSit()
+        {
+            Name = "sit";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Take a seat on another resident's lap";
+            LongDescription = "Sit on another resident's lap once they !consent. You get the comfy seat — they're the foundation. Pairs with !lap, where you're the one offering your lap instead.";
+            Usage = "!sit [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "lap", "cuddle", "consent", "dossier" };
+            CooldownDuration = "30 minutes (but can still interact without incrementing count)";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            LapsitCommandSupport.Run(bot, commandController, rawTerms, characterName, channel, LapsitProcessor.SitType);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauSystemTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauSystemTitles.cs
@@ -109,7 +109,49 @@ namespace FChatDicebot
                 ("bullytake", 50, "Victim"),
                 ("bullytake", 100, "Asking For It"),
                 ("bullytake", 500, "Bully Bait"),
-                
+
+                // Lapsit - giving (the sitter, on top)
+                ("lapsitgive", 1, "Will Sit On You"),
+                ("lapsitgive", 10, "Supported"),
+                ("lapsitgive", 50, "S is for Sitter"),
+                ("lapsitgive", 100, "Lap Pet"),
+                ("lapsitgive", 500, "Disciple of Rin"),
+
+                // Lapsit - taking (the lap, on bottom)
+                ("lapsittake", 1, "Lap"),
+                ("lapsittake", 10, "Supportive"),
+                ("lapsittake", 50, "Chair"),
+                ("lapsittake", 100, "Comfy"),
+                ("lapsittake", 500, "Throne"),
+
+                // Boobhat - giving (the chest providing the hat)
+                ("boobhatgive", 1, "Boo(b)"),
+                ("boobhatgive", 10, "Good Hat"),
+                ("boobhatgive", 50, "Umbrella"),
+                ("boobhatgive", 100, "Speaks With Their Chest"),
+                ("boobhatgive", 500, "Heavy is the Crown"),
+
+                // Boobhat - taking (the head wearing the hat)
+                ("boobhattake", 1, "Guess Who?"),
+                ("boobhattake", 10, "Nice Hat"),
+                ("boobhattake", 50, "Boobrest"),
+                ("boobhattake", 100, "Didn't Skip Neck Day"),
+                ("boobhattake", 500, "Heavy is the Head"),
+
+                // Lick - giving (the licker)
+                ("lickgive", 1, ":P"),
+                ("lickgive", 10, "Mlem"),
+                ("lickgive", 50, "Talented Tongue"),
+                ("lickgive", 100, "Licksalot"),
+                ("lickgive", 500, "Got to the Center of the Tootsie Pop"),
+
+                // Lick - taking (the licked)
+                ("licktake", 1, "Licked"),
+                ("licktake", 10, "Tasty"),
+                ("licktake", 50, "Salt Lick"),
+                ("licktake", 100, "Spit Shined"),
+                ("licktake", 500, "Tootsie Pop"),
+
                 // INVOLVED INTERACTION titles
 
                 // Milking - giving

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -201,6 +201,10 @@
     <Compile Include="BotCommands\ChateauCuddle.cs" />
     <Compile Include="BotCommands\ChateauKiss.cs" />
     <Compile Include="BotCommands\ChateauBully.cs" />
+    <Compile Include="BotCommands\ChateauBoobhat.cs" />
+    <Compile Include="BotCommands\ChateauLick.cs" />
+    <Compile Include="BotCommands\ChateauLap.cs" />
+    <Compile Include="BotCommands\ChateauSit.cs" />
     <Compile Include="BotCommands\ChateauAbandonPledge.cs" />
     <Compile Include="BotCommands\ChateauFulfill.cs" />
     <Compile Include="BotCommands\ChateauPledge.cs" />
@@ -353,10 +357,14 @@
     <Compile Include="Database\Chateaudatabase.cs" />
     <Compile Include="Database\Ichateaudatabase.cs" />
     <Compile Include="InteractionCountMigration.cs" />
+    <Compile Include="InteractionProcessors\Casual\BoobhatProcessor.cs" />
     <Compile Include="InteractionProcessors\Casual\BullyProcessor.cs" />
     <Compile Include="InteractionProcessors\Casual\CuddleProcessor.cs" />
     <Compile Include="InteractionProcessors\Casual\HandholdProcessor.cs" />
     <Compile Include="InteractionProcessors\Casual\KissProcessor.cs" />
+    <Compile Include="InteractionProcessors\Casual\LapsitCommandSupport.cs" />
+    <Compile Include="InteractionProcessors\Casual\LapsitProcessor.cs" />
+    <Compile Include="InteractionProcessors\Casual\LickProcessor.cs" />
     <Compile Include="InteractionProcessors\Casual\SpankProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\EntitleProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\MarkProcessor.cs" />

--- a/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
@@ -1,0 +1,74 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors.Casual
+{
+    /// <summary>
+    /// Processor for the boobhat interaction: the initiator rests their chest on the
+    /// recipient's head. Directional casual — <c>boobhatgive</c> goes to the one providing
+    /// the hat (the chest), <c>boobhattake</c> to the one wearing it. Modeled on
+    /// <see cref="SpankProcessor"/> / <see cref="BullyProcessor"/>.
+    /// </summary>
+    public class BoobhatProcessor : InteractionProcessorBase
+    {
+        public override string InteractionType => "boobhat";
+        public override string InvestmentLevel => "casual";
+
+        private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Constructor for dependency injection (for testing)
+        /// </summary>
+        public BoobhatProcessor(IChateauDatabase database) : base(database)
+        {
+        }
+
+        /// <summary>
+        /// Legacy constructor for backward compatibility
+        /// </summary>
+        public BoobhatProcessor() : base()
+        {
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+
+            // Save the interaction to history
+            Database.AddInteraction(command.pendingInteraction);
+
+            // Increment counts with rate limiting (give/take variants).
+            // Initiator provides the hat (boobhatgive); recipient wears it (boobhattake).
+            _lastRateLimitMessage = IncrementDifferentCountsWithRateLimit(
+                initiator, recipient, "boobhatgive", "boobhattake", RateLimit);
+
+            // Remove pending interaction
+            Database.DeletePendingCommand(command.Id);
+
+            return "boobhat";
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            // Owner-provided descriptors.
+            var boobhatDescriptors = new List<string>
+            {
+                "Nice hat!",
+                "How heavy are they?",
+                "Can you still see?",
+                "Soft, warm...",
+                "How forward!"
+            };
+
+            return $"{initiatorProfile.displayName} lets the full weight of their chest fall onto {recipientProfile.displayName}. {GetRandomDescriptor(boobhatDescriptors)}";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            return initiatorProfile.displayName + " wants to rest their chest atop " + recipientProfile.displayName + ". Do you !consent to the temporary headwear?";
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
@@ -1,0 +1,54 @@
+using FChatDicebot.Model;
+
+namespace FChatDicebot.InteractionProcessors.Casual
+{
+    /// <summary>
+    /// Shared command-side wiring for <c>!lap</c> and <c>!sit</c>. Both parse the same way
+    /// (a single <c>[user]</c> tag) and differ only in the typed verb, so the parse,
+    /// not-found handling, pending-command creation, and consent message all live here.
+    ///
+    /// Lives outside <c>FChatDicebot.BotCommands</c> so the reflection-based loader in
+    /// <see cref="BotCommandController"/> doesn't try to <c>Activator.CreateInstance</c> it
+    /// as a chat command. Mirrors <see cref="Commitment.CorruptionCommandSupport"/>.
+    /// </summary>
+    public static class LapsitCommandSupport
+    {
+        public static void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string characterName, string channel, string typedVerb)
+        {
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+                return;
+            }
+
+            var interaction = new Interaction
+            {
+                initiator = characterName,
+                recipient = recipient,
+                // Type carries the typed verb so ProcessInteraction can credit give/take to
+                // the right side. The identifier mirrors it so the completion message and
+                // consent warning (which only receive the identifier) can render the right
+                // wording.
+                type = typedVerb,
+                identifier = typedVerb,
+                investmentLevel = "casual"
+            };
+
+            var pending = new PendingCommand
+            {
+                pendingInteraction = interaction,
+                awaitingConsentFrom = recipient
+            };
+            MonDB.addPendingCommand(pending);
+
+            var processor = InteractionProcessorRegistry.GetProcessor(typedVerb);
+            string consentMessage = processor != null
+                ? processor.GetConsentWarning(initiatorProfile, recipientProfile, interaction.identifier)
+                : (initiatorProfile.displayName + " wants to share a lap with " + recipientProfile.displayName + ". Do you !consent?");
+            bot.SendMessageInChannel(consentMessage, channel);
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -1,0 +1,144 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors.Casual
+{
+    /// <summary>
+    /// Backs both <c>!lap</c> (initiator is the lap — the one being sat on) and <c>!sit</c>
+    /// (initiator is the sitter, the recipient is the lap). The same instance is registered
+    /// under both type keys in <see cref="InteractionProcessorRegistry"/>, the way
+    /// <c>!corrupt</c>/<c>!purify</c> share one processor.
+    ///
+    /// This is the single-target (1:1) form of lapsit. The full multi-person "lap stack"
+    /// (3+ participants, per-position counts) needs the group-interaction infrastructure
+    /// and is intentionally out of scope here.
+    ///
+    /// Count semantics follow the project-wide give/take convention: the <b>sitter</b>
+    /// (topmost) gets <c>lapsitgive</c> ("they sat on someone"), the <b>lap</b> (bottom)
+    /// gets <c>lapsittake</c> ("they were sat on"). Which side the initiator plays depends
+    /// on the typed verb, carried on <see cref="Interaction.type"/> and mirrored onto the
+    /// <see cref="Interaction.identifier"/> so <see cref="GetCompletionMessage"/> (which only
+    /// receives the identifier) can render the right opener.
+    /// </summary>
+    public class LapsitProcessor : InteractionProcessorBase
+    {
+        public const string LapType = "lap";
+        public const string SitType = "sit";
+
+        public override string InteractionType => LapType;
+        public override string InvestmentLevel => "casual";
+
+        private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Constructor for dependency injection (for testing)
+        /// </summary>
+        public LapsitProcessor(IChateauDatabase database) : base(database)
+        {
+        }
+
+        /// <summary>
+        /// Legacy constructor for backward compatibility
+        /// </summary>
+        public LapsitProcessor() : base()
+        {
+        }
+
+        public override string GetInteractionVerb(VerbTense tense)
+        {
+            switch (tense)
+            {
+                case VerbTense.Past:    return "sat on";
+                case VerbTense.Present: return "sits on";
+                case VerbTense.Future:  return "will sit on";
+                default:                return "lapsit";
+            }
+        }
+
+        /// <summary>
+        /// True when the typed verb makes the initiator the sitter (top), i.e. <c>!sit</c>.
+        /// Defaults to false (<c>!lap</c>: initiator is the lap) for any unrecognized verb.
+        /// </summary>
+        public static bool InitiatorIsSitter(string verb)
+        {
+            return string.Equals(verb, SitType, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+            string verb = command.pendingInteraction.type;
+
+            // Save the interaction to history
+            Database.AddInteraction(command.pendingInteraction);
+
+            // Sitter (top) → lapsitgive; lap (bottom) → lapsittake. The typed verb decides
+            // which side the initiator is on.
+            string initiatorLabel = InitiatorIsSitter(verb) ? "lapsitgive" : "lapsittake";
+            string recipientLabel = InitiatorIsSitter(verb) ? "lapsittake" : "lapsitgive";
+
+            _lastRateLimitMessage = IncrementDifferentCountsWithRateLimit(
+                initiator, recipient, initiatorLabel, recipientLabel, RateLimit);
+
+            // Remove pending interaction
+            Database.DeletePendingCommand(command.Id);
+
+            return verb;
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            bool initiatorIsSitter = InitiatorIsSitter(identifier);
+
+            // {lapsitgiver} = the topmost sitter (whoever gets lapsitgive): the initiator on
+            // !sit, the recipient on !lap.
+            string lapsitGiver = initiatorIsSitter
+                ? initiatorProfile.displayName
+                : recipientProfile.displayName;
+
+            // Owner-provided descriptors (shared by !lap and !sit).
+            var lapsitDescriptors = new List<string>
+            {
+                "Does it count as a stack if it's only two?",
+                "Lap! Lap! Lap!",
+                "We have normal chairs too, in case you didn't know...",
+                "That means {lapsitgiver} is on top, literally.",
+                "Always nice to have some support."
+            };
+
+            string descriptor = GetRandomDescriptor(lapsitDescriptors)
+                .Replace("{lapsitgiver}", lapsitGiver);
+
+            string opener;
+            if (initiatorIsSitter)
+            {
+                // !sit: the initiator sits on the recipient (the bottom/lap).
+                var sitOpeners = new List<string>
+                {
+                    $"{initiatorProfile.displayName} uses {recipientProfile.displayName} as a comfy lap to sit on.",
+                    $"{initiatorProfile.displayName} pulls themselves onto {recipientProfile.displayName}'s lap."
+                };
+                opener = GetRandomDescriptor(sitOpeners);
+            }
+            else
+            {
+                // !lap: the initiator is the lap and pulls the recipient onto it.
+                opener = $"{initiatorProfile.displayName} pulls {recipientProfile.displayName} onto their lap.";
+            }
+
+            return $"{opener} {descriptor}";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            if (InitiatorIsSitter(identifier))
+            {
+                return initiatorProfile.displayName + " wants to sit on " + recipientProfile.displayName + "'s lap. Do you !consent to being their seat?";
+            }
+            return initiatorProfile.displayName + " wants to pull " + recipientProfile.displayName + " onto their lap. Do you !consent to taking a seat?";
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
@@ -1,0 +1,79 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors.Casual
+{
+    /// <summary>
+    /// Processor for the lick interaction: the initiator licks the recipient. Directional
+    /// casual — <c>lickgive</c> goes to the licker, <c>licktake</c> to the licked. Modeled
+    /// on <see cref="SpankProcessor"/> / <see cref="BullyProcessor"/>.
+    /// </summary>
+    public class LickProcessor : InteractionProcessorBase
+    {
+        public override string InteractionType => "lick";
+        public override string InvestmentLevel => "casual";
+
+        private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Constructor for dependency injection (for testing)
+        /// </summary>
+        public LickProcessor(IChateauDatabase database) : base(database)
+        {
+        }
+
+        /// <summary>
+        /// Legacy constructor for backward compatibility
+        /// </summary>
+        public LickProcessor() : base()
+        {
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+
+            // Save the interaction to history
+            Database.AddInteraction(command.pendingInteraction);
+
+            // Increment counts with rate limiting (give/take variants).
+            // Initiator is the licker (lickgive); recipient is the licked (licktake).
+            _lastRateLimitMessage = IncrementDifferentCountsWithRateLimit(
+                initiator, recipient, "lickgive", "licktake", RateLimit);
+
+            // Remove pending interaction
+            Database.DeletePendingCommand(command.Id);
+
+            return "lick";
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            // Owner-provided descriptors. {lickgiver} = the licker (initiator); {licktaker} =
+            // the licked (recipient). Tokens are resolved against display names here.
+            var lickDescriptors = new List<string>
+            {
+                "How many more licks to get to the center?",
+                "I bet they taste good.",
+                "In cat culture, that means {lickgiver} is in charge.",
+                "In bunny culture, that means {licktaker} is in charge.",
+                "Is this what it means to be groomed?",
+                "Mlem!"
+            };
+
+            string descriptor = GetRandomDescriptor(lickDescriptors)
+                .Replace("{lickgiver}", initiatorProfile.displayName)
+                .Replace("{licktaker}", recipientProfile.displayName);
+
+            return $"{initiatorProfile.displayName} gives {recipientProfile.displayName} a slow lick. {descriptor}";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            return initiatorProfile.displayName + " wants to give " + recipientProfile.displayName + " a lick. Do you !consent to being lapped at?";
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
@@ -31,6 +31,13 @@ namespace FChatDicebot.InteractionProcessors
             RegisterProcessor(new HandholdProcessor());
             RegisterProcessor(new SpankProcessor());
             RegisterProcessor(new BullyProcessor());
+            RegisterProcessor(new BoobhatProcessor());
+            RegisterProcessor(new LickProcessor());
+            // LapsitProcessor backs both !lap and !sit — same instance under two type keys
+            // so each verb routes to the shared give/take logic.
+            var lapsit = new LapsitProcessor();
+            RegisterProcessor(lapsit);
+            RegisterProcessor(LapsitProcessor.SitType, lapsit);
 
             //commitment interactions
             RegisterProcessor(new MarkProcessor());


### PR DESCRIPTION
## What

Adds three new casual interactions to the Chateau Contract framework:

- **`!boobhat <user>`** — rest your chest atop another resident (`boobhatgive`/`boobhattake`)
- **`!lick <user>`** — give another resident a lick (`lickgive`/`licktake`)
- **`!lap <user>` / `!sit <user>`** — a shared lap-sit; `!lap` makes the initiator the lap, `!sit` makes them the sitter (`lapsitgive`/`lapsittake`)

All three are directional casuals modeled on the existing `!spank`/`!bully` give/take pattern. `!lap` and `!sit` share a single `LapsitProcessor` (the same one-processor-two-verbs approach as `!corrupt`/`!purify`), with the typed verb carried on `Interaction.type` and mirrored onto `identifier` so the completion/consent messages can render the correct direction.

## Scope

This implements **only the B7 "new casuals" portion** of the bundled `Group-Interactions-And-Pending-Lifecycle` spec, as **single-target (1:1)** interactions. The owner explicitly chose this scope. Intentionally **deferred**:

- **B4** — the multi-person / lap-stack (3+) group system (new `PendingCommand` schema, group-aware consent resolution)
- **B5** — `!refuse` / `!withdraw` lifecycle commands

`LapsitProcessor` is written so the 3+ stack can slot in later without rework.

## Wiring touchpoints

- `InteractionProcessorRegistry` — registers the 3 processors (lapsit under both `lap` and `sit` keys)
- `ChateauConsent.GetCountKeys` — count-key mappings for the rate-limit clerk-note path
- `ChateauDossier` — chip labels + casual specialist verbs for all 6 new count keys
- `ChateauSystemTitles` — 30 new title-ladder rows (owner-provided, thresholds 1/10/50/100/500)
- `ChateauHelp` — new commands added to the casual list
- `FChatDicebot.csproj` — explicit `<Compile Include>` entries (main project is old-style, not SDK-style)

## User-facing text

All consent prompts, completion openers, dossier labels, and specialist verbs were reviewed and approved by the owner. Descriptors and title ladders are spec-verbatim.

## Tests

24 new processor tests (`Boobhat`/`Lick`/`Lapsit`). Full suite green: **1218 passed, 0 failed**. Build clean (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)