### PR TITLE
Real cooldown facts in consent warnings; welcome + corruption disclosure (B1/B2/B3)

### DIFF
--- a/FChatDicebot.Tests/Unit/Bondprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Bondprocessortests.cs
@@ -275,6 +275,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.Contains("Bob", warning);
             Assert.Contains("[b]", warning);
             Assert.Contains("not be taken lightly", warning);
+            // Bond's cooldown binds both parties globally, so the clause is not per-pair.
+            Assert.Contains("You can only declare a bond once per day.", warning);
+            Assert.DoesNotContain("between the two of you", warning);
             Assert.Contains("!consent", warning);
         }
 

--- a/FChatDicebot.Tests/Unit/ConsentWarningTextTests.cs
+++ b/FChatDicebot.Tests/Unit/ConsentWarningTextTests.cs
@@ -1,0 +1,131 @@
+using FChatDicebot.InteractionProcessors;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Unit coverage for the shared consent-warning composer and the CooldownSpec help
+    /// formatter — the single source of truth behind every "[b]This should not be taken
+    /// lightly...[/b]" block and the derived !help cooldown strings.
+    /// </summary>
+    public class ConsentWarningTextTests
+    {
+        [Theory]
+        [InlineData(1, "day")]
+        [InlineData(7, "week")]
+        public void PeriodWord_RendersDayAndWeek(int days, string expected)
+        {
+            Assert.Equal(expected, ConsentWarningText.PeriodWord(days));
+        }
+
+        [Fact]
+        public void Block_WrapsOpenerAndClauses_SkippingEmpties()
+        {
+            string block = ConsentWarningText.Block("First clause.", "", null, "Second clause.");
+
+            Assert.Equal("[b]This should not be taken lightly. First clause. Second clause.[/b]", block);
+        }
+
+        [Fact]
+        public void Block_WithNoClauses_IsJustTheOpener()
+        {
+            Assert.Equal("[b]This should not be taken lightly.[/b]", ConsentWarningText.Block());
+        }
+
+        // Shape A — both parties.
+        [Fact]
+        public void FrequencyBoth_RendersBetweenTheTwoOfYou()
+        {
+            Assert.Equal(
+                "You can only declare a bond between the two of you once per day.",
+                ConsentWarningText.FrequencyBoth("declare a bond", 1));
+        }
+
+        // Shape B — recipient, globally.
+        [Theory]
+        [InlineData("employed", 1, "You can only be employed once per day.")]
+        [InlineData("monsterized", 7, "You can only be monsterized once per week.")]
+        public void FrequencyRecipient_RendersRecipientFramedParticiple(string participle, int days, string expected)
+        {
+            Assert.Equal(expected, ConsentWarningText.FrequencyRecipient(participle, days));
+        }
+
+        // Shape C — per-axis on the initiator, named.
+        [Fact]
+        public void FrequencyPerAxis_NamesInitiatorAndAxis()
+        {
+            Assert.Equal(
+                "Alice can only dose you with a given vice once per week.",
+                ConsentWarningText.FrequencyPerAxis("Alice", "dose you with a given vice", 7));
+        }
+
+        // Shape D — per-day magnitude quota on the initiator, named.
+        [Fact]
+        public void FrequencyQuota_NamesInitiatorAndMagnitude()
+        {
+            Assert.Equal(
+                "Alice can only corrupt you by 10 per day.",
+                ConsentWarningText.FrequencyQuota("Alice", "corrupt", 10, 1));
+        }
+
+        [Fact]
+        public void ConsumedClause_ShowsSpentMagnitudeWhenPositive()
+        {
+            Assert.Equal(
+                "Alice has already corrupted you by 2 today.",
+                ConsentWarningText.ConsumedClause("Alice", "corrupted", 2));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void ConsumedClause_SuppressedWhenNothingSpent(int used)
+        {
+            Assert.Equal("", ConsentWarningText.ConsumedClause("Alice", "corrupted", used));
+        }
+
+        // -------------------------------------------------------------------
+        // CooldownSpec — derived help / !whatis strings
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void FormatDuration_OneDayCooldown()
+        {
+            var spec = new CooldownSpec { Kind = CooldownKind.Cooldown, Binds = CooldownBinds.Recipient, PeriodDays = 1 };
+            Assert.Equal("1 Day", spec.FormatDuration());
+        }
+
+        [Fact]
+        public void FormatDuration_SevenDayCooldown()
+        {
+            var spec = new CooldownSpec { Kind = CooldownKind.Cooldown, Binds = CooldownBinds.Initiator, PeriodDays = 7, Scope = "vice" };
+            Assert.Equal("7 Days", spec.FormatDuration());
+        }
+
+        [Fact]
+        public void FormatDuration_MagnitudeQuota()
+        {
+            var spec = new CooldownSpec { Kind = CooldownKind.MagnitudeQuota, Binds = CooldownBinds.Initiator, PeriodDays = 1, QuotaMagnitude = 10 };
+            Assert.Equal("Daily quota (10 magnitude per recipient)", spec.FormatDuration());
+        }
+
+        [Theory]
+        [InlineData(CooldownBinds.Both, null, "both initiator and recipient")]
+        [InlineData(CooldownBinds.Recipient, null, "recipient")]
+        [InlineData(CooldownBinds.Initiator, "vice", "initiator (per vice per recipient)")]
+        [InlineData(CooldownBinds.Initiator, null, "initiator")]
+        [InlineData(CooldownBinds.Pair, null, "both initiator and recipient (per pair)")]
+        public void FormatAppliesTo_Cooldown(CooldownBinds binds, string scope, string expected)
+        {
+            var spec = new CooldownSpec { Kind = CooldownKind.Cooldown, Binds = binds, PeriodDays = 1, Scope = scope };
+            Assert.Equal(expected, spec.FormatAppliesTo());
+        }
+
+        [Fact]
+        public void FormatAppliesTo_MagnitudeQuota_IsInitiator()
+        {
+            var spec = new CooldownSpec { Kind = CooldownKind.MagnitudeQuota, Binds = CooldownBinds.Initiator, QuotaMagnitude = 10 };
+            Assert.Equal("initiator", spec.FormatAppliesTo());
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Corruptionprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Corruptionprocessortests.cs
@@ -545,6 +545,65 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.Contains("increasing their purity by 5", warning);
         }
 
+        [Fact]
+        public void GetConsentWarning_Corrupt_DisclosesVisibilityAndQuotaRule()
+        {
+            // B3 + shape-D: corrupting direction discloses corruption visibility and states
+            // the per-day magnitude quota by the initiator's display name.
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("corrupt", 3));
+
+            Assert.Contains("Corruption will be visible in most interactions, and in anything milked from you.", warning);
+            Assert.Contains("Alice can only corrupt you by 10 per day.", warning);
+            Assert.DoesNotContain("Purity will be visible", warning);
+        }
+
+        [Fact]
+        public void GetConsentWarning_Purify_DisclosesPurityVisibility()
+        {
+            // Direction-adaptive: a purifying action speaks of purity, not corruption.
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("purify", 3));
+
+            Assert.Contains("Purity will be visible in most interactions, and in anything milked from you.", warning);
+            Assert.Contains("Alice can only purify you by 10 per day.", warning);
+            Assert.DoesNotContain("Corruption will be visible", warning);
+        }
+
+        [Fact]
+        public void GetConsentWarning_NoQuotaSpentToday_OmitsConsumedClause()
+        {
+            // Consumed clause is suppressed when nothing has been spent yet.
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("corrupt", 3));
+
+            Assert.DoesNotContain("has already", warning);
+        }
+
+        [Fact]
+        public void GetConsentWarning_QuotaPartlySpentToday_ShowsConsumedClause()
+        {
+            // When the initiator has already spent some of today's budget against this
+            // recipient, the prompt names how much.
+            SeedPair();
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            CorruptionProcessor.RecordUsedQuota(alice, bob.userName, DateTime.UtcNow.Date, 2);
+
+            string warning = _processor.GetConsentWarning(alice, bob, CorruptionProcessor.ComposeIdentifier("corrupt", 3));
+
+            Assert.Contains("Alice has already corrupted you by 2 today.", warning);
+        }
+
         // -------------------------------------------------------------------
         // LevelChange direction resolver
         // -------------------------------------------------------------------

--- a/FChatDicebot.Tests/Unit/Curseprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Curseprocessortests.cs
@@ -295,8 +295,11 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             // The chastity Identifier description must surface inside the warning.
             Assert.Contains("achieving !climax", consent);
             Assert.Contains("missing a day of work", consent);
-            // Mirrors the standard Consequence-tier warning phrasing.
-            Assert.Contains("should not be taken lightly, and can not be done frequently", consent);
+            // Mirrors the standard Consequence-tier warning, now stating the real per-curse
+            // cooldown and a recipient-framed cleanse note.
+            Assert.Contains("This should not be taken lightly.", consent);
+            Assert.Contains("can only afflict you with a given curse once per week", consent);
+            Assert.Contains("you'll need to !cleanse", consent);
             Assert.Contains("Do you !consent", consent);
         }
 

--- a/FChatDicebot/BotCommands/ChateauBond.cs
+++ b/FChatDicebot/BotCommands/ChateauBond.cs
@@ -50,6 +50,24 @@ namespace FChatDicebot.BotCommands
                 bot.SendPrivateMessage(ChateauInteractionHandler.typeNotFoundText(identifierType), characterName);
                 valid = false;
             }
+            // A bond drops a 1-day "bond" cooldown on BOTH parties, so neither can declare
+            // another bond until it lapses. Enforce it at command time for immediate feedback.
+            else if (initiatorProfile.timers.ContainsKey("bond")
+                && initiatorProfile.timers["bond"].timerEnd.CompareTo(DateTime.UtcNow) > 0)
+            {
+                string tooSoonText = "You've declared a bond too recently! Please respect that 'Commitment' interactions are meant to be meaningful, and not spammed. You'll be able to declare another bond in "
+                    + Utils.GetTimeSpanPrint(initiatorProfile.timers["bond"].timerEnd - DateTime.UtcNow);
+                bot.SendPrivateMessage(tooSoonText, characterName);
+                valid = false;
+            }
+            else if (recipientProfile.timers.ContainsKey("bond")
+                && recipientProfile.timers["bond"].timerEnd.CompareTo(DateTime.UtcNow) > 0)
+            {
+                string tooSoonText = "You're trying to bond with " + recipientProfile.displayName + " but they declared a bond too recently! Please respect that 'Commitment' interactions are meant to be meaningful, and not spammed. They'll be able to take part in another bond in "
+                    + Utils.GetTimeSpanPrint(recipientProfile.timers["bond"].timerEnd - DateTime.UtcNow);
+                bot.SendPrivateMessage(tooSoonText, characterName);
+                valid = false;
+            }
             if (valid)
             {
                 Interaction bondInteraction = new Interaction();

--- a/FChatDicebot/BotCommands/ChateauBreed.cs
+++ b/FChatDicebot/BotCommands/ChateauBreed.cs
@@ -56,16 +56,10 @@ namespace FChatDicebot.BotCommands
                 return;
             }
 
-            int existingPregnancies = recipientProfile.pregnancies != null ? recipientProfile.pregnancies.Count : 0;
-            string pregnancyCountText = existingPregnancies > 0
-                ? " (" + recipientProfile.displayName + " is already carrying " + existingPregnancies + " other "
-                    + (existingPregnancies == 1 ? "pregnancy" : "pregnancies") + ".)"
-                : string.Empty;
-
-            string message = initiatorProfile.displayName + " wants to breed " + recipientProfile.displayName
-                + " with new " + monster + " life! [b]This should not be taken lightly, and can not be done frequently.[/b]"
-                + pregnancyCountText
-                + " Do you !consent to being bred?";
+            // Delegate consent wording (including the existing-pregnancy note) to the processor
+            // so it stays in one place.
+            var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("breed");
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, monster);
 
             Interaction breedInteraction = new Interaction
             {

--- a/FChatDicebot/BotCommands/ChateauConsume.cs
+++ b/FChatDicebot/BotCommands/ChateauConsume.cs
@@ -56,7 +56,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " is going to consume " + recipientProfile.displayName + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to being consumed, devoured, or otherwise feasted upon?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("consume");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, null);
 
                 Interaction objectifyInteraction = new Interaction();
                 objectifyInteraction.initiator = characterName;

--- a/FChatDicebot/BotCommands/ChateauCorrupt.cs
+++ b/FChatDicebot/BotCommands/ChateauCorrupt.cs
@@ -19,7 +19,7 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Commitment Interaction";
             ShortDescription = "Push another resident toward corruption";
-            LongDescription = "Move another resident's corruption value downward (toward 'corrupt') by the given magnitude. Negative amounts flip the direction, behaving as !purify of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per UTC day, summed across both directions — the excess is clamped silently at process time.";
+            LongDescription = "Move another resident's corruption value downward (toward 'corrupt') by the given magnitude. Negative amounts flip the direction, behaving as !purify of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per day, summed across both directions — the excess is clamped silently at process time. Once it builds up, a resident's corruption (or purity) becomes visible in most interactions and flavors anything milked from them.";
             Usage = "!corrupt [noparse][user]NameInUserTag[/user][/noparse] {amount}\nor\n!corrupt [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "purify", "consent", "dossier" };
             CooldownDuration = "Daily quota (10 magnitude per recipient)";

--- a/FChatDicebot/BotCommands/ChateauEmploy.cs
+++ b/FChatDicebot/BotCommands/ChateauEmploy.cs
@@ -52,7 +52,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " graciously offers to employ " + recipientProfile.displayName + " at the Chateau as their " + Utils.JobToText(job) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to this new career path?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("employ");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, job);
 
                 Interaction employInteraction = new Interaction();
                 employInteraction.initiator = characterName;

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -263,15 +263,29 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
-            // Cooldown information
-            if (!string.IsNullOrEmpty(cmd.CooldownDuration))
+            // Cooldown information. Prefer the structured CooldownSpec on the interaction's
+            // processor (single source of truth) so this line can't drift from the consent
+            // warning; fall back to the command's free-text fields for system commands and
+            // aliases that have no processor of their own.
+            string cooldownDuration = cmd.CooldownDuration;
+            string cooldownAppliesTo = cmd.CooldownAppliesTo;
+            if (!string.IsNullOrEmpty(cmd.Name))
+            {
+                var cooldownRule = InteractionProcessors.InteractionProcessorRegistry.GetProcessor(cmd.Name)?.CooldownRule;
+                if (cooldownRule != null)
+                {
+                    cooldownDuration = cooldownRule.FormatDuration();
+                    cooldownAppliesTo = cooldownRule.FormatAppliesTo();
+                }
+            }
+            if (!string.IsNullOrEmpty(cooldownDuration))
             {
                 sb.Append("[u]Cooldown:[/u] ");
-                sb.Append(cmd.CooldownDuration);
-                if (!string.IsNullOrEmpty(cmd.CooldownAppliesTo))
+                sb.Append(cooldownDuration);
+                if (!string.IsNullOrEmpty(cooldownAppliesTo))
                 {
                     sb.Append(" (applies to ");
-                    sb.Append(cmd.CooldownAppliesTo);
+                    sb.Append(cooldownAppliesTo);
                     sb.Append(")");
                 }
                 if (cmd.Category == "Casual Interaction")

--- a/FChatDicebot/BotCommands/ChateauMark.cs
+++ b/FChatDicebot/BotCommands/ChateauMark.cs
@@ -57,7 +57,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " is going to mark " + recipientProfile.displayName + " on their " + Utils.BodypartToText(bodypart) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to receiving their mark?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("mark");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, bodypart);
 
                 Interaction markInteraction = new Interaction();
                 markInteraction.initiator = characterName;

--- a/FChatDicebot/BotCommands/ChateauPetrify.cs
+++ b/FChatDicebot/BotCommands/ChateauPetrify.cs
@@ -63,7 +63,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " is going to petrify " + recipientProfile.displayName + " " + Utils.LocationToText(location, initiatorProfile.displayName, recipientProfile.displayName) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming still as a statue?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("petrify");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, location);
 
                 Interaction petrify = new Interaction();
                 petrify.initiator = characterName;

--- a/FChatDicebot/BotCommands/ChateauPlant.cs
+++ b/FChatDicebot/BotCommands/ChateauPlant.cs
@@ -63,7 +63,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into a " + plant + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming plantlife?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("plant");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, plant);
 
                 Interaction plantInteraction = new Interaction();
                 plantInteraction.initiator = characterName;

--- a/FChatDicebot/BotCommands/ChateauPurify.cs
+++ b/FChatDicebot/BotCommands/ChateauPurify.cs
@@ -17,7 +17,7 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Commitment Interaction";
             ShortDescription = "Push another resident toward purity";
-            LongDescription = "Move another resident's corruption value upward (toward 'pure') by the given magnitude. Negative amounts flip the direction, behaving as !corrupt of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per UTC day, summed across both directions — the excess is clamped silently at process time.";
+            LongDescription = "Move another resident's corruption value upward (toward 'pure') by the given magnitude. Negative amounts flip the direction, behaving as !corrupt of the same magnitude. Amount defaults to 1 if omitted. Self-target is allowed. A single initiator may move any single recipient's corruption value by at most 10 total magnitude per day, summed across both directions — the excess is clamped silently at process time. Once it builds up, a resident's corruption (or purity) becomes visible in most interactions and flavors anything milked from them.";
             Usage = "!purify [noparse][user]NameInUserTag[/user][/noparse] {amount}\nor\n!purify [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "corrupt", "consent", "dossier" };
             CooldownDuration = "Daily quota (10 magnitude per recipient)";

--- a/FChatDicebot/BotCommands/ChateauRename.cs
+++ b/FChatDicebot/BotCommands/ChateauRename.cs
@@ -67,7 +67,9 @@ namespace FChatDicebot.BotCommands
             }
             if (valid)
             {
-                string message = initiatorProfile.displayName + " intends for " + recipientProfile.displayName + " to be known as " + newName + " from now on. [b]This should not be taken lightly, and can not be done frequently. The new name will show almost every time the Chateau mentions you.[/b] Do you !consent to this life-changing occasion?";
+                // Delegate consent wording to the processor so it stays in one place.
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("rename");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, newName);
 
                 Interaction rename = new Interaction();
                 rename.initiator = characterName;

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -40,7 +40,7 @@ namespace FChatDicebot.Database
                 };
                 collection.InsertOne(toRegister.ToBsonDocument());
 
-                return "Welcome to the Chateau, " + toRegister.displayName + "! We hope you enjoy your time here. Use !help for a list of commands, and feel free to ask around. I promise, we only bite if you want us to~ \n[b]The bot is currently under construction. If you are seeing this message, your profile will almost certainly be reset before release, so don't get too attached![/b]";
+                return "Welcome to the Chateau, " + toRegister.displayName + "! We hope you enjoy your time here. Use !help for a list of commands, and feel free to ask around. I promise, we only bite if you want us to~";
             }
             else
             {

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -375,6 +375,8 @@
     <Compile Include="InteractionProcessors\Casual\SpankProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\EntitleProcessor.cs" />
     <Compile Include="InteractionProcessors\Commitment\MarkProcessor.cs" />
+    <Compile Include="InteractionProcessors\CooldownSpec.cs" />
+    <Compile Include="InteractionProcessors\ConsentWarningText.cs" />
     <Compile Include="InteractionProcessors\IdentifierPayload.cs" />
     <Compile Include="InteractionProcessors\IInteractionProcessor.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorBase.cs" />

--- a/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
@@ -13,6 +13,15 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         public override string InteractionType => "bond";
         public override string InvestmentLevel => "commitment";
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Both,
+            PeriodDays = 1
+        };
+
         public BondProcessor(IChateauDatabase database) : base(database)
         {
         }
@@ -100,10 +109,14 @@ namespace FChatDicebot.InteractionProcessors.Consequence
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            Identifier bondIdentifier = MonDB.getIdentifier(identifier);
-            string bondText = bondIdentifier != null ? bondIdentifier.description : identifier;
+            // A bond puts a global cooldown on BOTH parties (not a per-pair limit), so the
+            // recipient-framed clause speaks to the act of declaring a bond at all.
+            string seriousness = ConsentWarningText.Block(
+                "You can only declare a bond once per " + ConsentWarningText.PeriodWord(Cooldown.PeriodDays) + ".");
 
-            return initiatorProfile.displayName + " would like to declare that " + recipientProfile.displayName + " is their " + Utils.BondToText(identifier, true) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to this new bond?";
+            return initiatorProfile.displayName + " would like to declare that " + recipientProfile.displayName
+                + " is their " + Utils.BondToText(identifier, true) + "! " + seriousness
+                + " Do you !consent to this new bond?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
@@ -209,6 +209,15 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 + recipientProfile.displayName + " will carry the pregnancy until they're ready to !birth their young.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Both,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             int existingPregnancies = recipientProfile.pregnancies != null ? recipientProfile.pregnancies.Count : 0;
@@ -217,8 +226,11 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                     + (existingPregnancies == 1 ? "pregnancy" : "pregnancies") + ".)"
                 : string.Empty;
 
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyBoth("breed", Cooldown.PeriodDays));
+
             return initiatorProfile.displayName + " wants to breed " + recipientProfile.displayName
-                + " with new " + identifier + " life! [b]This should not be taken lightly, and can not be done frequently.[/b]"
+                + " with new " + identifier + " life! " + seriousness
                 + pregnancyCountText
                 + " Do you !consent to being bred?";
         }

--- a/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
@@ -49,9 +49,22 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " consumes " + recipientProfile.displayName + ", and they were never heard from again... or at least, it will be quite some time before they manage to escape, reform, or otherwise recover their strength.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            return initiatorProfile.displayName + " is going to consume " + recipientProfile.displayName + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to being consumed, devoured, or otherwise feasted upon?";
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("consumed", Cooldown.PeriodDays));
+
+            return initiatorProfile.displayName + " is going to consume " + recipientProfile.displayName + "! " + seriousness
+                + " Do you !consent to being consumed, devoured, or otherwise feasted upon?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
@@ -254,6 +254,16 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 + change.ActionPast + " by " + appliedMagnitude + ", " + DescribeCurrentLevel(newCorruption) + ".";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.MagnitudeQuota,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 1,
+            QuotaMagnitude = DailyMagnitudeLimit
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string verb = ParseVerbFromIdentifier(identifier);
@@ -272,9 +282,24 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             bool isSelf = string.Equals(initiatorProfile?.userName, recipientProfile?.userName, StringComparison.Ordinal);
             string target = isSelf ? "themself" : (recipientProfile?.displayName ?? "you");
 
+            // B3: disclose that the recipient's corruption/purity surfaces elsewhere. The
+            // direction is taken from the effective verb (the movement currently in play),
+            // not the projected end-state side.
+            string visibilityClause = sign < 0
+                ? "Corruption will be visible in most interactions, and in anything milked from you."
+                : "Purity will be visible in most interactions, and in anything milked from you.";
+
+            // Shape D: a per-day magnitude quota, so the prompt states the rule and (when the
+            // initiator has already spent some of today's budget against this recipient) how
+            // much has been used so far.
+            int usedToday = GetUsedQuota(initiatorProfile, recipientProfile?.userName, DateTime.UtcNow.Date);
+            string quotaClause = ConsentWarningText.FrequencyQuota(subject, verb, Cooldown.QuotaMagnitude, Cooldown.PeriodDays);
+            string consumedClause = ConsentWarningText.ConsumedClause(subject, PastTense(verb), usedToday);
+
+            string seriousness = ConsentWarningText.Block(visibilityClause, quotaClause, consumedClause);
+
             return subject + " wants to " + verb + " " + target + ", " + change.ActionPresent + " their "
-                + change.Side + " by " + requestedMagnitude + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently.[/b] "
+                + change.Side + " by " + requestedMagnitude + "! " + seriousness + " "
                 + "Do you !consent to being " + PastTense(verb) + "?";
         }
 

--- a/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
@@ -74,12 +74,23 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has given " + recipientProfile.displayName + " the esteemed position of " + Utils.JobToText(identifier) + "! Enjoy your new job everytime you !work (and don't forget you can still !volunteer to see what other jobs are like.)";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            Identifier jobIdentifier = MonDB.getIdentifier(identifier);
-            string jobText = jobIdentifier != null ? jobIdentifier.description : identifier;
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("employed", Cooldown.PeriodDays));
 
-            return initiatorProfile.displayName + " graciously offers to employ " + recipientProfile.displayName + " at the Chateau as their " + Utils.JobToText(identifier) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to this new career path?";
+            return initiatorProfile.displayName + " graciously offers to employ " + recipientProfile.displayName
+                + " at the Chateau as their " + Utils.JobToText(identifier) + "! " + seriousness
+                + " Do you !consent to this new career path?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/MarkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/MarkProcessor.cs
@@ -103,11 +103,22 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             return $"{initiatorProfile.displayName} emblazons their mark upon {recipientProfile.displayName}'s {bodypartText}. Wear it with pride~ {mark}";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string bodypartText = Utils.BodypartToText(identifier);
-            
-            return $"{initiatorProfile.displayName} is going to mark {recipientProfile.displayName} on their {bodypartText}! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to receiving their mark?";
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("marked", Cooldown.PeriodDays));
+
+            return $"{initiatorProfile.displayName} is going to mark {recipientProfile.displayName} on their {bodypartText}! {seriousness} Do you !consent to receiving their mark?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
@@ -108,9 +108,23 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has made " + recipientProfile.displayName + " into some sort of " + identifier + "! Who knows what's in store for them, but they'll be stuck with their fate for quite awhile...";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            return initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into some sort of " + identifier + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming an object?";
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("objectified", Cooldown.PeriodDays));
+
+            return initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName
+                + " into some sort of " + identifier + "! " + seriousness
+                + " Do you !consent to becoming an object?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
@@ -84,9 +84,23 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has petrified " + recipientProfile.displayName + " " + Utils.LocationToText(identifier, initiatorProfile.userName, recipientProfile.userName) + "! They might be stuck there for quite awhile... hopefully visitors enjoy the pose they're stuck in.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 7
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            return initiatorProfile.displayName + " is going to petrify " + recipientProfile.displayName + " " + Utils.LocationToText(identifier, initiatorProfile.displayName, recipientProfile.displayName) + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming still as a statue?";
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("petrified", Cooldown.PeriodDays));
+
+            return initiatorProfile.displayName + " is going to petrify " + recipientProfile.displayName + " "
+                + Utils.LocationToText(identifier, initiatorProfile.displayName, recipientProfile.displayName) + "! " + seriousness
+                + " Do you !consent to becoming still as a statue?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
@@ -71,12 +71,23 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has grown the garden by turning " + recipientProfile.displayName + " into " + identifier + "! They might stay planted for quite awhile... surely the gardeners will take good care of them.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 1
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            Identifier plantIdentifier = MonDB.getIdentifier(identifier);
-            string plantText = plantIdentifier != null ? plantIdentifier.description : identifier;
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("planted", Cooldown.PeriodDays));
 
-            return initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName + " into a " + identifier + "! [b]This should not be taken lightly, and can not be done frequently.[/b] Do you !consent to becoming plantlife?";
+            return initiatorProfile.displayName + " is going to turn " + recipientProfile.displayName
+                + " into a " + identifier + "! " + seriousness
+                + " Do you !consent to becoming plantlife?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/ConsentWarningText.cs
+++ b/FChatDicebot/InteractionProcessors/ConsentWarningText.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// The single place the "[b]This should not be taken lightly...[/b]" seriousness block
+    /// is composed. Each warned processor's <c>GetConsentWarning</c> builds its frequency
+    /// clause from its <see cref="CooldownSpec"/> and any bespoke implication clause, then
+    /// wraps them with <see cref="Block"/>. Keeping the opener and the per-shape frequency
+    /// phrasings here means the warning wording can't drift between interactions, and stays
+    /// in lockstep with the help text derived from the same <see cref="CooldownSpec"/>.
+    ///
+    /// The frequency clause is recipient-framed ("you"); initiator-bound shapes name the
+    /// initiator by display name rather than "they".
+    /// </summary>
+    public static class ConsentWarningText
+    {
+        /// <summary>The fixed opening sentence of every seriousness block.</summary>
+        public const string Opener = "This should not be taken lightly.";
+
+        /// <summary>
+        /// Wrap the opener followed by the supplied clauses (in order, empties skipped) in a
+        /// single bold block. Callers control clause order so each interaction reads naturally
+        /// (e.g. corrupt leads with its visibility disclosure before the quota rule).
+        /// </summary>
+        public static string Block(params string[] clauses)
+        {
+            var parts = new List<string> { Opener };
+            if (clauses != null)
+            {
+                foreach (var clause in clauses)
+                {
+                    if (!string.IsNullOrEmpty(clause)) parts.Add(clause);
+                }
+            }
+            return "[b]" + string.Join(" ", parts) + "[/b]";
+        }
+
+        /// <summary>"day" for a 1-day period, "week" for 7 days, an "N days" fallback otherwise.</summary>
+        public static string PeriodWord(int periodDays)
+        {
+            if (periodDays == 1) return "day";
+            if (periodDays == 7) return "week";
+            return periodDays + " days";
+        }
+
+        /// <summary>
+        /// Shape A — cooldown binding both parties (bond, breed). The verb phrase is the
+        /// interaction's own ("declare a bond", "breed").
+        /// </summary>
+        public static string FrequencyBoth(string verbPhrase, int periodDays)
+        {
+            return "You can only " + verbPhrase + " between the two of you once per " + PeriodWord(periodDays) + ".";
+        }
+
+        /// <summary>
+        /// Shape B — cooldown binding the recipient globally (employ, mark, objectify, plant,
+        /// consume, monsterize, petrify, rename). The past participle is recipient-framed
+        /// ("employed", "marked", ...).
+        /// </summary>
+        public static string FrequencyRecipient(string pastParticiple, int periodDays)
+        {
+            return "You can only be " + pastParticiple + " once per " + PeriodWord(periodDays) + ".";
+        }
+
+        /// <summary>
+        /// Shape C — per-axis cooldown on the initiator (break, curse, dose, infest, odorize).
+        /// The verb phrase carries the axis ("dose you with a given vice", "break a given part
+        /// of you"); the initiator is named.
+        /// </summary>
+        public static string FrequencyPerAxis(string initiatorName, string verbPhrase, int periodDays)
+        {
+            return initiatorName + " can only " + verbPhrase + " once per " + PeriodWord(periodDays) + ".";
+        }
+
+        /// <summary>
+        /// Shape D — per-day magnitude quota on the initiator (corrupt / purify). The verb is
+        /// the effective verb infinitive; the initiator is named.
+        /// </summary>
+        public static string FrequencyQuota(string initiatorName, string verb, int quotaMagnitude, int periodDays)
+        {
+            return initiatorName + " can only " + verb + " you by " + quotaMagnitude + " per " + PeriodWord(periodDays) + ".";
+        }
+
+        /// <summary>
+        /// Shape D — the "already spent today" line that follows the quota rule. Suppressed
+        /// (returns empty) when nothing has been spent yet, so the prompt never reads
+        /// "already corrupted you by 0".
+        /// </summary>
+        public static string ConsumedClause(string initiatorName, string verbPastTense, int usedToday)
+        {
+            if (usedToday <= 0) return string.Empty;
+            return initiatorName + " has already " + verbPastTense + " you by " + usedToday + " today.";
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs
@@ -186,6 +186,16 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         /// <see cref="ComposeConsentText"/> directly with the actual requested days and
         /// clamp direction so the player sees the real duration before saying !consent.
         /// </summary>
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 7,
+            Scope = "bodypart"
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string baseWarning = ComposeConsentText(initiatorProfile.displayName, recipientProfile.displayName, identifier, DefaultDays, ClampDirection.None);
@@ -202,11 +212,12 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         {
             string daysWord = days == 1 ? "day" : "days";
             string blockedVerbs = BlockedVerbListForPart(part);
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyPerAxis(initiatorName, "break a given part of you", Cooldown.PeriodDays),
+                "While broken, your sore " + part + " will keep you from " + blockedVerbs
+                    + ", and might be noticed during other interactions as well.");
             string warning = initiatorName + " is going to break " + recipientName + "'s " + part
-                + " for " + days + " " + daysWord + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently. "
-                + "While broken, " + recipientName + "'s sore " + part + " will prevent them from "
-                + blockedVerbs + ", and might be noticed during other interactions as well.[/b] Do you !consent?";
+                + " for " + days + " " + daysWord + "! " + seriousness + " Do you !consent?";
 
             if (clamp == ClampDirection.Min)
             {

--- a/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
@@ -418,6 +418,16 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + "Surely nothing ill will come of this.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 7,
+            Scope = "curse"
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string casterName = string.IsNullOrEmpty(initiatorProfile?.displayName)
@@ -443,12 +453,12 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 cleanseCostPhrase = CleanseCostPhrase(spec.CleanseCost);
             }
 
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyPerAxis(casterName, "afflict you with a given curse", Cooldown.PeriodDays),
+                "To remove this curse, you'll need to !cleanse at the cost of " + cleanseCostPhrase + ".");
             string baseWarning = casterName + " wants to curse " + subjectName
                 + " with [b]" + identifier + "[/b]! "
-                + effectDescription + " "
-                + "[b]This should not be taken lightly, and can not be done frequently. "
-                + "To remove this curse, the recipient will need to !cleanse at the cost of "
-                + cleanseCostPhrase + ".[/b] "
+                + effectDescription + " " + seriousness + " "
                 + "Do you !consent to this curse?";
 
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);

--- a/FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs
@@ -205,14 +205,25 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + level + "/" + MaxAddictionLevel + ")[/sub]";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 7,
+            Scope = "vice"
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string vicePhrase = ViceText.ViceName(Database?.GetIdentifier(identifier), identifier, initiatorProfile?.displayName);
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyPerAxis(initiatorProfile.displayName, "dose you with a given vice", Cooldown.PeriodDays),
+                "Addictive cravings can show up in any interaction until you !detox at a hefty cost. "
+                    + "Everyone will know when you're satisfying an addictive craving.");
             string baseWarning = initiatorProfile.displayName + " wants to dose " + recipientProfile.displayName
-                + " with " + vicePhrase + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently. "
-                + "Addictive cravings can show up in any interaction until you !detox at a hefty cost. "
-                + "Everyone will know when you're satisfying an addictive craving.[/b] "
+                + " with " + vicePhrase + "! " + seriousness + " "
                 + "Do you !consent?";
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
             return AppendStatusFragments(baseWarning, effects.ConsentWarnings);

--- a/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
@@ -243,19 +243,30 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + "Enjoy your future as a host, and see if you can help it spread~";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 7,
+            Scope = "parasite"
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string costPhrase = CostPhrase(PurgeCostFor(identifier));
             int graceHours = (int)SpreadGracePeriod.TotalHours;
             string parasiteWithArticle = ParasiteText.ParasiteNameWithArticle(identifier);
 
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyPerAxis(initiatorProfile.displayName, "infest you with a given parasite", Cooldown.PeriodDays),
+                "This parasite has a chance to spread to anyone you have a non-casual interaction with, "
+                    + "and signs of your infection might be noticeable in any interaction. "
+                    + "You can !purge at the cost of " + costPhrase + ", "
+                    + "with a " + graceHours + "-hour grace period during which !purge has no cost.");
             string baseWarning = initiatorProfile.displayName + " wants to infest "
-                + recipientProfile.displayName + " with " + parasiteWithArticle + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently. "
-                + "This parasite has a chance to spread to anyone you have a non-casual interaction with, "
-                + "and signs of your infection might be noticeable in any interaction. "
-                + "You can !purge at the cost of " + costPhrase + ", "
-                + "with a " + graceHours + "-hour grace period during which !purge has no cost.[/b] "
+                + recipientProfile.displayName + " with " + parasiteWithArticle + "! " + seriousness + " "
                 + "Do you !consent to being made into a new host?";
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
             return AppendStatusFragments(baseWarning, effects.ConsentWarnings);

--- a/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
@@ -96,12 +96,24 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has bolstered monsterkind by turning " + recipientProfile.displayName + " into " + identifier + "! We welcome all monsters to our Chateau, no matter what your origins. Enjoy your new life as " + identifier + "~";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 7
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            Identifier monsterIdentifier = MonDB.getIdentifier(identifier);
-            string monsterText = monsterIdentifier != null ? monsterIdentifier.description : identifier;
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("monsterized", Cooldown.PeriodDays),
+                "The capabilities of your new body might be referenced in flavor text and !work checks.");
 
-            return initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName + " into " + Utils.AnOrA(identifier) + " " + identifier + "! [b]This should not be taken lightly, and can not be done frequently. The capabilities of your new body might be referenced in flavor text and !work checks.[/b] Do you !consent to your new form?";
+            return initiatorProfile.displayName + " is going to transform " + recipientProfile.displayName
+                + " into " + Utils.AnOrA(identifier) + " " + identifier + "! " + seriousness
+                + " Do you !consent to your new form?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs
@@ -140,12 +140,25 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + recipientProfile.displayName + " may !wash once per day to scrub off a single layer.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Initiator,
+            PeriodDays = 7,
+            Scope = "scent"
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string phrase = ScentText.ScentPhrase(Database.GetIdentifier(identifier), identifier, initiatorProfile.displayName);
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyPerAxis(initiatorProfile.displayName, "saturate you with a given scent", Cooldown.PeriodDays),
+                "The scent will linger on you through several interactions before it fades. "
+                    + "You may !wash once per day to scrub off a single layer.");
             return initiatorProfile.displayName + " is going to saturate " + recipientProfile.displayName + " with " + phrase + "! "
-                + "[b]This should not be taken lightly, and can not be done frequently.[/b] "
-                + "The scent will follow them into other interactions for some time. Do you !consent to this lingering aroma?";
+                + seriousness + " Do you !consent to this lingering aroma?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
@@ -69,10 +69,25 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " has made it known that " + recipientProfile.displayName + " is to be known as " + newName + " henceforth! All occurences of their name in our records will be changed to reflect their new identity.";
         }
 
+        public override CooldownSpec CooldownRule => Cooldown;
+
+        public static readonly CooldownSpec Cooldown = new CooldownSpec
+        {
+            Kind = CooldownKind.Cooldown,
+            Binds = CooldownBinds.Recipient,
+            PeriodDays = 7
+        };
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string newName = identifier;
-            return initiatorProfile.displayName + " intends for " + recipientProfile.displayName + " to be known as " + newName + " from now on. [b]This should not be taken lightly, and can not be done frequently. The new name will show almost every time the Chateau mentions you.[/b] Do you !consent to this life-changing occasion?";
+            string seriousness = ConsentWarningText.Block(
+                ConsentWarningText.FrequencyRecipient("renamed", Cooldown.PeriodDays),
+                "The new name will show almost every time the Chateau mentions you.");
+
+            return initiatorProfile.displayName + " intends for " + recipientProfile.displayName
+                + " to be known as " + newName + " from now on. " + seriousness
+                + " Do you !consent to this life-changing occasion?";
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/CooldownSpec.cs
+++ b/FChatDicebot/InteractionProcessors/CooldownSpec.cs
@@ -1,0 +1,96 @@
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// What kind of rate limit an interaction carries.
+    /// </summary>
+    public enum CooldownKind
+    {
+        None,
+        Cooldown,        // a hard cooldown that fires once the interaction lands
+        MagnitudeQuota   // a per-day magnitude budget (corrupt / purify)
+    }
+
+    /// <summary>
+    /// Who a cooldown binds. Determines the recipient/initiator framing of the
+    /// consent-warning frequency clause.
+    /// </summary>
+    public enum CooldownBinds
+    {
+        None,
+        Initiator,   // the initiator, usually scoped to an axis + the specific recipient
+        Recipient,   // the recipient, globally
+        Both,        // both parties
+        Pair         // the specific (initiator, recipient) pair
+    }
+
+    /// <summary>
+    /// Structured description of an interaction's rate limit. Authored once on the
+    /// processor (the canonical interaction unit) and used as the single source of
+    /// truth for both the player-facing consent-warning frequency clause and the
+    /// derived help / <c>!whatis</c> cooldown strings, so the two can never drift.
+    ///
+    /// See <see cref="ConsentWarningText"/> for the consent-warning rendering and
+    /// <see cref="FormatDuration"/> / <see cref="FormatAppliesTo"/> for the help text.
+    /// </summary>
+    public class CooldownSpec
+    {
+        public CooldownKind Kind;
+        public CooldownBinds Binds;
+
+        /// <summary>Cooldown period in whole days. 1 renders "day"/"per day", 7 renders "week"/"per week".</summary>
+        public int PeriodDays;
+
+        /// <summary>
+        /// The per-axis scope for initiator-bound cooldowns: "vice", "curse",
+        /// "parasite", "scent", "bodypart". Null when the cooldown is not axis-scoped.
+        /// </summary>
+        public string Scope;
+
+        /// <summary>The daily magnitude budget for <see cref="CooldownKind.MagnitudeQuota"/> shapes (corrupt / purify = 10).</summary>
+        public int QuotaMagnitude;
+
+        /// <summary>
+        /// The duration string shown in <c>!help</c> / <c>!whatis</c> (the
+        /// <c>CooldownDuration</c> field). Derived so it can't diverge from the warning.
+        /// </summary>
+        public string FormatDuration()
+        {
+            if (Kind == CooldownKind.MagnitudeQuota)
+            {
+                return "Daily quota (" + QuotaMagnitude + " magnitude per recipient)";
+            }
+            if (PeriodDays == 1)
+            {
+                return "1 Day";
+            }
+            return PeriodDays + " Days";
+        }
+
+        /// <summary>
+        /// The "applies to" string shown in <c>!help</c> / <c>!whatis</c> (the
+        /// <c>CooldownAppliesTo</c> field). Derived so it can't diverge from the warning.
+        /// </summary>
+        public string FormatAppliesTo()
+        {
+            if (Kind == CooldownKind.MagnitudeQuota)
+            {
+                return "initiator";
+            }
+            switch (Binds)
+            {
+                case CooldownBinds.Both:
+                    return "both initiator and recipient";
+                case CooldownBinds.Pair:
+                    return "both initiator and recipient (per pair)";
+                case CooldownBinds.Recipient:
+                    return "recipient";
+                case CooldownBinds.Initiator:
+                    return string.IsNullOrEmpty(Scope)
+                        ? "initiator"
+                        : "initiator (per " + Scope + " per recipient)";
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -20,6 +20,13 @@ namespace FChatDicebot.InteractionProcessors
         /// </summary>
         string InvestmentLevel { get; }
 
+        /// <summary>
+        /// Structured rate-limit description, or null when the interaction carries no warned
+        /// cooldown. Single source of truth for both the consent-warning frequency clause and
+        /// the derived help / <c>!whatis</c> cooldown strings. See <see cref="CooldownSpec"/>.
+        /// </summary>
+        CooldownSpec CooldownRule { get; }
+
         string GetInteractionVerb(VerbTense tense);
         string GetInteractionVerb(VerbTense tense, bool isPlural);
 

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -98,6 +98,13 @@ namespace FChatDicebot.InteractionProcessors
         public abstract string InteractionType { get; }
         public abstract string InvestmentLevel { get; }
 
+        /// <summary>
+        /// Structured rate-limit description, or null when the interaction carries no warned
+        /// cooldown. Warned processors override this to return their static spec; the help
+        /// layer reads it so the cooldown strings can't drift from the consent warning.
+        /// </summary>
+        public virtual CooldownSpec CooldownRule => null;
+
         public string GetAndClearRateLimitMessage()
         {
             string msg = _lastRateLimitMessage;


### PR DESCRIPTION
Implements the B1/B2/B3 "quick text passes" cluster from `wiki-docs/Feature-Requests.md`, per the design in `wiki-docs/specs/Consent-Warning-And-Welcome-Text.md`. All wording was reviewed and signed off by the owner.

## What changed

**B1 — Welcome text**
Removed the "[b]The bot is currently under construction…[/b]" line from the `!joinchateau` welcome.

**B2 — Real cooldown facts in the seriousness warning**
The canonical `[b]This should not be taken lightly, and can not be done frequently.[/b]` told players neither how often nor whom a cooldown binds. Now:
- New `CooldownSpec` value object (`CooldownKind`/`CooldownBinds`/period/scope/quota) authored on each warned processor as the single source of truth, with `FormatDuration()`/`FormatAppliesTo()` for the derived `!help` strings.
- New `ConsentWarningText` composer renders the four limiter shapes — **A** both-party (bond/breed), **B** recipient (employ/mark/objectify/plant/consume = 1d; monsterize/petrify/rename = 7d), **C** per-axis-initiator (break/curse/dose/infest/odorize = 7d), **D** magnitude-quota (corrupt/purify = 10/day) — so the consent warning and `!help` cooldown line can't drift.
- `ChateauHelp` derives the cooldown line from `processor.CooldownRule`, falling back to free-text for casuals/system/alias commands.
- Killed the 7 inlined command warnings (employ/mark/plant/petrify/consume/breed/rename) — they now delegate to the processor like bond already did.
- Implication clauses for break/curse/odorize re-framed recipient-first ("you"); infest/dose/monsterize/rename kept verbatim.

**B3 — Corruption visibility disclosure**
`!corrupt` / `!purify` now disclose (direction-adaptively) that corruption/purity is visible in other interactions and in milked product, on the consent prompt and in the help text. Also fixed `per UTC day` → `per day` in their help (no-UTC rule).

**bond — reworded + enforcement fix (owner-directed during review)**
- Reworded to "You can only declare a bond once per day": bond's cooldown is a global per-user `"bond"` timer on *both* parties, not a per-pair limit.
- Fixed missing enforcement: the 1-day cooldown was set in `BondProcessor.ProcessInteraction` but never checked. Now enforced at command-init in `ChateauBond.Run` (checks both parties' timer, mirroring breed).

## Notes for reviewers
- Processor folder ≠ declared namespace in several files (e.g. `BondProcessor` is in `Commitment/` but declares `namespace …Consequence`), which is why help derivation routes through the registry rather than direct static references.
- `CooldownSpec.cs` and `ConsentWarningText.cs` were added to `FChatDicebot.csproj` (explicit Compile Include — the test project globs).
- Help-string normalizations that surfaced from derivation (approved): 7-day durations now render `7 Days`; breed "applies to" is now `both initiator and recipient`.

## Testing
- Build clean (0 errors).
- Full suite green: **1286 passed, 0 failed**.
- New coverage: `ConsentWarningTextTests` (helper + formatter), corruption visibility/quota/consumed clauses (both directions, consumed = 0 and > 0); updated bond/curse assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)