### PR TITLE
Add employer earnings: !work MANOR kickback + !business (B6)

### DIFF
--- a/FChatDicebot.Tests/Builders/Profilebuilder.cs
+++ b/FChatDicebot.Tests/Builders/Profilebuilder.cs
@@ -108,6 +108,24 @@ namespace FChatDicebot.Tests.Builders
         }
 
         /// <summary>
+        /// Record a MANOR kickback this profile has earned (as an employer) from a given
+        /// employee in a given currency, mirroring how !work increments employeeEarnings.
+        /// </summary>
+        public ProfileBuilder WithEmployeeEarnings(string employeeUserName, string currency, int amount)
+        {
+            if (_profile.employeeEarnings == null)
+            {
+                _profile.employeeEarnings = new Dictionary<string, Dictionary<string, int>>();
+            }
+            if (!_profile.employeeEarnings.ContainsKey(employeeUserName))
+            {
+                _profile.employeeEarnings[employeeUserName] = new Dictionary<string, int>();
+            }
+            _profile.employeeEarnings[employeeUserName][currency] = amount;
+            return this;
+        }
+
+        /// <summary>
         /// Returns the built profile without saving to database.
         /// Useful for testing validation logic.
         /// </summary>
@@ -139,6 +157,7 @@ namespace FChatDicebot.Tests.Builders
             registeredProfile.milkInventory = _profile.milkInventory;
             registeredProfile.trainings = _profile.trainings;
             registeredProfile.dailyClimaxCounts = _profile.dailyClimaxCounts;
+            registeredProfile.employeeEarnings = _profile.employeeEarnings;
 
             // Now save with the correct _id
             database.SetProfile(_profile.userName, registeredProfile);

--- a/FChatDicebot.Tests/Unit/Chateaubusinesstests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubusinesstests.cs
@@ -1,0 +1,180 @@
+using FChatDicebot.BotCommands;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Unit tests for the B6 employer-earnings feature: the ChateauWork.EmployerCut /
+    /// ApplyEmployerKickback kickback helpers and the ChateauBusiness.BuildBusiness render
+    /// helper. All pure — none touch the database.
+    /// </summary>
+    public class ChateauBusinessTests
+    {
+        // --- EmployerCut: 25% of the rolled reward, floored, min 1 when positive ---
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(-5, 0)]
+        [InlineData(1, 1)]   // floor(0.25) = 0 -> min 1
+        [InlineData(2, 1)]   // floor(0.50) = 0 -> min 1
+        [InlineData(3, 1)]   // floor(0.75) = 0 -> min 1
+        [InlineData(4, 1)]   // floor(1.00) = 1
+        [InlineData(7, 1)]   // floor(1.75) = 1
+        [InlineData(8, 2)]   // floor(2.00) = 2
+        [InlineData(100, 25)]
+        public void EmployerCut_AppliesFloorAndMinimum(int rewardAmount, int expectedCut)
+        {
+            Assert.Equal(expectedCut, ChateauWork.EmployerCut(rewardAmount));
+        }
+
+        // --- ApplyEmployerKickback: wallet + ledger mutation, curse voiding, worker-facing line ---
+
+        [Fact]
+        public void ApplyEmployerKickback_UncursedEmployer_CreditsWalletAndLedger_AndReturnsLine()
+        {
+            Profile employer = new ProfileBuilder().WithDisplayName("Boss").Build();
+
+            string line = ChateauWork.ApplyEmployerKickback("worker", employer, "Boss", 100, "copper");
+
+            Assert.Equal(25, employer.currencies["copper"]);
+            Assert.Equal(25, employer.employeeEarnings["worker"]["copper"]);
+            Assert.Contains("Boss", line);
+            Assert.Contains("[b]25 copper[/b]", line);
+            Assert.Contains("MANOR", line);
+        }
+
+        [Fact]
+        public void ApplyEmployerKickback_AddsToExistingBalances()
+        {
+            Profile employer = new ProfileBuilder()
+                .WithCurrency("copper", 10)
+                .WithEmployeeEarnings("worker", "copper", 5)
+                .Build();
+
+            ChateauWork.ApplyEmployerKickback("worker", employer, "Boss", 100, "copper");
+
+            Assert.Equal(35, employer.currencies["copper"]);          // 10 + 25
+            Assert.Equal(30, employer.employeeEarnings["worker"]["copper"]); // 5 + 25
+        }
+
+        [Fact]
+        public void ApplyEmployerKickback_EmployerPovertyCursed_VoidsEverything()
+        {
+            Profile employer = new ProfileBuilder().WithDisplayName("Boss").Build();
+            CurseInstance.SaveAll(employer, new List<CurseInstance>
+            {
+                new CurseInstance { Curse = "poverty", AppliedBy = "Someone", AppliedAt = DateTime.UtcNow }
+            });
+
+            string line = ChateauWork.ApplyEmployerKickback("worker", employer, "Boss", 100, "copper");
+
+            Assert.Equal(string.Empty, line);
+            Assert.False(employer.currencies.ContainsKey("copper"));
+            Assert.False(employer.employeeEarnings.ContainsKey("worker"));
+        }
+
+        [Fact]
+        public void ApplyEmployerKickback_ZeroRolledReward_PaysNothing()
+        {
+            Profile employer = new ProfileBuilder().WithDisplayName("Boss").Build();
+
+            string line = ChateauWork.ApplyEmployerKickback("worker", employer, "Boss", 0, "copper");
+
+            Assert.Equal(string.Empty, line);
+            Assert.False(employer.currencies.ContainsKey("copper"));
+            Assert.False(employer.employeeEarnings.ContainsKey("worker"));
+        }
+
+        // --- BuildBusiness: rendering the employeeEarnings ledger ---
+
+        private static string IdentityResolver(string userName) => userName;
+
+        [Fact]
+        public void BuildBusiness_NullProfile_ReturnsEmptyState()
+        {
+            Assert.Equal(ChateauBusiness.EmptyStateMessage, ChateauBusiness.BuildBusiness(null, IdentityResolver));
+        }
+
+        [Fact]
+        public void BuildBusiness_NoEarnings_ReturnsEmptyState()
+        {
+            Profile profile = new ProfileBuilder().Build();
+            Assert.Equal(ChateauBusiness.EmptyStateMessage, ChateauBusiness.BuildBusiness(profile, IdentityResolver));
+        }
+
+        [Fact]
+        public void BuildBusiness_SingleEmployeeSingleCurrency_RendersRowAndTotal()
+        {
+            Profile profile = new ProfileBuilder()
+                .WithEmployeeEarnings("alice", "copper", 42)
+                .Build();
+
+            string output = ChateauBusiness.BuildBusiness(profile, un => "Alice");
+
+            Assert.Contains("Alice: [b]42 copper[/b]", output);
+            Assert.Contains("Total earned from all employees: [b]42 copper[/b]", output);
+        }
+
+        [Fact]
+        public void BuildBusiness_MultipleEmployees_SortsByTotalDescAndSumsGrandTotals()
+        {
+            // Alice: 42 copper + 3 silver (total 45); Bob: 18 copper (total 18).
+            Profile profile = new ProfileBuilder()
+                .WithEmployeeEarnings("alice", "copper", 42)
+                .WithEmployeeEarnings("alice", "silver", 3)
+                .WithEmployeeEarnings("bob", "copper", 18)
+                .Build();
+
+            var names = new Dictionary<string, string> { { "alice", "Alice" }, { "bob", "Bob" } };
+            string output = ChateauBusiness.BuildBusiness(profile, un => names[un]);
+
+            int iAlice = output.IndexOf("Alice:", StringComparison.Ordinal);
+            int iBob = output.IndexOf("Bob:", StringComparison.Ordinal);
+            Assert.True(iAlice >= 0 && iBob >= 0);
+            Assert.True(iAlice < iBob, "Higher earner Alice should render before Bob");
+
+            // Currencies within a row are alphabetical.
+            Assert.Contains("Alice: [b]42 copper[/b] | [b]3 silver[/b]", output);
+            Assert.Contains("Bob: [b]18 copper[/b]", output);
+
+            // Grand totals sum across employees, per currency.
+            Assert.Contains("Total earned from all employees: [b]60 copper[/b] | [b]3 silver[/b]", output);
+        }
+
+        [Fact]
+        public void BuildBusiness_PrunesNonPositiveEntries()
+        {
+            // Bob's only entry is zero -> Bob is dropped entirely; a zero currency on Alice is pruned.
+            Profile profile = new ProfileBuilder()
+                .WithEmployeeEarnings("alice", "copper", 10)
+                .WithEmployeeEarnings("alice", "silver", 0)
+                .WithEmployeeEarnings("bob", "copper", 0)
+                .Build();
+
+            var names = new Dictionary<string, string> { { "alice", "Alice" }, { "bob", "Bob" } };
+            string output = ChateauBusiness.BuildBusiness(profile, un => names[un]);
+
+            Assert.Contains("Alice: [b]10 copper[/b]", output);
+            Assert.DoesNotContain("silver", output);
+            Assert.DoesNotContain("Bob", output);
+            Assert.Contains("Total earned from all employees: [b]10 copper[/b]", output);
+        }
+
+        [Fact]
+        public void BuildBusiness_MissingDisplayName_FallsBackToUserNameKey()
+        {
+            Profile profile = new ProfileBuilder()
+                .WithEmployeeEarnings("ghost_user", "copper", 5)
+                .Build();
+
+            // Resolver returns null (profile gone) -> the stored userName key is shown.
+            string output = ChateauBusiness.BuildBusiness(profile, un => null);
+
+            Assert.Contains("ghost_user: [b]5 copper[/b]", output);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauBusiness.cs
+++ b/FChatDicebot/BotCommands/ChateauBusiness.cs
@@ -1,0 +1,127 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !business: an employer's read-only view of the MANOR kickbacks their employees have
+    /// earned them, broken down by employee and by currency (from Profile.employeeEarnings,
+    /// which !work increments). Not an interaction — no consent, cooldown, or DB-layer change;
+    /// it reads only the invoker's own profile, in the mold of !payroll / !economics.
+    /// </summary>
+    public class ChateauBusiness : ChatBotCommand
+    {
+        public ChateauBusiness()
+        {
+            Name = "business";
+            Aliases = new string[] { };
+            Category = "Information";
+            ShortDescription = "See what your employees have earned you";
+            LongDescription = "View the profits you've earned from the hard work of your employees, broken down by employee and by currency. You earn approximately 25% of what your employee makes, on top of what they would make if self employed.";
+            Usage = "!business";
+            RelatedCommands = new string[] { "employ", "work", "bank", "payroll" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            Profile userProfile = MonDB.getProfile(characterName);
+            string message = BuildBusiness(userProfile, MonDB.getDisplayName);
+            bot.SendPrivateMessage(message, characterName);
+        }
+
+        public const string EmptyStateMessage =
+            "None of your employees have earned you anything yet. Use !employ to put someone on the payroll, and they'll start sending MANOR kickbacks your way every time they !work.";
+
+        /// <summary>
+        /// Renders an employer's employeeEarnings ledger. <paramref name="resolveDisplayName"/>
+        /// maps an employee userName to a current display name (e.g. MonDB.getDisplayName);
+        /// when it returns null/empty (profile gone) the stored userName key is shown instead.
+        /// Pure aside from the resolver, so it can be unit-tested without a bot or DB.
+        /// </summary>
+        public static string BuildBusiness(Profile profile, Func<string, string> resolveDisplayName)
+        {
+            Dictionary<string, Dictionary<string, int>> ledger = profile?.employeeEarnings;
+
+            // Aggregate per employee, pruning any non-positive currency entries.
+            var rows = new List<EmployeeRow>();
+            if (ledger != null)
+            {
+                foreach (var employeeEntry in ledger)
+                {
+                    if (employeeEntry.Value == null)
+                        continue;
+
+                    var positive = employeeEntry.Value
+                        .Where(c => c.Value > 0)
+                        .OrderBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
+                        .ToList();
+                    if (positive.Count == 0)
+                        continue;
+
+                    string displayName = resolveDisplayName != null ? resolveDisplayName(employeeEntry.Key) : null;
+                    if (string.IsNullOrEmpty(displayName))
+                        displayName = employeeEntry.Key;
+
+                    rows.Add(new EmployeeRow
+                    {
+                        DisplayName = displayName,
+                        Currencies = positive,
+                        Total = positive.Sum(c => c.Value)
+                    });
+                }
+            }
+
+            if (rows.Count == 0)
+                return EmptyStateMessage;
+
+            // Highest-earning employees first, then alphabetical for stable ties.
+            rows = rows
+                .OrderByDescending(r => r.Total)
+                .ThenBy(r => r.DisplayName, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var grandTotals = new Dictionary<string, int>();
+            var sb = new StringBuilder();
+            sb.Append("Here's what your employees have earned you:\n");
+            foreach (EmployeeRow row in rows)
+            {
+                sb.Append("  ").Append(row.DisplayName).Append(": ");
+                sb.Append(string.Join(" | ", row.Currencies.Select(c => "[b]" + c.Value + " " + c.Key + "[/b]")));
+                sb.Append('\n');
+
+                foreach (var c in row.Currencies)
+                {
+                    if (grandTotals.ContainsKey(c.Key))
+                        grandTotals[c.Key] += c.Value;
+                    else
+                        grandTotals[c.Key] = c.Value;
+                }
+            }
+
+            string totalChips = string.Join(" | ", grandTotals
+                .OrderBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(c => "[b]" + c.Value + " " + c.Key + "[/b]"));
+            sb.Append("Total earned from all employees: ").Append(totalChips);
+
+            return sb.ToString();
+        }
+
+        private class EmployeeRow
+        {
+            public string DisplayName { get; set; }
+            public List<KeyValuePair<string, int>> Currencies { get; set; }
+            public int Total { get; set; }
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -72,6 +72,7 @@ namespace FChatDicebot.BotCommands
                 "!parasites",
                 "!payroll",
                 "!economics",
+                "!business",
                 "!joinchateau",
                 "!modmessage",
                 "!feedback [sub]!suggestion[/sub]",
@@ -148,7 +149,7 @@ namespace FChatDicebot.BotCommands
                 "!odorize",
                 "!break"
             };
-            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 21st 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
+            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 22nd 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
                     "[u]Does not require channel[/u]\n" +
                     Utils.sortedListDisplayText(generalCommands) + "\n" +
                     "[i]Recovery Commands:[/i] " + Utils.sortedListDisplayText(recoveryCommands) + "\n\n" +

--- a/FChatDicebot/BotCommands/ChateauWork.cs
+++ b/FChatDicebot/BotCommands/ChateauWork.cs
@@ -76,6 +76,10 @@ namespace FChatDicebot.BotCommands
                         // (the day's effort is still spent). See CurseProcessor.CatalogMap.
                         bool hasPovertyCurse = CurseInstance.LoadAll(userProfile)
                             .Any(c => string.Equals(c.Curse, "poverty", StringComparison.OrdinalIgnoreCase));
+                        // Capture the rolled reward so the employer kickback can be computed from it
+                        // after the loop, independently of the worker's own poverty curse (B6.3).
+                        int grantedRewardAmount = 0;
+                        string grantedRewardCurrency = null;
                         foreach (KeyValuePair<string, Reward> rewardEntry in chosenResult.rewardList)
                         {
                             randomWeightPick -= rewardEntry.Value.weight;
@@ -83,6 +87,8 @@ namespace FChatDicebot.BotCommands
                             {
                                 //grant this reward
                                 int rewardAmount = random.Next(rewardEntry.Value.min, rewardEntry.Value.max + 1); //+1 because upper bound is exclusive
+                                grantedRewardAmount = rewardAmount;
+                                grantedRewardCurrency = rewardEntry.Value.currency;
                                 if (hasPovertyCurse)
                                 {
                                     message += "You would have received [b]" + rewardAmount + " " + rewardEntry.Value.currency + "[/b], but your poverty curse makes it vanish in a poof of smoke before you can claim it.\n";
@@ -123,6 +129,34 @@ namespace FChatDicebot.BotCommands
                         }
                         MonDB.removePendingDuty(dutyInProgress.Id);
                         MonDB.setProfile(characterName, userProfile);
+
+                        // MANOR employer kickback: when a worker employed by someone else completes a
+                        // duty, their employer earns a bonus on top of (and without reducing) the
+                        // worker's reward. Computed from the rolled amount independently of the
+                        // worker's poverty curse — only the cursed party is impacted (B6.3). The
+                        // employer is never push-notified (TOS); they discover it via !business.
+                        if (grantedRewardAmount > 0
+                            && userProfile.characteristics.ContainsKey("employer")
+                            && userProfile.characteristics["employer"] != characterName)
+                        {
+                            string employerUserName = userProfile.characteristics["employer"];
+                            Profile employerProfile = MonDB.getProfile(employerUserName);
+                            if (employerProfile != null)
+                            {
+                                string employerDisplayName = MonDB.getDisplayName(employerUserName);
+                                if (string.IsNullOrEmpty(employerDisplayName))
+                                    employerDisplayName = employerUserName;
+
+                                string kickbackLine = ApplyEmployerKickback(characterName, employerProfile,
+                                    employerDisplayName, grantedRewardAmount, grantedRewardCurrency);
+                                if (!string.IsNullOrEmpty(kickbackLine))
+                                {
+                                    MonDB.setProfile(employerUserName, employerProfile);
+                                    message += kickbackLine;
+                                }
+                            }
+                        }
+
                         // Check for system title achievements after work completion
                         string titleNotification = ChateauSystemTitles.CheckAndGrantTitles(characterName);
                         if (!string.IsNullOrEmpty(titleNotification))
@@ -231,6 +265,64 @@ namespace FChatDicebot.BotCommands
                 }
                 return false;
             }
+        }
+
+        /// <summary>
+        /// The MANOR kickback an employer earns from a worker's rolled reward: a flat 25%,
+        /// floored, with a minimum of 1 whenever the roll was positive, and 0 otherwise.
+        /// Pure — extracted so the rounding rules can be unit-tested without a work session.
+        /// </summary>
+        public static int EmployerCut(int rewardAmount)
+        {
+            return rewardAmount > 0
+                ? Math.Max(1, (int)Math.Floor(rewardAmount * 0.25))
+                : 0;
+        }
+
+        /// <summary>
+        /// Applies the employer kickback to <paramref name="employerProfile"/> (wallet + the
+        /// employeeEarnings ledger) and returns the worker-facing line to append to the work
+        /// PM, or an empty string when no kickback is paid. Pays nothing — no credit, no ledger
+        /// entry, and no worker-facing line — when the cut rounds to 0 or the employer carries
+        /// their own poverty curse (we neither pay it nor leak the employer's curse to the
+        /// worker). The caller is responsible for the eligibility checks that need DB access
+        /// (employer key present, employed by someone other than self, employer profile exists)
+        /// and for persisting the mutated employer profile when a non-empty line is returned.
+        /// </summary>
+        public static string ApplyEmployerKickback(string workerUserName, Profile employerProfile,
+            string employerDisplayName, int rewardAmount, string currency)
+        {
+            int cut = EmployerCut(rewardAmount);
+            if (cut <= 0)
+                return string.Empty;
+
+            // The employer's own poverty curse voids their cut entirely.
+            bool employerHasPovertyCurse = CurseInstance.LoadAll(employerProfile)
+                .Any(c => string.Equals(c.Curse, "poverty", StringComparison.OrdinalIgnoreCase));
+            if (employerHasPovertyCurse)
+                return string.Empty;
+
+            // Credit the employer's wallet (add the currency key if absent).
+            if (employerProfile.currencies == null)
+                employerProfile.currencies = new Dictionary<string, int>();
+            if (employerProfile.currencies.ContainsKey(currency))
+                employerProfile.currencies[currency] += cut;
+            else
+                employerProfile.currencies.Add(currency, cut);
+
+            // Increment the per-employee, per-currency ledger.
+            if (employerProfile.employeeEarnings == null)
+                employerProfile.employeeEarnings = new Dictionary<string, Dictionary<string, int>>();
+            if (!employerProfile.employeeEarnings.ContainsKey(workerUserName))
+                employerProfile.employeeEarnings[workerUserName] = new Dictionary<string, int>();
+            Dictionary<string, int> ledger = employerProfile.employeeEarnings[workerUserName];
+            if (ledger.ContainsKey(currency))
+                ledger[currency] += cut;
+            else
+                ledger.Add(currency, cut);
+
+            return "Your employer " + employerDisplayName + " also gets [b]" + cut + " " + currency +
+                "[/b] for your diligent work, courtesy of the Chateau MANOR.\n";
         }
     }
 }

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -163,6 +163,7 @@
     <Compile Include="BotCommands\ChateauBirth.cs" />
     <Compile Include="BotCommands\ChateauAdminRename.cs" />
     <Compile Include="BotCommands\ChateauBank.cs" />
+    <Compile Include="BotCommands\ChateauBusiness.cs" />
     <Compile Include="BotCommands\ChateauPay.cs" />
     <Compile Include="BotCommands\ChateauSetTitle.cs" />
     <Compile Include="BotCommands\ChateauSystemTitles.cs" />

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -52,6 +52,17 @@ namespace FChatDicebot.Model
         // descriptor selection. Old entries are pruned on write (keep last 30 days).
         [BsonIgnoreIfNull]
         public Dictionary<string, int> dailyClimaxCounts { get; set; } = new Dictionary<string, int>();
+
+        // Lifetime MANOR kickbacks this profile has earned as an EMPLOYER, keyed by
+        // employee userName -> currency -> cumulative amount. Written by !work when an
+        // employee (employed by someone other than themselves) completes a duty; read
+        // by !business. Persists across employment changes (it is history), so a former
+        // employee's entry survives if they later change jobs or bosses. Display names
+        // are resolved at render time from the userName key. Lifetime cumulative; never
+        // decremented or reset in v1.
+        [BsonIgnoreIfNull]
+        public Dictionary<string, Dictionary<string, int>> employeeEarnings { get; set; }
+            = new Dictionary<string, Dictionary<string, int>>();
     }
 
     public class Pregnancy

--- a/scripts/backfill-employee-earnings.js
+++ b/scripts/backfill-employee-earnings.js
@@ -1,0 +1,210 @@
+/*
+ * Backfill Profile.employeeEarnings (B6 "employer earnings") with an ESTIMATE of the
+ * historic MANOR kickbacks employers would have earned from their employees' !work,
+ * for duties completed BEFORE the kickback hook shipped.
+ *
+ * Run with mongosh, e.g.:
+ *   mongosh "mongodb://USER:PASS@HOST:PORT" scripts/backfill-employee-earnings.js
+ * (edit DB_NAME / DRY_RUN below first; review the DRY RUN output before applying.)
+ *
+ * ── Owner-provided assumptions ────────────────────────────────────────────────
+ *   1. No one has changed jobs.        -> a resident only ever worked their CURRENT
+ *                                         characteristics.job.
+ *   2. All job experience in the        -> workCount = jobExperience[currentJob].
+ *      current job was while employed.    (Volunteering can't target your current job,
+ *                                         so this counter is pure !work completions.)
+ *   3. All currency rolls were ~average -> per roll, the amount is the midpoint of the
+ *                                         reward's [min, max] range.
+ *
+ * ── One extra modelling choice (no data exists to do better) ──────────────────
+ *   Within a duty, the player's result choice is unknown and result gating
+ *   (job-experience / training / monster / currency conditionals) can't be replayed.
+ *   RESULT_STRATEGY decides how to collapse a duty's result choices into an estimate:
+ *     "average"  (default) every result equally likely; gating ignored.
+ *     "baseline"           only the no-condition result(s) — the safe/low estimate.
+ *     "best"               the single highest-expected-reward result — the high estimate.
+ *
+ * The employer cut mirrors ChateauWork.EmployerCut exactly:
+ *   25% of the rolled amount, floored, minimum 1 when the amount is positive.
+ *
+ * ── Safety ────────────────────────────────────────────────────────────────────
+ *   - DRY_RUN = true by default: prints a per-employer summary and writes NOTHING.
+ *   - Idempotent: it recomputes from the stable jobExperience counter and $set's the
+ *     whole employeeEarnings map, so re-running produces the same result. Run this
+ *     ONCE at deploy time, BEFORE the live kickback hook starts accruing real
+ *     earnings — a run after go-live would overwrite real accruals with the estimate.
+ */
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+const DB_NAME = "chateau";          // <-- set to the live database name
+const DRY_RUN = true;               // <-- set to false to actually write
+const RESULT_STRATEGY = "average";  // "average" | "baseline" | "best"
+// ──────────────────────────────────────────────────────────────────────────────
+
+const targetDb = db.getSiblingDB(DB_NAME);
+const PROFILES = "RegisteredProfiles";
+const DUTIES = "Duties";
+
+// Mirror of ChateauWork.EmployerCut.
+function employerCut(amount) {
+    return amount > 0 ? Math.max(1, Math.floor(amount * 0.25)) : 0;
+}
+
+// Expected reward amount of a single result, weighting each currency by its weight
+// and taking the midpoint of each [min, max] range.
+function resultExpectedAmount(result) {
+    const rl = result.rewardList || {};
+    let totalWeight = 0;
+    Object.keys(rl).forEach(function (k) { totalWeight += (rl[k].weight || 0); });
+    if (totalWeight <= 0) return 0;
+    let ev = 0;
+    Object.keys(rl).forEach(function (k) {
+        const rw = rl[k];
+        ev += (rw.weight / totalWeight) * (((rw.min || 0) + (rw.max || 0)) / 2);
+    });
+    return ev;
+}
+
+// The set of results a worker is assumed to "choose" from, per RESULT_STRATEGY.
+function chosenResults(duty) {
+    const dr = duty.dutyResults || {};
+    const all = Object.keys(dr).map(function (k) { return dr[k]; });
+    if (!all.length) return [];
+
+    if (RESULT_STRATEGY === "baseline") {
+        const base = all.filter(function (r) {
+            return r.conditional && String(r.conditional.type).substr(0, 3) === "non";
+        });
+        return base.length ? base : all;
+    }
+    if (RESULT_STRATEGY === "best") {
+        let best = null, bestVal = -1;
+        all.forEach(function (r) {
+            const ev = resultExpectedAmount(r);
+            if (ev > bestVal) { bestVal = ev; best = r; }
+        });
+        return best ? [best] : [];
+    }
+    return all; // "average"
+}
+
+// 1) Load duties grouped by job.
+const dutiesByJob = {};
+targetDb.getCollection(DUTIES).find({}).forEach(function (d) {
+    if (!dutiesByJob[d.job]) dutiesByJob[d.job] = [];
+    dutiesByJob[d.job].push(d);
+});
+
+// 2) Build, per job, a per-currency model: { currency -> { prob, cut } } where
+//    prob = average per-work probability of rolling that currency, and
+//    cut  = employer cut for that currency at its average rolled amount.
+function buildJobModel(duties) {
+    const probAccum = {}; // currency -> summed probability mass across duties
+    const amtAccum = {};  // currency -> summed (prob * avgAmount) across duties
+    let dutyCount = 0;
+
+    duties.forEach(function (duty) {
+        const results = chosenResults(duty);
+        if (!results.length) return;
+        dutyCount++;
+        const perResult = 1 / results.length; // each chosen result equally likely
+        results.forEach(function (r) {
+            const rl = r.rewardList || {};
+            let totalWeight = 0;
+            Object.keys(rl).forEach(function (k) { totalWeight += (rl[k].weight || 0); });
+            if (totalWeight <= 0) return;
+            Object.keys(rl).forEach(function (k) {
+                const rw = rl[k];
+                const cur = rw.currency;
+                const pCur = perResult * (rw.weight / totalWeight);
+                const avgAmt = ((rw.min || 0) + (rw.max || 0)) / 2;
+                probAccum[cur] = (probAccum[cur] || 0) + pCur;
+                amtAccum[cur] = (amtAccum[cur] || 0) + pCur * avgAmt;
+            });
+        });
+    });
+
+    const model = {};
+    if (dutyCount === 0) return model;
+    Object.keys(probAccum).forEach(function (cur) {
+        const prob = probAccum[cur] / dutyCount;       // proper per-work distribution
+        const avgAmt = amtAccum[cur] / probAccum[cur]; // E[amount | this currency]
+        model[cur] = { prob: prob, cut: employerCut(avgAmt) };
+    });
+    return model;
+}
+
+// Job model with the same "default" fallback ChateauWork uses for jobs with no duties.
+const modelCache = {};
+function getJobModel(job) {
+    if (modelCache[job]) return modelCache[job];
+    let duties = dutiesByJob[job];
+    if (!duties || !duties.length) duties = dutiesByJob["default"] || [];
+    const m = buildJobModel(duties);
+    modelCache[job] = m;
+    return m;
+}
+
+// 3) Walk every profile and accumulate each employer's estimated earnings.
+//    earningsByEmployer: employerUserName -> employeeUserName -> currency -> amount
+const earningsByEmployer = {};
+const profiles = targetDb.getCollection(PROFILES);
+
+profiles.find({}).forEach(function (p) {
+    const ch = p.characteristics || {};
+    const worker = p.userName;
+    const employer = ch["employer"];
+    const job = ch["job"];
+    if (!employer || employer === worker || !job) return; // unemployed or self-employed
+
+    const workCount = (p.jobExperience || {})[job] || 0;
+    if (workCount <= 0) return;
+
+    const model = getJobModel(job);
+    Object.keys(model).forEach(function (cur) {
+        const m = model[cur];
+        if (m.cut <= 0) return;
+        const total = Math.round(workCount * m.prob * m.cut);
+        if (total <= 0) return;
+        if (!earningsByEmployer[employer]) earningsByEmployer[employer] = {};
+        if (!earningsByEmployer[employer][worker]) earningsByEmployer[employer][worker] = {};
+        earningsByEmployer[employer][worker][cur] =
+            (earningsByEmployer[employer][worker][cur] || 0) + total;
+    });
+});
+
+// 4) Summarize and (optionally) write.
+print("Employer-earnings backfill — strategy=" + RESULT_STRATEGY + (DRY_RUN ? " [DRY RUN]" : " [APPLYING]"));
+print("");
+
+let employerCount = 0, writeCount = 0, skipped = 0;
+Object.keys(earningsByEmployer).sort().forEach(function (employer) {
+    if (profiles.countDocuments({ userName: employer }) === 0) {
+        print("  [skip] employer not registered: " + employer);
+        skipped++;
+        return;
+    }
+    employerCount++;
+    const ledger = earningsByEmployer[employer];
+    print("Employer " + employer + ":");
+    Object.keys(ledger).sort().forEach(function (emp) {
+        const chips = Object.keys(ledger[emp]).sort().map(function (c) {
+            return ledger[emp][c] + " " + c;
+        }).join(" | ");
+        print("    " + emp + ": " + chips);
+    });
+
+    if (!DRY_RUN) {
+        profiles.updateOne({ userName: employer }, { $set: { employeeEarnings: ledger } });
+        writeCount++;
+    }
+});
+
+print("");
+print("Employers with estimated earnings: " + employerCount +
+    (skipped ? (" (" + skipped + " skipped — employer profile missing)") : ""));
+if (DRY_RUN) {
+    print("DRY RUN — nothing was written. Set DRY_RUN = false to apply.");
+} else {
+    print("Wrote employeeEarnings to " + writeCount + " employer profile(s).");
+}

--- a/wiki-docs/Feature-Requests.md
+++ b/wiki-docs/Feature-Requests.md
@@ -5,7 +5,6 @@ Features and changes, big and small, that have been proposed but not thoroughly 
 * Revisit corruption text to indicate it will be visible in other interactions, and other implications
 * A system to include multiple people in a casual interaction, and possibly other interactions.
 * !cancel and !decline (initiator and recipient geared 'remove pending interaction' commands) on top of existing time out parameters.
-* if someone is !employed by another (not themselves), give their employer some currency when the employee works. TOS prevents us from notifying the employer in response to an employee privately doing !work, so should also include some sort of command for employers to see how much employees have earned them
 * additional casual commands. lapsit, boobhat, lick, possibly more. Will it take up too much dossier space? Do they have reasonable titles to accrue?
 * !bondtree and/or !familytree which would map out all users connected to someone by N degrees of separation via bonds.
 * Some way to resurface chips, poker, other games from the underlying dicebot functionality (currently, Chateau Work has overwritten the dicebot work). Save this for after original dice bot developer pushes their most recent dicebot changes to Git, for ease of merging

--- a/wiki-docs/specs/Future-Economy/Employer-Earnings.md
+++ b/wiki-docs/specs/Future-Economy/Employer-Earnings.md
@@ -1,6 +1,7 @@
 # Employer Earnings — `!work` kickback + `!business`
 
-**Status:** Proposed (design-complete, owner-reviewed 2026-06-21).
+**Status:** ✅ Shipped 2026-06-22. `!work` kickback hook + `!business` command + `Profile.employeeEarnings` landed; final user-facing strings owner-approved (see below). A one-time historic backfill is provided at [`scripts/backfill-employee-earnings.js`](../../../scripts/backfill-employee-earnings.js).
+**Status (original):** Proposed (design-complete, owner-reviewed 2026-06-21).
 **Feature-Requests source:** "if someone is !employed by another (not themselves), give their employer some currency when the employee works… should also include some sort of command for employers to see how much employees have earned them" (B6).
 
 > The sibling request B8 ("in-system flow to walk users through creating a !work duty") was **resolved out-of-band** — there is now a short tutorial paragraph on the Chateau Contract profile, also reachable via `!modmessage duty`, and no in-bot builder will be implemented. It is intentionally not specced here.
@@ -162,10 +163,16 @@ No DB-layer (`Chateaudatabase.cs` / `Ichateaudatabase.cs`) changes — `employee
 - **B6.4** Ledger broken down by **both employee and currency**, summable to totals at display; lifetime cumulative; persists across employment changes.
 - **B6.5** View command is **`!business`**, self-only, per-employee × per-currency with totals.
 
+## Resolved on ship (owner, 2026-06-22)
+
+- **Worker-facing kickback line** — owner-approved as specced: "Your employer {employer} also gets [b]{N} {currency}[/b] for your diligent work, courtesy of the Chateau MANOR."
+- **`!business` empty-state** — owner-approved as specced.
+- **`!business` long help text** — owner-finalized to: "View the profits you've earned from the hard work of your employees, broken down by employee and by currency. You earn approximately 25% of what your employee makes, on top of what they would make if self employed."
+- **`!volunteer` exclusion** — confirmed (work-only).
+- **Historic backfill** — `scripts/backfill-employee-earnings.js` estimates pre-launch earnings from `jobExperience[currentJob]` × an average-roll model read from the `Duties` collection (assumes no job changes, all current-job experience was while employed, and average rolls). `DRY_RUN` defaults on; idempotent; run once at deploy.
+
 ## Open items
 
-- **Worker-facing kickback line** and **`!business` strings** are first drafts pending owner wording approval (house rule: surface every changed user-facing string before declaring done).
-- **`!volunteer` exclusion** decided by default (work-only) — override if volunteer income should also kick back.
 - **Admin-queryable `!business [user]`** left out of v1 — add if wanted.
 - Possible later **employer-milestone titles** (e.g. lifetime currency earned from employees) — not in scope.
 


### PR DESCRIPTION
## Overview

Implements **B6 employer earnings** from the Feature-Requests backlog. When a resident employed by *someone else* completes `!work`, their employer now earns a **25% MANOR kickback** (floored, minimum 1) on top of the worker's reward — the worker keeps their full pay, and the employer is never billed (lore-consistent with `!bank`'s MANOR explanation). A new `!business` command lets employers see what their employees have earned them.

Design spec: `wiki-docs/specs/Future-Economy/Employer-Earnings.md` (owner-reviewed; final user-facing strings approved this session).

## What changed

- **`Profile.employeeEarnings`** — new lifetime ledger (`employee userName -> currency -> cumulative`). `[BsonIgnoreIfNull]`, no migration; rides existing `GetProfile`/`SetProfile` (no DB-layer change).
- **`!work` kickback hook** (`ChateauWork.cs`) — pays the employer a bonus on top of the worker's reward. Computed from the *rolled* amount independently of the worker's poverty curse (only the cursed party is impacted); the employer's *own* poverty curse silently voids the cut (no credit, no ledger entry, no worker-facing line). Math extracted into testable statics `EmployerCut(int)` and `ApplyEmployerKickback(...)`.
- **`!business`** (`ChateauBusiness.cs`) — self-only Information command. Testable `BuildBusiness(Profile, resolver)`; employees sorted by total desc, currencies alphabetical, grand-totals line, empty-state fallback. Display names resolved at render (falls back to stored userName key).
- **Registration** — added `!business` to the hand-maintained help index in `ChateauHelp.cs` (dispatch + `!help business` detail are reflection-driven); added the new file to `FChatDicebot.csproj`.
- **Historic backfill** — `scripts/backfill-employee-earnings.js` (mongosh): one-time estimate of pre-launch earnings = `jobExperience[currentJob]` x an average-roll model read from the live `Duties` collection. `DRY_RUN` defaults on; idempotent. Already run successfully against the live DB.
- Worker-facing kickback line and `!business` help text are owner-final.

## Scope notes for reviewers

- **`!work` only, not `!volunteer`** (volunteering is exploring other careers, not doing your job for your boss).
- `!business` is **self-only** in v1; admin-queryable `!business [user]` was intentionally deferred.
- The kickback is a MANOR-funded bonus — it does **not** reduce the worker's reward.
- Backfill `RESULT_STRATEGY` knob handles the one unknowable input (which duty result a player chose): `average` (default), `baseline` (low), or `best` (high).

## Testing

- 19 new unit tests (`Chateaubusinesstests.cs`): `EmployerCut` rounding, `ApplyEmployerKickback` (wallet/ledger mutation, poverty-curse voiding, zero-roll), and `BuildBusiness` rendering (empty, single, multi-employee sort + grand totals, zero-pruning, display-name fallback).
- Full suite green: **1251 passing**. Build clean (0 errors).

B6 bullet retired from `Feature-Requests.md`; spec marked shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)