### PR TITLE
Add !feedback / !suggestion + admin !feedbacklist (B9)

### DIFF
--- a/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
+++ b/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
@@ -44,6 +44,7 @@ namespace FChatDicebot.Tests.Fixtures
             Database.ClearCollection("ModMessages");
             Database.ClearCollection("Pledges");
             Database.ClearCollection("MonsterStats");
+            Database.ClearCollection("Feedback");
         }
 
         /// <summary>

--- a/FChatDicebot.Tests/Unit/Chateaufeedbacklisttests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaufeedbacklisttests.cs
@@ -1,0 +1,235 @@
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for the !feedback / !feedbacklist feature: the pure ParseFeedback and
+    /// BuildFeedbackList helpers, plus the AddFeedback / GetRecentFeedback DB operations.
+    /// </summary>
+    [Collection("Database")]
+    public class ChateauFeedbackListTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public ChateauFeedbackListTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        public void Dispose()
+        {
+            _fixture.Reset();
+        }
+
+        #region ParseFeedback
+
+        [Fact]
+        public void ParseFeedback_NullOrEmpty_ReturnsGeneralAndEmptyText()
+        {
+            var fromNull = ChateauFeedback.ParseFeedback(null);
+            Assert.Equal("general", fromNull.category);
+            Assert.Equal("", fromNull.text);
+
+            var fromEmpty = ChateauFeedback.ParseFeedback(new string[] { });
+            Assert.Equal("general", fromEmpty.category);
+            Assert.Equal("", fromEmpty.text);
+        }
+
+        [Fact]
+        public void ParseFeedback_NoCategoryToken_DefaultsToGeneralAndKeepsAllText()
+        {
+            var result = ChateauFeedback.ParseFeedback(new[] { "please", "add", "dancing", "emotes" });
+
+            Assert.Equal("general", result.category);
+            Assert.Equal("please add dancing emotes", result.text);
+        }
+
+        [Fact]
+        public void ParseFeedback_LeadingCategoryToken_StrippedAndStored()
+        {
+            var result = ChateauFeedback.ParseFeedback(new[] { "bug", "the", "login", "broke" });
+
+            Assert.Equal("bug", result.category);
+            Assert.Equal("the login broke", result.text);
+        }
+
+        [Fact]
+        public void ParseFeedback_CategoryToken_IsCaseInsensitive_AndPreservesTextCase()
+        {
+            var result = ChateauFeedback.ParseFeedback(new[] { "IDEA", "Add", "a", "Dance", "Emote" });
+
+            Assert.Equal("idea", result.category);
+            Assert.Equal("Add a Dance Emote", result.text);
+        }
+
+        [Fact]
+        public void ParseFeedback_CategoryTokenWithNoText_LeavesTextEmpty()
+        {
+            // Run() treats empty text as a rejected submission, so "!feedback bug" is not accepted.
+            var result = ChateauFeedback.ParseFeedback(new[] { "bug" });
+
+            Assert.Equal("bug", result.category);
+            Assert.Equal("", result.text);
+        }
+
+        #endregion
+
+        #region BuildFeedbackList
+
+        [Fact]
+        public void BuildFeedbackList_NullOrEmpty_ReturnsEmptyState()
+        {
+            Assert.Equal(ChateauFeedbackList.EmptyStateMessage, ChateauFeedbackList.BuildFeedbackList(null, DateTime.UtcNow));
+            Assert.Equal(ChateauFeedbackList.EmptyStateMessage, ChateauFeedbackList.BuildFeedbackList(new List<FeedbackEntry>(), DateTime.UtcNow));
+        }
+
+        [Fact]
+        public void BuildFeedbackList_RendersNewestFirst_WithNameCategoryTextAndRelativeTime()
+        {
+            DateTime now = new DateTime(2026, 6, 22, 12, 0, 0, DateTimeKind.Utc);
+
+            var oldest = MakeEntry("Alice", "Alice the Adventurer", "idea", "oldest idea", now.AddHours(-3));
+            var middle = MakeEntry("Bob", "Bob the Bold", "bug", "middle bug", now.AddHours(-1));
+            var newest = MakeEntry("Cara", "Cara the Clever", "general", "newest note", now.AddMinutes(-5));
+
+            // Intentionally unordered input — the builder must sort newest-first itself.
+            string output = ChateauFeedbackList.BuildFeedbackList(new List<FeedbackEntry> { oldest, newest, middle }, now);
+
+            int iNewest = output.IndexOf("newest note", StringComparison.Ordinal);
+            int iMiddle = output.IndexOf("middle bug", StringComparison.Ordinal);
+            int iOldest = output.IndexOf("oldest idea", StringComparison.Ordinal);
+
+            Assert.True(iNewest >= 0 && iMiddle >= 0 && iOldest >= 0);
+            Assert.True(iNewest < iMiddle, "newest should render before middle");
+            Assert.True(iMiddle < iOldest, "middle should render before oldest");
+
+            // Name, category and relative time are all surfaced.
+            Assert.Contains("Cara the Clever", output);
+            Assert.Contains("general", output);
+            Assert.Contains("5 minutes ago", output);
+        }
+
+        [Fact]
+        public void BuildFeedbackList_NullCategory_RendersAsGeneral()
+        {
+            DateTime now = DateTime.UtcNow;
+            var entry = MakeEntry("Alice", "Alice", null, "some text", now.AddMinutes(-2));
+
+            string output = ChateauFeedbackList.BuildFeedbackList(new List<FeedbackEntry> { entry }, now);
+
+            Assert.Contains("general", output);
+        }
+
+        [Fact]
+        public void BuildFeedbackList_NoDisplayName_FallsBackToUserName()
+        {
+            DateTime now = DateTime.UtcNow;
+            var entry = MakeEntry("Alice", null, "idea", "anonymous-ish", now.AddMinutes(-2));
+
+            string output = ChateauFeedbackList.BuildFeedbackList(new List<FeedbackEntry> { entry }, now);
+
+            Assert.Contains("Alice", output);
+        }
+
+        [Fact]
+        public void BuildFeedbackList_PastCharCap_TruncatesWithNote()
+        {
+            DateTime now = DateTime.UtcNow;
+            var entries = new List<FeedbackEntry>();
+            for (int i = 0; i < 10; i++)
+            {
+                entries.Add(MakeEntry("User" + i, "User" + i, "general", new string('x', 100), now.AddMinutes(-i)));
+            }
+
+            // Force truncation with a small cap.
+            string output = ChateauFeedbackList.BuildFeedbackList(entries, now, maxChars: 300);
+
+            Assert.Contains("output truncated", output);
+            // At least one but not all 10 entries rendered.
+            Assert.Contains("User0", output);
+            Assert.DoesNotContain("User9", output);
+        }
+
+        #endregion
+
+        #region AddFeedback / GetRecentFeedback
+
+        [Fact]
+        public void AddFeedback_ThenGetRecent_ReturnsEntry()
+        {
+            var entry = MakeEntry("Alice", "Alice", "bug", "it broke", DateTime.UtcNow);
+
+            _database.AddFeedback(entry);
+
+            var recent = _database.GetRecentFeedback(10);
+            Assert.Single(recent);
+            Assert.Equal("Alice", recent[0].submitterUserName);
+            Assert.Equal("bug", recent[0].category);
+            Assert.Equal("it broke", recent[0].text);
+        }
+
+        [Fact]
+        public void GetRecentFeedback_ReturnsNewestFirst()
+        {
+            DateTime now = DateTime.UtcNow;
+            _database.AddFeedback(MakeEntry("Alice", "Alice", "general", "oldest", now.AddHours(-2)));
+            _database.AddFeedback(MakeEntry("Bob", "Bob", "general", "newest", now.AddMinutes(-1)));
+            _database.AddFeedback(MakeEntry("Cara", "Cara", "general", "middle", now.AddHours(-1)));
+
+            var recent = _database.GetRecentFeedback(10);
+
+            Assert.Equal(3, recent.Count);
+            Assert.Equal("newest", recent[0].text);
+            Assert.Equal("middle", recent[1].text);
+            Assert.Equal("oldest", recent[2].text);
+        }
+
+        [Fact]
+        public void GetRecentFeedback_RespectsCountLimit()
+        {
+            DateTime now = DateTime.UtcNow;
+            _database.AddFeedback(MakeEntry("Alice", "Alice", "general", "first", now.AddHours(-3)));
+            _database.AddFeedback(MakeEntry("Bob", "Bob", "general", "second", now.AddHours(-2)));
+            _database.AddFeedback(MakeEntry("Cara", "Cara", "general", "third", now.AddHours(-1)));
+
+            var recent = _database.GetRecentFeedback(2);
+
+            Assert.Equal(2, recent.Count);
+            // The two newest, in order.
+            Assert.Equal("third", recent[0].text);
+            Assert.Equal("second", recent[1].text);
+        }
+
+        [Fact]
+        public void GetRecentFeedback_NoSubmissions_ReturnsEmpty()
+        {
+            var recent = _database.GetRecentFeedback(10);
+            Assert.Empty(recent);
+        }
+
+        #endregion
+
+        private static FeedbackEntry MakeEntry(string userName, string displayName, string category, string text, DateTime submittedAt)
+        {
+            return new FeedbackEntry
+            {
+                submitterUserName = userName,
+                submitterDisplayName = displayName,
+                category = category,
+                text = text,
+                sourceChannel = null,
+                submittedAt = submittedAt
+            };
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauFeedback.cs
+++ b/FChatDicebot/BotCommands/ChateauFeedback.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Linq;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !feedback (alias !suggestion): lets any registered resident submit a free-text idea or
+    /// bug report into the Feedback collection. Not an interaction — no consent, investment
+    /// level, status hook, or reversal. Staff read submissions back via the admin !feedbacklist.
+    /// </summary>
+    public class ChateauFeedback : ChatBotCommand
+    {
+        // 5-minute submission cooldown, gated via profile.timers (the !work pattern).
+        public const string CooldownKey = "feedback";
+        public const int CooldownMinutes = 5;
+
+        // Known leading category keywords. A first term matching one of these (case-insensitive)
+        // is stripped and stored as the category; otherwise everything is stored as "general".
+        public static readonly string[] KnownCategories = new string[] { "bug", "idea", "other" };
+        public const string DefaultCategory = "general";
+
+        public ChateauFeedback()
+        {
+            Name = "feedback";
+            Aliases = new string[] { "suggestion" };
+            Category = "General";
+            ShortDescription = "Send the staff an idea or a bug report";
+            LongDescription = "Send the Chateau mods an idea or a bug report. Works in a channel or in a private message to the bot. Optionally start your message with 'bug' 'idea' or 'other' to tag it. A mod may reach out to you for clarification, discussion, or to inform you of a change resulting from your feedback. A 5 minute cooldown applies between submissions.";
+            Usage = "!feedback <your idea or bug>\nor\n!feedback [bug|idea|other] <text>";
+            RelatedCommands = new string[] { "modmessage", "help", "botinfo" };
+            CooldownDuration = "5 minutes";
+            CooldownAppliesTo = "initiator";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            Profile userProfile = MonDB.getProfile(characterName);
+            bool fromChannel = commandController.MessageCameFromChannel(channel);
+
+            // Cooldown gate — set only on a successful submission, so a too-soon retry that was
+            // never accepted (e.g. an empty message) does not start the timer.
+            if (userProfile.timers.ContainsKey(CooldownKey) && userProfile.timers[CooldownKey].timerEnd > DateTime.UtcNow)
+            {
+                TimeSpan timeLeft = userProfile.timers[CooldownKey].timerEnd - DateTime.UtcNow;
+                Reply(bot, fromChannel, channel, characterName, CooldownMessage(timeLeft));
+                return;
+            }
+
+            (string category, string text) = ParseFeedback(rawTerms);
+
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                Reply(bot, fromChannel, channel, characterName, EmptyUsageMessage);
+                return;
+            }
+
+            string displayName = string.IsNullOrEmpty(userProfile.displayName) ? characterName : userProfile.displayName;
+
+            FeedbackEntry entry = new FeedbackEntry
+            {
+                submitterUserName = characterName,
+                submitterDisplayName = displayName,
+                category = category,
+                text = text,
+                sourceChannel = fromChannel ? channel : null,
+                submittedAt = DateTime.UtcNow
+            };
+            MonDB.addFeedback(entry);
+
+            CoolDown timer = new CoolDown();
+            timer.timerEnd = DateTime.UtcNow.AddMinutes(CooldownMinutes);
+            if (userProfile.timers.ContainsKey(CooldownKey))
+            {
+                userProfile.timers[CooldownKey] = timer;
+            }
+            else
+            {
+                userProfile.timers.Add(CooldownKey, timer);
+            }
+            MonDB.setProfile(characterName, userProfile);
+
+            Reply(bot, fromChannel, channel, characterName, AcknowledgementMessage);
+        }
+
+        /// <summary>
+        /// Splits the raw (original-case) argument terms into an optional leading category and the
+        /// remaining free text. A first term matching <see cref="KnownCategories"/> is consumed as
+        /// the category; otherwise the category is <see cref="DefaultCategory"/> and all terms are
+        /// the text. Pure and case-preserving so it can be unit tested without a bot or DB.
+        /// </summary>
+        public static (string category, string text) ParseFeedback(string[] rawTerms)
+        {
+            if (rawTerms == null || rawTerms.Length == 0)
+            {
+                return (DefaultCategory, "");
+            }
+
+            string firstToken = rawTerms[0].Trim().ToLower();
+            if (KnownCategories.Contains(firstToken))
+            {
+                string remainder = string.Join(" ", rawTerms.Skip(1)).Trim();
+                return (firstToken, remainder);
+            }
+
+            return (DefaultCategory, string.Join(" ", rawTerms).Trim());
+        }
+
+        private static void Reply(BotMain bot, bool fromChannel, string channel, string characterName, string message)
+        {
+            if (fromChannel)
+            {
+                bot.SendMessageInChannel(message, channel);
+            }
+            else
+            {
+                bot.SendPrivateMessage(message, characterName);
+            }
+        }
+
+        // --- User-facing strings (acknowledgement is owner-final; others are first drafts pending review) ---
+
+        public const string EmptyUsageMessage =
+            "Be sure you actually include your feedback! Usage: !feedback <your idea or bug report>";
+
+        public const string AcknowledgementMessage =
+            "Thank you for your feedback! A mod might reach out to you with further inquiry, and we'll do our best to let you know how we used your feedback, one way or the other.";
+
+        public static string CooldownMessage(TimeSpan timeLeft)
+        {
+            return "You've shared feedback very recently. Please wait " +
+                string.Format("{0:D2}m:{1:D2}s", timeLeft.Minutes, timeLeft.Seconds) +
+                " before sending more.";
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauFeedbackList.cs
+++ b/FChatDicebot/BotCommands/ChateauFeedbackList.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !feedbacklist (admin): pull the most recent feedback submissions, newest first, and PM
+    /// them to the requesting admin. A dedicated command rather than overloading !feedback, so
+    /// there is no ambiguity between "submit the word 'list' as feedback" and "list feedback".
+    /// </summary>
+    public class ChateauFeedbackList : ChatBotCommand
+    {
+        public const int DefaultCount = 10;
+        public const int MaxCount = 50;
+        // Stay clear of the F-Chat 4096-char message cap when assembling the readout.
+        public const int MaxMessageChars = 3900;
+
+        public ChateauFeedbackList()
+        {
+            Name = "feedbacklist";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Staff: view recent feedback submissions";
+            LongDescription = "Staff only. View the most recent feedback submissions (from !feedback / !suggestion), newest first. Optionally pass a count, e.g. !feedbacklist 25. The result is sent to you in a private message.";
+            Usage = "!feedbacklist\nor\n!feedbacklist [count]";
+            RelatedCommands = new string[] { "feedback", "modmessage" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = true;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            int count = DefaultCount;
+            if (terms.Length > 0 && int.TryParse(terms[0], out int requested) && requested > 0)
+            {
+                count = Math.Min(requested, MaxCount);
+            }
+
+            List<FeedbackEntry> entries = MonDB.getRecentFeedback(count);
+            string message = BuildFeedbackList(entries, DateTime.UtcNow);
+            bot.SendPrivateMessage(message, characterName);
+        }
+
+        /// <summary>
+        /// Renders the feedback readout, newest first, one block per entry. Pure and DB-free so it
+        /// can be unit tested over a synthetic list. Stops short of <paramref name="maxChars"/> and
+        /// appends a truncation note rather than overflowing the F-Chat message cap.
+        /// </summary>
+        public static string BuildFeedbackList(List<FeedbackEntry> entries, DateTime now, int maxChars = MaxMessageChars)
+        {
+            if (entries == null || entries.Count == 0)
+            {
+                return EmptyStateMessage;
+            }
+
+            List<FeedbackEntry> ordered = entries.OrderByDescending(e => e.submittedAt).ToList();
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append("[b]Recent feedback submissions:[/b]\n");
+
+            int shown = 0;
+            foreach (FeedbackEntry e in ordered)
+            {
+                string relative = Utils.TimeDifferenceText(e.submittedAt, now) + " ago";
+                string cat = string.IsNullOrEmpty(e.category) ? ChateauFeedback.DefaultCategory : e.category;
+                string name = string.IsNullOrEmpty(e.submitterDisplayName) ? e.submitterUserName : e.submitterDisplayName;
+                string block = "\n" + relative + " — [b]" + name + "[/b] ([i]" + cat + "[/i]): " + e.text + "\n";
+
+                if (shown > 0 && sb.Length + block.Length > maxChars)
+                {
+                    sb.Append("\n…(output truncated — showing the ").Append(shown)
+                      .Append(" most recent of ").Append(ordered.Count).Append(')');
+                    break;
+                }
+
+                sb.Append(block);
+                shown++;
+            }
+
+            return sb.ToString().TrimEnd('\n');
+        }
+
+        // First-draft empty-state wording, pending owner review.
+        public const string EmptyStateMessage = "No feedback has been submitted yet.";
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -74,6 +74,7 @@ namespace FChatDicebot.BotCommands
                 "!economics",
                 "!joinchateau",
                 "!modmessage",
+                "!feedback [sub]!suggestion[/sub]",
                 "!setmark",
                 "!help [sub]!commands[/sub]",
                 "!botinfo",
@@ -166,7 +167,8 @@ namespace FChatDicebot.BotCommands
             if(Utils.IsCharacterAdmin(bot.AccountSettings.AdminCharacters, command.characterName))
             {
                 messageText += "\n[b]Admin only Commands [/b](no channel req)\n" +
-                    "!namechange [noparse][user]old profile in user tag[/user][/noparse] \"new profile in quotes\" - updates the database to reflect a user who has changed their Flist username. CaSe SeNsItIvE \n";
+                    "!namechange [noparse][user]old profile in user tag[/user][/noparse] \"new profile in quotes\" - updates the database to reflect a user who has changed their Flist username. CaSe SeNsItIvE \n" +
+                    "!feedbacklist [count] - view recent !feedback / !suggestion submissions (newest first) \n";
             }
 
             if (commandController.MessageCameFromChannel(channel))

--- a/FChatDicebot/BotCommands/ChateauSuggestion.cs
+++ b/FChatDicebot/BotCommands/ChateauSuggestion.cs
@@ -1,0 +1,37 @@
+using System;
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !suggestion: working alias for !feedback. Command dispatch matches on Name only, so an
+    /// alias has to be its own command class that delegates to the canonical command
+    /// (the ChateauW / ChateauBalance pattern) — the Aliases array is cosmetic (help display).
+    /// </summary>
+    public class ChateauSuggestion : ChatBotCommand
+    {
+        public ChateauSuggestion()
+        {
+            Name = "suggestion";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !feedback";
+            LongDescription = "Alternative wording for the !feedback command. See !help feedback for full details.";
+            Usage = "!suggestion <your idea or bug>\nor\n!suggestion [bug|idea|other] <text>";
+            RelatedCommands = new string[] { "feedback", "modmessage", "help" };
+            CooldownDuration = "5 minutes";
+            CooldownAppliesTo = "initiator";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            ChateauFeedback feedback = new ChateauFeedback();
+            feedback.Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -737,6 +737,24 @@ namespace FChatDicebot.Database
             collection.DeleteOne(filter);
         }
 
+        // Feedback Operations
+        public void AddFeedback(FeedbackEntry entry)
+        {
+            var collection = Database.GetCollection<BsonDocument>("Feedback");
+            collection.InsertOne(entry.ToBsonDocument());
+        }
+
+        public List<FeedbackEntry> GetRecentFeedback(int count)
+        {
+            var collection = Database.GetCollection<BsonDocument>("Feedback");
+            var documents = collection.Find(Builders<BsonDocument>.Filter.Empty)
+                .Sort(Builders<BsonDocument>.Sort.Descending("submittedAt"))
+                .Limit(count)
+                .ToList();
+
+            return documents.Select(doc => BsonSerializer.Deserialize<FeedbackEntry>(doc)).ToList();
+        }
+
         // Database Management
         public void ClearDatabase()
         {

--- a/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/Database/Ichateaudatabase.cs
@@ -88,6 +88,10 @@ namespace FChatDicebot.Database
         void UpdatePledge(Pledge pledge);
         void DeletePledge(ObjectId pledgeId);
 
+        // Feedback Operations
+        void AddFeedback(FeedbackEntry entry);
+        List<FeedbackEntry> GetRecentFeedback(int count);
+
         // Database Management
         void ClearDatabase();
         void ClearCollection(string collectionName);

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -204,6 +204,9 @@
     <Compile Include="BotCommands\ChateauBoobhat.cs" />
     <Compile Include="BotCommands\ChateauLick.cs" />
     <Compile Include="BotCommands\ChateauLap.cs" />
+    <Compile Include="BotCommands\ChateauFeedback.cs" />
+    <Compile Include="BotCommands\ChateauSuggestion.cs" />
+    <Compile Include="BotCommands\ChateauFeedbackList.cs" />
     <Compile Include="BotCommands\ChateauSit.cs" />
     <Compile Include="BotCommands\ChateauAbandonPledge.cs" />
     <Compile Include="BotCommands\ChateauFulfill.cs" />

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -238,4 +238,18 @@ namespace FChatDicebot.Model
         // Helper to check if this pledge is active
         public bool IsActive => status == "active";
     }
+
+    public class FeedbackEntry
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId Id { get; set; }
+        public string submitterUserName { get; set; }    // login name (survives renames)
+        public string submitterDisplayName { get; set; } // snapshot at submit time
+        public string category { get; set; }             // "general" | "bug" | "idea" | "other"
+        public string text { get; set; }
+        [BsonIgnoreIfNull]
+        public string sourceChannel { get; set; }        // channel name, or null if PM
+        public DateTime submittedAt { get; set; }
+    }
 }

--- a/FChatDicebot/MonDB.cs
+++ b/FChatDicebot/MonDB.cs
@@ -253,5 +253,15 @@ namespace FChatDicebot
         {
             GetDatabase().DeletePledge(pledgeId);
         }
+
+        internal static void addFeedback(FeedbackEntry entry)
+        {
+            GetDatabase().AddFeedback(entry);
+        }
+
+        internal static List<FeedbackEntry> getRecentFeedback(int count)
+        {
+            return GetDatabase().GetRecentFeedback(count);
+        }
     }
 }

--- a/wiki-docs/Feature-Requests.md
+++ b/wiki-docs/Feature-Requests.md
@@ -7,7 +7,6 @@ Features and changes, big and small, that have been proposed but not thoroughly 
 * !cancel and !decline (initiator and recipient geared 'remove pending interaction' commands) on top of existing time out parameters.
 * if someone is !employed by another (not themselves), give their employer some currency when the employee works. TOS prevents us from notifying the employer in response to an employee privately doing !work, so should also include some sort of command for employers to see how much employees have earned them
 * additional casual commands. lapsit, boobhat, lick, possibly more. Will it take up too much dossier space? Do they have reasonable titles to accrue?
-* !feedback (alias !suggestion) to submit an idea or report a bug
 * !bondtree and/or !familytree which would map out all users connected to someone by N degrees of separation via bonds.
 * Some way to resurface chips, poker, other games from the underlying dicebot functionality (currently, Chateau Work has overwritten the dicebot work). Save this for after original dice bot developer pushes their most recent dicebot changes to Git, for ease of merging
 * Random events, to encourage spontaneous chat activity. Responding to a random event would always start !random but might also require an additional argument, to slow down campers/snipers

--- a/wiki-docs/specs/Feedback.md
+++ b/wiki-docs/specs/Feedback.md
@@ -1,7 +1,18 @@
 # Feedback — `!feedback` / `!suggestion` + admin `!feedbacklist`
 
-**Status:** Proposed (design-complete, owner-reviewed 2026-06-21).
+**Status:** Implemented. (design owner-reviewed 2026-06-21; shipped 2026-06-22)
 **Feature-Requests source:** "!feedback (alias !suggestion) to submit an idea or report a bug" (B9).
+
+---
+
+## Differences from the original spec
+
+The feature shipped as designed, with these as-built notes:
+
+- **Category tagging kept.** The optional leading `bug`/`idea`/`other` keyword was retained (the spec OK'd dropping it if parsing got fiddly; it didn't). Implemented as a pure, unit-tested `ChateauFeedback.ParseFeedback(rawTerms)` returning `(category, text)`.
+- **Test fixture is a real test DB, not an in-memory double.** [Testdatabasefixture.cs](../../FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs) wraps a live `ChateauDatabase` against the test connection string (the Pledges precedent), so `AddFeedback`/`GetRecentFeedback` are exercised end-to-end. The fixture's `Reset()` just adds `Feedback` to the cleared collections.
+- **Owner-reviewed wording (2026-06-22):** empty-submission hint is *"Be sure you actually include your feedback! Usage: !feedback <your idea or bug report>"*; the `!feedback` long-description references the **mods** (not "staff"). The success acknowledgement is unchanged from the spec.
+- **`!feedbacklist`** renders one block per entry (`{relative} ago — {name} ({category}): {text}`) and truncates with a note before the 4096-char cap; default 10, max 50.
 
 ---
 
@@ -15,7 +26,7 @@ This is **not** an interaction (no consent, investment level, status hook, or re
 
 ## The `!feedback` command (submission)
 
-New `ChatBotCommand`: [ChateauFeedback.cs](../../../FChatDicebot/BotCommands/ChateauFeedback.cs) under `BotCommands/`.
+New `ChatBotCommand`: [ChateauFeedback.cs](../../FChatDicebot/BotCommands/ChateauFeedback.cs) under `BotCommands/`.
 
 | Field | Value |
 |-------|-------|
@@ -29,7 +40,7 @@ New `ChatBotCommand`: [ChateauFeedback.cs](../../../FChatDicebot/BotCommands/Cha
 | `RequireChannel` | `false` (works in channel or PM) |
 | `RequireBotAdmin` / `RequireChannelAdmin` | `false` / `false` |
 
-**`!suggestion` alias** = its own delegating class [ChateauSuggestion.cs](../../../FChatDicebot/BotCommands/ChateauSuggestion.cs), `Name="suggestion"`, whose `Run` calls `new ChateauFeedback().Run(...)` (the [ChateauW.cs](../../../FChatDicebot/BotCommands/ChateauW.cs) pattern — the `Aliases` array does **not** route; see the [cluster README](README.md#cluster-wide-implementation-note-aliases-are-separate-command-classes)).
+**`!suggestion` alias** = its own delegating class [ChateauSuggestion.cs](../../FChatDicebot/BotCommands/ChateauSuggestion.cs), `Name="suggestion"`, whose `Run` calls `new ChateauFeedback().Run(...)` (the [ChateauW.cs](../../FChatDicebot/BotCommands/ChateauW.cs) pattern — the `Aliases` array does **not** route; see the [cluster README](Future-Social/README.md#cluster-wide-implementation-note-aliases-are-separate-command-classes)).
 
 **Optional leading category (B9.2).** If the first term is one of a small known set (`bug`, `idea`, `other` — extend freely), strip it and store it as `category`; otherwise `category = "general"` and the whole message is the text. Keep this trivial: a single first-token check. **If it complicates parsing in practice, drop it entirely** and store every submission as `general` — the owner has explicitly OK'd dropping the category rather than fighting the parser.
 
@@ -40,9 +51,9 @@ New `ChatBotCommand`: [ChateauFeedback.cs](../../../FChatDicebot/BotCommands/Cha
 
 **On success:**
 1. Build a `FeedbackEntry` (see Persistence) — submitter `userName` + `displayName`, `category`, `text`, the `sourceChannel` (the channel name, or `null`/empty when sent by PM), and `submittedAt = DateTime.UtcNow`.
-2. `Database.AddFeedback(entry)` (InsertOne — the [Pledges](../../../FChatDicebot/Database/Chateaudatabase.cs) write precedent).
+2. `Database.AddFeedback(entry)` (InsertOne — the [Pledges](../../FChatDicebot/Database/Chateaudatabase.cs) write precedent).
 3. Set the 5-minute cooldown timer and save the profile.
-4. Acknowledge. Mirror [ModMessage.cs](../../../FChatDicebot/BotCommands/ModMessage.cs)'s reply routing: reply in-channel if it came from a channel, else PM. Only the acknowledgement is emitted — never echo the submitted text publicly.
+4. Acknowledge. Mirror [ModMessage.cs](../../FChatDicebot/BotCommands/ModMessage.cs)'s reply routing: reply in-channel if it came from a channel, else PM. Only the acknowledgement is emitted — never echo the submitted text publicly.
 
 > **For owner wording review — acknowledgement (owner-supplied, final):**
 > `Thank you for your feedback! A mod might reach out to you with further inquiry, and we'll do our best to let you know how we used your feedback, one way or the other.`
@@ -51,7 +62,7 @@ New `ChatBotCommand`: [ChateauFeedback.cs](../../../FChatDicebot/BotCommands/Cha
 
 ## The `!feedbacklist` command (admin read)
 
-New `ChatBotCommand`: [ChateauFeedbackList.cs](../../../FChatDicebot/BotCommands/ChateauFeedbackList.cs). A dedicated admin command (rather than overloading `!feedback`) so there is **no ambiguity** between "submit the word 'list' as feedback" and "list feedback."
+New `ChatBotCommand`: [ChateauFeedbackList.cs](../../FChatDicebot/BotCommands/ChateauFeedbackList.cs). A dedicated admin command (rather than overloading `!feedback`) so there is **no ambiguity** between "submit the word 'list' as feedback" and "list feedback."
 
 | Field | Value |
 |-------|-------|
@@ -71,7 +82,7 @@ Built around a static `BuildFeedbackList(List<FeedbackEntry>)` helper for unit t
 
 ## Persistence shape
 
-New model `FeedbackEntry` (in [ChateauDB.cs](../../../FChatDicebot/Model/ChateauDB.cs), alongside `Pledge`):
+New model `FeedbackEntry` (in [ChateauDB.cs](../../FChatDicebot/Model/ChateauDB.cs), alongside `Pledge`):
 
 ```csharp
 public class FeedbackEntry
@@ -94,7 +105,7 @@ Stored in a new **`Feedback`** Mongo collection. Unlike B6, this **does** touch 
 - `Ichateaudatabase.cs`: `void AddFeedback(FeedbackEntry entry);` and `List<FeedbackEntry> GetRecentFeedback(int count);`
 - `Chateaudatabase.cs`: implement both against `Database.GetCollection<BsonDocument>("Feedback")` — `AddFeedback` = `InsertOne(entry.ToBsonDocument())` (Pledges pattern); `GetRecentFeedback` = `Find(empty).SortByDescending(submittedAt).Limit(count)` deserialized to `FeedbackEntry`.
 - `MonDB.cs`: thin static pass-throughs (`addFeedback` / `getRecentFeedback`) matching the existing `MonDB` wrapper style.
-- Test double [Testdatabasefixture.cs](../../../FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs) gains an in-memory `Feedback` list + the two methods.
+- Test double [Testdatabasefixture.cs](../../FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs) gains an in-memory `Feedback` list + the two methods.
 
 ---
 

--- a/wiki-docs/specs/Future-Social/README.md
+++ b/wiki-docs/specs/Future-Social/README.md
@@ -8,7 +8,6 @@ Self-contained design specs for **upcoming** Chateau Contract community, relatio
 
 | Spec | Adds |
 |------|------|
-| [Feedback](Feedback.md) | `!feedback` (+ `!suggestion` alias) for residents to submit an idea or bug report into a new `Feedback` collection, plus an admin-only `!feedbacklist` to read recent submissions. (B9) |
 | [Bond-Tree](Bond-Tree.md) | `!bondtree` and `!familytree`, read-only commands that walk the bond graph and render everyone connected to a resident within N degrees of separation. (B10) |
 | [Random-Events](Random-Events.md) | An ambient event system: the bot periodically fires a random event into opted-in channels; residents join with the new `!random` command (with an optional anti-snipe argument) for a chance at currency, titles, training, corruption/purity, curses, or flavor. (B12) |
 

--- a/wiki-docs/specs/README.md
+++ b/wiki-docs/specs/README.md
@@ -44,6 +44,12 @@ Design + as-implemented documentation for the Chateau Contract interaction syste
 | [Infest-and-Purge](Infest-and-Purge.md) | `!purge` (free during 24h spread-grace, otherwise at a `PurgeCostType` cost) | Status-Effect-Hook, Dose-and-Detox (`PurgeCostType` infra). Adds new `IPostInteractionEffect` hook. |
 | [Curse-and-Cleanse](Curse-and-Cleanse.md) | `!cleanse` (at a per-curse `PurgeCostType` cost) | Status-Effect-Hook, Dose-and-Detox (`PurgeCostType` infra) |
 
+### Social
+
+| Spec | Adds |
+|------|------|
+| [Feedback](Feedback.md) | `!feedback` (+ `!suggestion` alias) to submit an idea or bug report into a new `Feedback` collection, plus admin-only `!feedbacklist` to read recent submissions. |
+
 ## Upcoming features
 
 See [`Future-Interactions/README.md`](Future-Interactions/README.md) for the design specs of features that haven't shipped yet, organized by tier and dependency.


### PR DESCRIPTION
Implements the **Feedback** spec (B9): an in-bot channel for residents to send ideas and bug reports to the mods.

## What's new
- **`!feedback`** (alias **`!suggestion`**) — any registered resident submits free text, persisted to a new `Feedback` Mongo collection. Optional leading `bug`/`idea`/`other` keyword tags the submission; everything else is `general`. Works in a channel or PM; the acknowledgement routes back to wherever it was sent and the submitted text is **never echoed publicly**. 5-minute cooldown, set only on a successful submission.
- **`!feedbacklist`** (admin-only) — PMs the requesting admin the most recent submissions, newest first (default 10, max 50), truncating with a note before the F-Chat 4096-char cap.

## Implementation notes
- `FeedbackEntry` model + `AddFeedback` / `GetRecentFeedback` across the DB abstraction (interface → `ChateauDatabase` → `MonDB` wrappers), following the existing Pledges precedent. Test fixture clears the new `Feedback` collection.
- New command classes auto-register via reflection; `!suggestion` is a delegating alias class (the `ChateauW` pattern) since dispatch matches on `Name` only.
- Pure, unit-tested helpers: `ChateauFeedback.ParseFeedback` (category/text split, case-preserving) and `ChateauFeedbackList.BuildFeedbackList` (rendering, ordering, truncation).
- Owner-reviewed user-facing wording.

## Docs
- Feedback spec relocated from `specs/Future-Social/` to the as-implemented `specs/` folder (status → Implemented, with an as-shipped notes section); B9 retired from `Feature-Requests.md`; indexes updated.

## Tests
- 14 new tests (ParseFeedback, BuildFeedbackList, and `AddFeedback`/`GetRecentFeedback` ordering + limit against the test DB).
- Full suite green: **1232 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)