### PR TITLE
Add !bondtree / !familytree bond-graph readouts (B10)

### DIFF
--- a/FChatDicebot.Tests/Unit/Chateaubondtreetests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubondtreetests.cs
@@ -1,0 +1,244 @@
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Unit tests for BondTreeSupport.BuildBondTree, exercising traversal and rendering over a
+    /// synthetic profile graph (an in-memory Func&lt;string, Profile&gt;), so no live DB is needed.
+    /// </summary>
+    public class ChateauBondtreeTests
+    {
+        // ---- Graph helpers -------------------------------------------------
+
+        private readonly Dictionary<string, Profile> _graph =
+            new Dictionary<string, Profile>(StringComparer.OrdinalIgnoreCase);
+
+        private Func<string, Profile> Lookup =>
+            u => _graph.TryGetValue(u ?? string.Empty, out Profile p) ? p : null;
+
+        /// <summary>
+        /// Add a person to the graph. bonds entries are (listLabel, neighborUserName) pairs, e.g.
+        /// ("bondpetinitiated", "Bob"). The display name defaults to the userName.
+        /// </summary>
+        private Profile AddPerson(string userName, string displayName = null, params (string list, string neighbor)[] bonds)
+        {
+            var builder = new ProfileBuilder()
+                .WithUserName(userName)
+                .WithDisplayName(displayName ?? userName);
+            foreach (var b in bonds)
+            {
+                builder.WithListItem(b.list, b.neighbor);
+            }
+            Profile p = builder.Build();
+            _graph[userName] = p;
+            return p;
+        }
+
+        private static int Count(string haystack, string needle)
+        {
+            int count = 0, index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                index += needle.Length;
+            }
+            return count;
+        }
+
+        // ---- Empty state ---------------------------------------------------
+
+        [Fact]
+        public void NoBonds_BondTree_ReturnsEmptyState()
+        {
+            AddPerson("Alice", "Alice");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
+
+            Assert.Equal("Alice has no bonds yet.", result);
+        }
+
+        [Fact]
+        public void NoBonds_FamilyTree_ReturnsFamilyEmptyState()
+        {
+            AddPerson("Alice", "Alice");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: true, Lookup);
+
+            Assert.Equal("Alice has no family bonds yet.", result);
+        }
+
+        [Fact]
+        public void OnlyNonFamilyBonds_FamilyTree_ReturnsFamilyEmptyState()
+        {
+            AddPerson("Alice", "Alice", ("bondpetinitiated", "Bob"));
+            AddPerson("Bob", "Bob");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: true, Lookup);
+
+            Assert.Equal("Alice has no family bonds yet.", result);
+        }
+
+        // ---- Direct bonds + perspective ------------------------------------
+
+        [Fact]
+        public void DirectBonds_RendersRolesFromBothPerspectives()
+        {
+            // Alice initiated a pet bond with Bob (Bob is Alice's pet), and received a submission
+            // bond from Dom (Dom is Alice's dominant).
+            AddPerson("Alice", "Alice",
+                ("bondpetinitiated", "Bob"),
+                ("bondsubmissionreceived", "Dom"));
+            AddPerson("Bob", "Bob");
+            AddPerson("Dom", "Dom");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 1, familyOnly: false, Lookup);
+
+            Assert.Contains("Bond tree for Alice, up to 1 degree:", result);
+            Assert.Contains("1st degree:", result);
+            Assert.Contains("Bob (Alice's pet)", result);     // initiated → BondToText(type, true)
+            Assert.Contains("Dom (Alice's dominant)", result); // received  → BondToText(type, false)
+        }
+
+        // ---- Second degree + dedup to shallowest ---------------------------
+
+        [Fact]
+        public void SecondDegree_PersonReachableAtBothDepths_AppearsOnceAtShallowest()
+        {
+            // Alice—Bob (sibling) and Alice—Carol (ally) are both 1st degree.
+            // Bob—Carol (sibling) would put Carol at 2nd degree too, but she must stay at 1st.
+            // Bob—Dave (sibling) is a genuine 2nd-degree node.
+            AddPerson("Alice", "Alice",
+                ("bondsiblinginitiated", "Bob"),
+                ("bondallyinitiated", "Carol"));
+            AddPerson("Bob", "Bob",
+                ("bondsiblinginitiated", "Carol"),
+                ("bondsiblinginitiated", "Dave"));
+            AddPerson("Carol", "Carol");
+            AddPerson("Dave", "Dave");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
+
+            Assert.Contains("Carol (Alice's ally)", result);  // reached at 1st degree, via Alice
+            Assert.DoesNotContain("Carol (Bob's", result);    // never the 2nd-degree label
+            Assert.Equal(1, Count(result, "Carol ("));        // appears exactly once
+            Assert.Contains("2nd degree:", result);
+            Assert.Contains("Dave (Bob's sibling)", result);  // genuine 2nd-degree node
+        }
+
+        // ---- Cycles --------------------------------------------------------
+
+        [Fact]
+        public void Cycle_Terminates_AndListsEachPersonOnce()
+        {
+            // Triangle A→B→C→A, with the symmetric initiated/received records the bond
+            // interaction writes on both ends of every edge.
+            AddPerson("A", "A",
+                ("bondallyinitiated", "B"),   // A initiated with B
+                ("bondallyreceived", "C"));   // C initiated with A
+            AddPerson("B", "B",
+                ("bondallyreceived", "A"),    // A→B
+                ("bondallyinitiated", "C"));  // B initiated with C
+            AddPerson("C", "C",
+                ("bondallyreceived", "B"),    // B→C
+                ("bondallyinitiated", "A"));  // C→A
+
+            string result = BondTreeSupport.BuildBondTree("A", 3, familyOnly: false, Lookup);
+
+            // Each non-root node appears exactly once; the root is never listed as a connection.
+            Assert.Equal(1, Count(result, "B (A's ally)"));
+            Assert.Equal(1, Count(result, "C (A's ally)"));
+            Assert.DoesNotContain("A (", result);
+        }
+
+        // ---- Family-only filter --------------------------------------------
+
+        [Fact]
+        public void FamilyOnly_IncludesFamilyBonds_ExcludesOthers()
+        {
+            AddPerson("Alice", "Alice",
+                ("bondsiblinginitiated", "Sib"),
+                ("bondpetinitiated", "Pet"),
+                ("bondrivalreceived", "Riv"));
+            AddPerson("Sib", "Sib");
+            AddPerson("Pet", "Pet");
+            AddPerson("Riv", "Riv");
+
+            string familyResult = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: true, Lookup);
+            Assert.Contains("Sib", familyResult);
+            Assert.DoesNotContain("Pet", familyResult);
+            Assert.DoesNotContain("Riv", familyResult);
+
+            // Sanity: the all-bonds variant includes all three.
+            string allResult = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
+            Assert.Contains("Sib", allResult);
+            Assert.Contains("Pet", allResult);
+            Assert.Contains("Riv", allResult);
+        }
+
+        // ---- Node cap ------------------------------------------------------
+
+        [Fact]
+        public void NodeCap_StopsAt100_AppendsLimitReached()
+        {
+            var bonds = new List<(string, string)>();
+            for (int i = 0; i < 150; i++)
+            {
+                string name = "U" + i;
+                bonds.Add(("bondallyinitiated", name));
+                AddPerson(name, name);
+            }
+            AddPerson("Root", "Root", bonds.ToArray());
+
+            string result = BondTreeSupport.BuildBondTree("Root", 1, familyOnly: false, Lookup);
+
+            Assert.Contains("limit reached", result);
+            Assert.Equal(BondTreeSupport.MaxNodes, Count(result, "(Root's ally)"));
+        }
+
+        // ---- Depth clamp ---------------------------------------------------
+
+        [Fact]
+        public void DepthClamp_AboveMax_BehavesAsThreeDegrees()
+        {
+            AddPerson("Alpha", "Alpha", ("bondallyinitiated", "Bravo"));
+            AddPerson("Bravo", "Bravo", ("bondallyinitiated", "Charlie"));
+            AddPerson("Charlie", "Charlie", ("bondallyinitiated", "Delta"));
+            AddPerson("Delta", "Delta", ("bondallyinitiated", "Echo"));
+            AddPerson("Echo", "Echo");
+
+            string result = BondTreeSupport.BuildBondTree("Alpha", 5, familyOnly: false, Lookup);
+
+            Assert.Contains("up to 3 degrees:", result);
+            Assert.Contains("Bravo", result);
+            Assert.Contains("Charlie", result);
+            Assert.Contains("Delta", result);
+            Assert.DoesNotContain("Echo", result); // 4th degree, beyond the clamped max
+
+            // Identical to an explicit N=3 request.
+            string atThree = BondTreeSupport.BuildBondTree("Alpha", 3, familyOnly: false, Lookup);
+            Assert.Equal(atThree, result);
+        }
+
+        // ---- Missing neighbor profile --------------------------------------
+
+        [Fact]
+        public void MissingNeighborProfile_FallsBackToUserName_TraversalContinues()
+        {
+            // Ghost is referenced in Alice's bond list but has no profile in the graph.
+            AddPerson("Alice", "Alice",
+                ("bondpetinitiated", "Ghost"),
+                ("bondsiblinginitiated", "Bob"));
+            AddPerson("Bob", "Bob");
+
+            string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
+
+            Assert.Contains("Ghost (Alice's pet)", result); // falls back to the stored userName
+            Assert.Contains("Bob (Alice's sibling)", result); // traversal still reaches the rest
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauBondtree.cs
+++ b/FChatDicebot/BotCommands/ChateauBondtree.cs
@@ -1,0 +1,66 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !bondtree — read-only walk of the bond graph that lists everyone connected to a resident
+    /// within N degrees of separation, across every bond type. Public, consent-free (bonds are
+    /// mutually declared, public facts); result is PM'd to the invoker. Shares its traversal with
+    /// !familytree via <see cref="BondTreeSupport"/>, differing only in the type filter.
+    /// </summary>
+    public class ChateauBondtree : ChatBotCommand
+    {
+        private readonly IChateauDatabase _database;
+
+        public ChateauBondtree(IChateauDatabase database)
+        {
+            _database = database;
+            Name = "bondtree";
+            Aliases = new string[] { };
+            Category = "Information";
+            ShortDescription = "Map everyone connected to a resident by bonds, N degrees out";
+            LongDescription = "Walks the bond graph and lists everyone connected to a resident within N degrees of separation, across every bond type, grouped by degree. " +
+                "Bonds are public, so no consent is needed. The result is sent to you in a private message.\n" +
+                "Defaults to yourself and 2 degrees. Pass a name to root the tree on someone else, and/or a number (1-3) to set the depth.";
+            Usage = "!bondtree\nor\n!bondtree [noparse][user]CharacterName[/user][/noparse]\nor\n!bondtree [noparse][user]CharacterName[/user][/noparse] 3";
+            RelatedCommands = new string[] { "bond", "dossier" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        /// <summary>
+        /// Legacy constructor for the reflection-based command loader (uses MonDB).
+        /// </summary>
+        public ChateauBondtree() : this(MonDB.GetDatabase())
+        {
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string targetUser = commandController.GetUserNameFromCommandTerms(rawTerms);
+            if (string.IsNullOrWhiteSpace(targetUser))
+            {
+                targetUser = characterName;
+            }
+
+            Profile rootProfile = _database.GetProfile(targetUser);
+            if (rootProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(targetUser), characterName);
+                return;
+            }
+
+            int degrees = BondTreeSupport.ParseDegrees(terms);
+            string message = BondTreeSupport.BuildBondTree(targetUser, degrees, familyOnly: false, _database.GetProfile);
+            bot.SendPrivateMessage(message, characterName);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauFamilytree.cs
+++ b/FChatDicebot/BotCommands/ChateauFamilytree.cs
@@ -1,0 +1,66 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !familytree — the family-only sibling of !bondtree. Same read-only bond-graph walk, but
+    /// restricted to the family bond subset (marriage, offspring, sibling, family/kin). Public,
+    /// consent-free; result is PM'd to the invoker. A real command rather than an alias, because
+    /// it differs from !bondtree in the type filter it passes to <see cref="BondTreeSupport"/>.
+    /// </summary>
+    public class ChateauFamilytree : ChatBotCommand
+    {
+        private readonly IChateauDatabase _database;
+
+        public ChateauFamilytree(IChateauDatabase database)
+        {
+            _database = database;
+            Name = "familytree";
+            Aliases = new string[] { };
+            Category = "Information";
+            ShortDescription = "Map a resident's family bonds, N degrees out";
+            LongDescription = "Walks only the family bonds (marriage, offspring, sibling, kin) and lists everyone connected to a resident within N degrees of separation, grouped by degree. " +
+                "Bonds are public, so no consent is needed. The result is sent to you in a private message.\n" +
+                "Defaults to yourself and 2 degrees. Pass a name to root the tree on someone else, and/or a number (1-3) to set the depth.";
+            Usage = "!familytree\nor\n!familytree [noparse][user]CharacterName[/user][/noparse]\nor\n!familytree [noparse][user]CharacterName[/user][/noparse] 3";
+            RelatedCommands = new string[] { "bond", "dossier" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        /// <summary>
+        /// Legacy constructor for the reflection-based command loader (uses MonDB).
+        /// </summary>
+        public ChateauFamilytree() : this(MonDB.GetDatabase())
+        {
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            string targetUser = commandController.GetUserNameFromCommandTerms(rawTerms);
+            if (string.IsNullOrWhiteSpace(targetUser))
+            {
+                targetUser = characterName;
+            }
+
+            Profile rootProfile = _database.GetProfile(targetUser);
+            if (rootProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(targetUser), characterName);
+                return;
+            }
+
+            int degrees = BondTreeSupport.ParseDegrees(terms);
+            string message = BondTreeSupport.BuildBondTree(targetUser, degrees, familyOnly: true, _database.GetProfile);
+            bot.SendPrivateMessage(message, characterName);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -54,6 +54,8 @@ namespace FChatDicebot.BotCommands
             List<string> generalCommands = new List<string>()
             {
                 "!dossier [sub]!profile, !bio[/sub] ",
+                "!bondtree",
+                "!familytree",
                 "!work [sub]!w[/sub]",
                 "!volunteer [sub]!v[/sub]",
                 "!bank [sub]!balance, !money[/sub]",

--- a/FChatDicebot/BotCommands/Support/BondTreeSupport.cs
+++ b/FChatDicebot/BotCommands/Support/BondTreeSupport.cs
@@ -1,0 +1,244 @@
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// Shared bond-graph traversal behind !bondtree and !familytree. Both commands walk the
+    /// same graph and differ only by which bond types are included, so the whole traversal +
+    /// rendering lives in one pure-ish static builder over an injected profile lookup
+    /// (testable without a live DB).
+    ///
+    /// The bond interaction writes both directions as profile lists: on the initiator
+    /// "bond{type}initiated" → recipient userNames, and on the recipient "bond{type}received"
+    /// → initiator userNames (see BondProcessor). A person's neighbors are therefore the union,
+    /// over every bond type, of those two list families; the graph is symmetric and walkable
+    /// one profile at a time. No DB-layer change — this rides existing GetProfile reads.
+    /// </summary>
+    public static class BondTreeSupport
+    {
+        /// <summary>
+        /// Family subset (B10.1). "family" and "kin" are the same bond — bond type "family"
+        /// renders as the role "kin" — so this is four bond types, not five. Shared so any
+        /// future family-only feature filters identically.
+        /// </summary>
+        public static readonly string[] FamilyBondTypes = { "marriage", "offspring", "sibling", "family" };
+
+        // B10.2 tuning: default 2 degrees, hard max of 3, hard cap of 100 distinct people rendered.
+        public const int DefaultDegrees = 2;
+        public const int MaxDegrees = 3;
+        public const int MaxNodes = 100;
+
+        // Past this assembled length the body is tucked behind a [spoiler] so the PM doesn't
+        // arrive as a wall of text (and stays clear of the F-Chat 4096-char message cap).
+        public const int SpoilerThreshold = 1900;
+
+        /// <summary>
+        /// Pull the optional depth argument out of the parsed command terms: the first term that
+        /// parses as an integer wins, otherwise <see cref="DefaultDegrees"/>. Clamping to the
+        /// [1, MaxDegrees] range is left to <see cref="BuildBondTree"/> so it happens in one place.
+        /// </summary>
+        public static int ParseDegrees(string[] terms)
+        {
+            if (terms != null)
+            {
+                foreach (string term in terms)
+                {
+                    if (int.TryParse(term, out int parsed))
+                    {
+                        return parsed;
+                    }
+                }
+            }
+            return DefaultDegrees;
+        }
+
+        /// <summary>
+        /// Walk the bond graph outward from <paramref name="rootUserName"/> and render everyone
+        /// within <paramref name="degrees"/> degrees, grouped by degree. <paramref name="familyOnly"/>
+        /// restricts the walk to <see cref="FamilyBondTypes"/> (the !familytree variant).
+        /// <paramref name="getProfile"/> is the only DB dependency, injected so tests can supply a
+        /// synthetic graph.
+        /// </summary>
+        public static string BuildBondTree(string rootUserName, int degrees, bool familyOnly,
+                                           Func<string, Profile> getProfile)
+        {
+            degrees = Math.Max(1, Math.Min(degrees, MaxDegrees));
+
+            Profile rootProfile = getProfile(rootUserName);
+            string rootDisplay = ResolveDisplay(rootProfile, rootUserName);
+
+            // BFS so each person is first reached — and therefore recorded — at their shallowest
+            // degree. visited is keyed case-insensitively so cycles (mutual / diamond bonds)
+            // terminate even when a name's casing differs between the two ends of an edge.
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { rootUserName };
+            var byDegree = new SortedDictionary<int, List<Connection>>();
+            var frontier = new Queue<FrontierNode>();
+            frontier.Enqueue(new FrontierNode(rootUserName, 0));
+
+            int rendered = 0;
+            bool capReached = false;
+
+            while (frontier.Count > 0 && !capReached)
+            {
+                FrontierNode node = frontier.Dequeue();
+                if (node.Degree >= degrees) continue; // reached the depth limit; don't expand further
+
+                Profile profile = getProfile(node.UserName);
+                if (profile == null || profile.lists == null) continue; // missing profile: can't expand
+                string connectorDisplay = ResolveDisplay(profile, node.UserName);
+
+                foreach (BondEdge edge in EnumerateBondEdges(profile, familyOnly))
+                {
+                    if (visited.Contains(edge.NeighborUserName)) continue;
+                    if (rendered >= MaxNodes) { capReached = true; break; }
+
+                    visited.Add(edge.NeighborUserName);
+                    int neighborDegree = node.Degree + 1;
+
+                    Profile neighborProfile = getProfile(edge.NeighborUserName);
+                    string neighborDisplay = ResolveDisplay(neighborProfile, edge.NeighborUserName);
+
+                    // Role is the neighbor's relationship to the person they were reached from,
+                    // mirroring BondProcessor's perspective: reached via the parent's *initiated*
+                    // list → the neighbor is the parent's BondToText(type, true); via *received* →
+                    // BondToText(type, false).
+                    string role = Utils.BondToText(edge.BondType, edge.ViaInitiated);
+
+                    if (!byDegree.ContainsKey(neighborDegree))
+                        byDegree[neighborDegree] = new List<Connection>();
+                    byDegree[neighborDegree].Add(new Connection(neighborDisplay, connectorDisplay, role));
+                    rendered++;
+
+                    frontier.Enqueue(new FrontierNode(edge.NeighborUserName, neighborDegree));
+                }
+            }
+
+            return Render(rootDisplay, degrees, familyOnly, byDegree, capReached);
+        }
+
+        /// <summary>
+        /// Yield every bond neighbor of a profile as (neighbor, bondType, viaInitiated) by
+        /// scanning its "bond{type}initiated" / "bond{type}received" lists, restricted to
+        /// <see cref="FamilyBondTypes"/> when <paramref name="familyOnly"/>.
+        /// </summary>
+        private static IEnumerable<BondEdge> EnumerateBondEdges(Profile profile, bool familyOnly)
+        {
+            foreach (KeyValuePair<string, List<string>> kv in profile.lists)
+            {
+                string key = kv.Key;
+                if (kv.Value == null || kv.Value.Count == 0) continue;
+                if (!key.StartsWith("bond")) continue;
+
+                bool viaInitiated;
+                string bondType;
+                if (key.EndsWith("initiated"))
+                {
+                    viaInitiated = true;
+                    bondType = key.Substring(4, key.Length - 4 - "initiated".Length);
+                }
+                else if (key.EndsWith("received"))
+                {
+                    viaInitiated = false;
+                    bondType = key.Substring(4, key.Length - 4 - "received".Length);
+                }
+                else
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrEmpty(bondType)) continue;
+                if (familyOnly && Array.IndexOf(FamilyBondTypes, bondType) < 0) continue;
+
+                foreach (string neighbor in kv.Value)
+                {
+                    if (string.IsNullOrEmpty(neighbor)) continue;
+                    yield return new BondEdge(neighbor, bondType, viaInitiated);
+                }
+            }
+        }
+
+        private static string Render(string rootDisplay, int degrees, bool familyOnly,
+                                     SortedDictionary<int, List<Connection>> byDegree, bool capReached)
+        {
+            bool anyConnections = byDegree.Any(kv => kv.Value.Count > 0);
+            if (!anyConnections)
+            {
+                // Empty-state wording pending owner review.
+                return familyOnly
+                    ? rootDisplay + " has no family bonds yet."
+                    : rootDisplay + " has no bonds yet.";
+            }
+
+            string treeLabel = familyOnly ? "Family tree" : "Bond tree";
+            string header = "[b]" + treeLabel + " for " + rootDisplay + ", up to " + degrees +
+                            (degrees == 1 ? " degree:" : " degrees:") + "[/b]";
+
+            StringBuilder body = new StringBuilder();
+            foreach (KeyValuePair<int, List<Connection>> kv in byDegree)
+            {
+                if (kv.Value.Count == 0) continue;
+                body.Append("\n[u]").Append(kv.Key).Append(Utils.GetDaySuffix(kv.Key)).Append(" degree:[/u]");
+                foreach (Connection c in kv.Value.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
+                {
+                    body.Append("\n  ").Append(c.Name).Append(" (").Append(c.ConnectorName)
+                        .Append("'s ").Append(c.Role).Append(")");
+                }
+            }
+            if (capReached)
+            {
+                body.Append("\n…and more (limit reached)");
+            }
+
+            string bodyText = body.ToString();
+            if (header.Length + bodyText.Length > SpoilerThreshold)
+            {
+                return header + "\n[spoiler]" + bodyText.TrimStart('\n') + "[/spoiler]";
+            }
+            return header + bodyText;
+        }
+
+        private static string ResolveDisplay(Profile profile, string fallbackUserName)
+        {
+            return profile != null && !string.IsNullOrEmpty(profile.displayName)
+                ? profile.displayName
+                : fallbackUserName;
+        }
+
+        private struct FrontierNode
+        {
+            public readonly string UserName;
+            public readonly int Degree;
+            public FrontierNode(string userName, int degree) { UserName = userName; Degree = degree; }
+        }
+
+        private struct BondEdge
+        {
+            public readonly string NeighborUserName;
+            public readonly string BondType;
+            public readonly bool ViaInitiated;
+            public BondEdge(string neighbor, string bondType, bool viaInitiated)
+            {
+                NeighborUserName = neighbor;
+                BondType = bondType;
+                ViaInitiated = viaInitiated;
+            }
+        }
+
+        private struct Connection
+        {
+            public readonly string Name;
+            public readonly string ConnectorName;
+            public readonly string Role;
+            public Connection(string name, string connectorName, string role)
+            {
+                Name = name;
+                ConnectorName = connectorName;
+                Role = role;
+            }
+        }
+    }
+}

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -195,6 +195,9 @@
     <Compile Include="BotCommands\ChateauPayroll.cs" />
     <Compile Include="BotCommands\ChateauEconomics.cs" />
     <Compile Include="BotCommands\Support\ChateauStatisticsSupport.cs" />
+    <Compile Include="BotCommands\Support\BondTreeSupport.cs" />
+    <Compile Include="BotCommands\ChateauBondtree.cs" />
+    <Compile Include="BotCommands\ChateauFamilytree.cs" />
     <Compile Include="BotCommands\ChateauIdentifiers.cs" />
     <Compile Include="BotCommands\ChateauIdentifier.cs" />
     <Compile Include="BotCommands\ChateauHandhold.cs" />

--- a/wiki-docs/Feature-Requests.md
+++ b/wiki-docs/Feature-Requests.md
@@ -7,7 +7,6 @@ Features and changes, big and small, that have been proposed but not thoroughly 
 * !cancel and !decline (initiator and recipient geared 'remove pending interaction' commands) on top of existing time out parameters.
 * if someone is !employed by another (not themselves), give their employer some currency when the employee works. TOS prevents us from notifying the employer in response to an employee privately doing !work, so should also include some sort of command for employers to see how much employees have earned them
 * additional casual commands. lapsit, boobhat, lick, possibly more. Will it take up too much dossier space? Do they have reasonable titles to accrue?
-* !bondtree and/or !familytree which would map out all users connected to someone by N degrees of separation via bonds.
 * Some way to resurface chips, poker, other games from the underlying dicebot functionality (currently, Chateau Work has overwritten the dicebot work). Save this for after original dice bot developer pushes their most recent dicebot changes to Git, for ease of merging
 * Random events, to encourage spontaneous chat activity. Responding to a random event would always start !random but might also require an additional argument, to slow down campers/snipers
 * Audit existing commands for sensible new aliases (and check for collisions before adding any). Surfaced while speccing !refuse/!withdraw, whose short aliases !r and !w need a collision check against the live command table.


### PR DESCRIPTION
## What

Two read-only commands that walk the bond graph and list everyone connected to a resident within N degrees of separation, grouped by degree and PM'd to the invoker. Implements **B10** from the Feature-Requests backlog (spec: `wiki-docs/specs/Future-Social/Bond-Tree.md`).

- **`!bondtree [user] [N]`** — walks **all** bond types.
- **`!familytree [user] [N]`** — walks only the family subset (`marriage`, `offspring`, `sibling`, `family`/kin — one type, since family == kin).

Both default to yourself at 2 degrees; an optional `[user]` re-roots the tree (public info, no consent) and an optional integer sets the depth.

## Why

Bonds are mutually declared, public facts already stored on both ends as profile lists (`bond{type}initiated` / `bond{type}received`). Surfacing the graph lets residents see their web of relationships at a glance. The reads ride the existing `GetProfile` path, so there is **no DB-layer change**.

## How

- A shared, DB-free static builder `BondTreeSupport.BuildBondTree(root, degrees, familyOnly, getProfile)` holds the whole traversal so both commands are thin shells and the logic is unit-testable over a synthetic profile graph.
- BFS dedups case-insensitively: cycles (mutual / diamond bonds) terminate, and each person appears once at their shallowest degree. The root is degree 0 and never listed as a connection.
- Depth clamps to `[1, 3]` (default 2). Rendering caps at **100** connections, appending a "…and more (limit reached)" note rather than ballooning the output, and tucks long results behind a `[spoiler]`.
- Edge roles use `Utils.BondToText` with the `BondProcessor` perspective (initiated → `BondToText(type, true)`, received → `false`), labeled relative to whoever connected each person — e.g. `Bob (Alice's pet)`. This connector-relative phrasing was the spec's open item; confirmed with the owner.

## Sample output

```
[b]Bond tree for Alice, up to 2 degrees:[/b]
[u]1st degree:[/u]
  Bob (Alice's pet)
  Dom (Alice's dominant)
[u]2nd degree:[/u]
  Dave (Bob's sibling)
```

## Files

- **New:** `BondTreeSupport.cs`, `ChateauBondtree.cs`, `ChateauFamilytree.cs`, `Chateaubondtreetests.cs`
- **Modified:** `FChatDicebot.csproj` (3 explicit `Compile Include` entries — required here), `ChateauHelp.cs` (registered both), `wiki-docs/Feature-Requests.md` (retired the B10 bullet)

## Testing

- 10 new unit tests (empty state, both perspectives, second-degree dedup, cycle termination, family-only filter, 100-node cap, depth clamp, missing-profile fallback) — all green.
- Clean build of both projects. The full suite was **not** run end-to-end because the other test collections require a live Mongo connection; the new tests are DB-free by design.

## Reviewer notes — user-facing wording (pending owner approval)

The header (`Bond tree for {Root}, up to N degrees:` / `Family tree for …`), empty states (`{Root} has no bonds yet.` / `… no family bonds yet.`), and the cap note are first-draft. The familytree header label ("Family tree") and the silent depth-clamp (asking for 5 just shows "up to 3 degrees") are easy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)