### PR TITLE
Group interactions, lifecycle commands (!no / !oops), and the lapsit lap-stack

### DIFF
--- a/FChatDicebot.Tests/Unit/Groupinteractionresolvertests.cs
+++ b/FChatDicebot.Tests/Unit/Groupinteractionresolvertests.cs
@@ -1,0 +1,264 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for the B4 hybrid-group flow: GroupInteractionResolver applies the symmetric
+    /// / directional / lapsit count math over whoever consented, emits one combined message,
+    /// and clears the group. Drives MarkSeatConsented + CheckAndResolve directly against the
+    /// test database (the same path ChateauConsent/ChateauRefuse use at runtime).
+    /// </summary>
+    [Collection("Database")]
+    public class GroupInteractionResolverTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public GroupInteractionResolverTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        // ---- Symmetric (cuddle): every participant gets +(M-1) ----
+
+        [Fact]
+        public void Symmetric_ThreePersonCuddle_EachGetsMMinus1()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(seats); // Bob then Carol
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.True(result.Resolved);
+            Assert.Equal(2, _database.GetProfile("Alice").counts["cuddle"]);
+            Assert.Equal(2, _database.GetProfile("Bob").counts["cuddle"]);
+            Assert.Equal(2, _database.GetProfile("Carol").counts["cuddle"]);
+            Assert.Empty(_database.GetPendingCommandsByGroupId(seats[0].groupId));
+        }
+
+        [Fact]
+        public void Symmetric_CompletionMessage_UsesSerialComma()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(seats);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.Contains("Alice, Bob, and Carol", result.ChannelMessage);
+            Assert.Contains("cuddle up together", result.ChannelMessage);
+        }
+
+        // ---- Directional (lick): initiator +R, each recipient +1 ----
+
+        [Fact]
+        public void Directional_GroupLick_InitiatorGetsR_RecipientsGet1()
+        {
+            SeedProfiles("Alice", "Bob", "Carol", "Dave");
+            var seats = CreateGroup("Alice", "lick", null, "Bob", "Carol", "Dave");
+            ConsentInOrder(seats);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.True(result.Resolved);
+            Assert.Equal(3, _database.GetProfile("Alice").counts["lickgive"]);
+            Assert.Equal(1, _database.GetProfile("Bob").counts["licktake"]);
+            Assert.Equal(1, _database.GetProfile("Carol").counts["licktake"]);
+            Assert.Equal(1, _database.GetProfile("Dave").counts["licktake"]);
+            Assert.Contains("Alice licks Bob, Carol, and Dave.", result.ChannelMessage);
+        }
+
+        // ---- Partial consent: fire with whoever consented ----
+
+        [Fact]
+        public void PartialConsent_FiresWithConsentedSubset_ExpiredSeatDropped()
+        {
+            SeedProfiles("Alice", "Bob", "Carol", "Dave");
+            var seats = CreateGroup("Alice", "lick", null, "Bob", "Carol", "Dave");
+
+            ConsentSeat(seats[0]); // Bob
+            ConsentSeat(seats[1]); // Carol
+            ExpireSeat(seats[2]);  // Dave never responds and times out
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.True(result.Resolved);
+            Assert.Equal(2, _database.GetProfile("Alice").counts["lickgive"]); // R = 2
+            Assert.Equal(1, _database.GetProfile("Bob").counts["licktake"]);
+            Assert.Equal(1, _database.GetProfile("Carol").counts["licktake"]);
+            Assert.False(_database.GetProfile("Dave").counts.ContainsKey("licktake"));
+        }
+
+        [Fact]
+        public void ZeroConsent_AllExpired_GroupDiesSilently()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ExpireSeat(seats[0]);
+            ExpireSeat(seats[1]);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.False(result.Resolved);
+            Assert.Empty(_database.GetPendingCommandsByGroupId(seats[0].groupId));
+            Assert.False(_database.GetProfile("Alice").counts.ContainsKey("cuddle"));
+            Assert.False(_database.GetProfile("Bob").counts.ContainsKey("cuddle"));
+        }
+
+        [Fact]
+        public void StillWaiting_PendingSeatRemains_DoesNotResolve()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentSeat(seats[0]); // only Bob; Carol still Pending and not expired
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.False(result.Resolved);
+            Assert.Equal(2, _database.GetPendingCommandsByGroupId(seats[0].groupId).Count);
+            Assert.False(_database.GetProfile("Alice").counts.ContainsKey("cuddle"));
+        }
+
+        // ---- Lapsit per-position math ----
+
+        [Fact]
+        public void Lapsit_Lap_PositionsByConsentOrder()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            // !lap: initiator is the bottom (position 0); consenters stack above in order.
+            var seats = CreateGroup("Alice", "lap", "lap", "Bob", "Carol");
+            ConsentInOrder(seats); // Bob then Carol → stack Alice(0), Bob(1), Carol(2), M=3
+
+            GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            var carol = _database.GetProfile("Carol");
+
+            Assert.Equal(2, alice.counts["lapsittake"]);
+            Assert.False(alice.counts.ContainsKey("lapsitgive"));
+            Assert.Equal(1, bob.counts["lapsittake"]);
+            Assert.Equal(1, bob.counts["lapsitgive"]);
+            Assert.False(carol.counts.ContainsKey("lapsittake"));
+            Assert.Equal(2, carol.counts["lapsitgive"]);
+        }
+
+        [Fact]
+        public void Lapsit_Sit_FirstConsenterClaimsBottom()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            // !sit: first consenter claims the open bottom, initiator sits at position 1.
+            var seats = CreateGroup("Alice", "sit", "sit", "Bob", "Carol");
+            ConsentInOrder(seats); // Bob then Carol → stack Bob(0), Alice(1), Carol(2), M=3
+
+            GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+            var carol = _database.GetProfile("Carol");
+
+            Assert.Equal(2, bob.counts["lapsittake"]);
+            Assert.False(bob.counts.ContainsKey("lapsitgive"));
+            Assert.Equal(1, alice.counts["lapsittake"]);
+            Assert.Equal(1, alice.counts["lapsitgive"]);
+            Assert.False(carol.counts.ContainsKey("lapsittake"));
+            Assert.Equal(2, carol.counts["lapsitgive"]);
+        }
+
+        [Fact]
+        public void Lapsit_Lap_TwoPerson_DegenerateCase()
+        {
+            SeedProfiles("Alice", "Bob");
+            var seats = CreateGroup("Alice", "lap", "lap", "Bob");
+            ConsentInOrder(seats); // stack Alice(0), Bob(1), M=2
+
+            GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.Equal(1, _database.GetProfile("Alice").counts["lapsittake"]);
+            Assert.Equal(1, _database.GetProfile("Bob").counts["lapsitgive"]);
+        }
+
+        [Fact]
+        public void Lapsit_TallStack_CompletionMessageRendersHeight()
+        {
+            SeedProfiles("Alice", "Bob", "Carol", "David", "Erwin");
+            var seats = CreateGroup("Alice", "lap", "lap", "Bob", "Carol", "David", "Erwin");
+            ConsentInOrder(seats);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.Contains("Alice pulls Bob onto their lap.", result.ChannelMessage);
+            Assert.Contains("Then Carol takes a seat, then David, then Erwin", result.ChannelMessage);
+            Assert.Contains("forming a lap stack 5 people tall!", result.ChannelMessage);
+        }
+
+        // ---- Helpers ----
+
+        private void SeedProfiles(params string[] names)
+        {
+            foreach (var name in names)
+            {
+                new ProfileBuilder().WithUserName(name).WithDisplayName(name).BuildAndSave(_database);
+            }
+        }
+
+        private List<PendingCommand> CreateGroup(string initiator, string type, string identifier, params string[] recipients)
+        {
+            string groupId = Guid.NewGuid().ToString("N");
+            var seats = new List<PendingCommand>();
+            foreach (var recipient in recipients)
+            {
+                var seat = new PendingCommand
+                {
+                    Id = ObjectId.GenerateNewId(),
+                    pendingInteraction = new Interaction
+                    {
+                        initiator = initiator,
+                        recipient = recipient,
+                        type = type,
+                        identifier = identifier,
+                        investmentLevel = "casual"
+                    },
+                    awaitingConsentFrom = recipient,
+                    groupId = groupId,
+                    consentState = PendingCommand.PendingConsentState
+                };
+                _database.AddPendingCommand(seat);
+                seats.Add(seat);
+            }
+            return seats;
+        }
+
+        private void ConsentInOrder(List<PendingCommand> seats)
+        {
+            foreach (var seat in seats) ConsentSeat(seat);
+        }
+
+        private void ConsentSeat(PendingCommand seat)
+        {
+            GroupInteractionResolver.MarkSeatConsented(_database, seat);
+        }
+
+        private void ExpireSeat(PendingCommand seat)
+        {
+            seat.startTime = DateTime.UtcNow.AddMinutes(-(GroupInteractionResolver.PendingMinutesKeep + 5));
+            _database.UpdatePendingCommand(seat);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Pendingcommandgroupdatabasetests.cs
+++ b/FChatDicebot.Tests/Unit/Pendingcommandgroupdatabasetests.cs
@@ -1,0 +1,119 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for the database additions backing the group/lifecycle features (B4/B5):
+    /// the two new pending lookups and the +N rate-limited increment helper.
+    /// </summary>
+    [Collection("Database")]
+    public class PendingCommandGroupDatabaseTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public PendingCommandGroupDatabaseTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        [Fact]
+        public void GetPendingCommandsByGroupId_ReturnsOnlyThatGroupsSeats()
+        {
+            string groupId = Guid.NewGuid().ToString("N");
+            _database.AddPendingCommand(MakeSeat("Alice", "Bob", groupId));
+            _database.AddPendingCommand(MakeSeat("Alice", "Carol", groupId));
+            _database.AddPendingCommand(MakeSeat("Alice", "Dave", null)); // 1:1, different request
+
+            var seats = _database.GetPendingCommandsByGroupId(groupId);
+
+            Assert.Equal(2, seats.Count);
+            Assert.All(seats, s => Assert.Equal(groupId, s.groupId));
+        }
+
+        [Fact]
+        public void GetPendingCommandsByInitiator_ReturnsAllSeatsFromThatInitiator()
+        {
+            string groupId = Guid.NewGuid().ToString("N");
+            _database.AddPendingCommand(MakeSeat("Alice", "Bob", groupId));
+            _database.AddPendingCommand(MakeSeat("Alice", "Carol", groupId));
+            _database.AddPendingCommand(MakeSeat("Bob", "Alice", null));
+
+            var aliceSeats = _database.GetPendingCommandsByInitiator("Alice");
+
+            Assert.Equal(2, aliceSeats.Count);
+            Assert.All(aliceSeats, s => Assert.Equal("Alice", s.pendingInteraction.initiator));
+        }
+
+        [Fact]
+        public void ChangeCountByWithRateLimit_FirstCall_AppliesFullAmount()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+
+            bool applied = _database.ChangeCountByWithRateLimit("Alice", "cuddle", 3, TimeSpan.FromMinutes(30));
+
+            Assert.True(applied);
+            Assert.Equal(3, _database.GetProfile("Alice").counts["cuddle"]);
+        }
+
+        [Fact]
+        public void ChangeCountByWithRateLimit_SecondCallWhileLimited_AppliesNothing()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+
+            _database.ChangeCountByWithRateLimit("Alice", "cuddle", 3, TimeSpan.FromMinutes(30));
+            bool applied = _database.ChangeCountByWithRateLimit("Alice", "cuddle", 2, TimeSpan.FromMinutes(30));
+
+            Assert.False(applied);
+            Assert.Equal(3, _database.GetProfile("Alice").counts["cuddle"]); // unchanged
+        }
+
+        [Fact]
+        public void UpdatePendingCommand_PersistsConsentStateAndOrder()
+        {
+            string groupId = Guid.NewGuid().ToString("N");
+            var seat = MakeSeat("Alice", "Bob", groupId);
+            _database.AddPendingCommand(seat);
+
+            seat.consentState = PendingCommand.ConsentedState;
+            seat.consentedOrder = 2;
+            _database.UpdatePendingCommand(seat);
+
+            var reloaded = _database.GetPendingCommandsByGroupId(groupId).Single();
+            Assert.True(reloaded.HasConsented);
+            Assert.Equal(2, reloaded.consentedOrder);
+        }
+
+        private static PendingCommand MakeSeat(string initiator, string recipient, string groupId)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "cuddle",
+                    identifier = null,
+                    investmentLevel = "casual"
+                },
+                awaitingConsentFrom = recipient,
+                groupId = groupId,
+                consentState = PendingCommand.PendingConsentState
+            };
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot/BotCommandController.cs
+++ b/FChatDicebot/BotCommandController.cs
@@ -343,6 +343,50 @@ namespace FChatDicebot
             return null;
         }
 
+        /// <summary>
+        /// Multi-target counterpart of <see cref="GetUserNameFromCommandTerms"/>: returns every
+        /// <c>[user]…[/user]</c> tag in the command, in order, deduplicated (case-insensitive)
+        /// while preserving first-seen order. Used by the casual group commands so
+        /// <c>!cuddle A B C</c> can spin up one shared moment. Never returns null — an empty
+        /// list means no user tags were present.
+        /// </summary>
+        public List<string> GetUserNamesFromCommandTerms(string[] terms)
+        {
+            var names = new List<string>();
+            if (terms == null)
+                return names;
+
+            bool isName = false;
+            string userName = "";
+            foreach (string term in terms)
+            {
+                if (isName)
+                {
+                    userName += " " + term;
+                }
+
+                if (term.StartsWith("[user]"))
+                {
+                    isName = true;
+                    userName = term;
+                }
+
+                if (term.EndsWith("[/user]"))
+                {
+                    isName = false;
+                    userName = userName.Remove(0, 6);
+                    userName = userName.Remove(userName.Length - 7);
+                    Utils.SanitizeInput(userName);
+                    if (!string.IsNullOrWhiteSpace(userName) &&
+                        !names.Any(n => string.Equals(n, userName, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        names.Add(userName);
+                    }
+                }
+            }
+            return names;
+        }
+
         public string GetEIconFromCommandTerms(string[] terms)
         {
             bool isEIcon = false;

--- a/FChatDicebot/BotCommands/ChateauBoobhat.cs
+++ b/FChatDicebot/BotCommands/ChateauBoobhat.cs
@@ -18,8 +18,8 @@ namespace FChatDicebot.BotCommands
             Name = "boobhat";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Put your chest on another resident's head";
-            LongDescription = "Rest your chest atop another resident's head like a hat, as soon as they !consent. Intended for those with a proper set of boobs, but no one is stopping you from doing it with your pecs instead.";
+            ShortDescription = "Put your chest on another resident's (or residents') head";
+            LongDescription = "Rest your chest atop another resident's (or residents') head like a hat, as soon as they !consent. Intended for those with a proper set of boobs, but no one is stopping you from doing it with your pecs instead.";
             Usage = "!boobhat [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "lick", "cuddle", "consent", "dossier" };
             CooldownDuration = "30 minutes (but can still interact without incrementing count)";
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "boobhat", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauBully.cs
+++ b/FChatDicebot/BotCommands/ChateauBully.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
             Name = "bully";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Bully another resident";
+            ShortDescription = "Bully another resident (or residents)";
             LongDescription = "Bully someone in a playful way. They must !consent and thus admit that they deserve a bit of bullying. Note that the Chateau does not condone actual bullying in any way shape or form.";
             Usage = "!bully [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "spank", "consent", "dossier" };
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "bully", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauCancel.cs
+++ b/FChatDicebot/BotCommands/ChateauCancel.cs
@@ -1,0 +1,33 @@
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!cancel</c> — alias for <c>!oops</c>. See <see cref="ChateauOops"/>.
+    /// </summary>
+    public class ChateauCancel : ChatBotCommand
+    {
+        public ChateauCancel()
+        {
+            Name = "cancel";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !oops";
+            LongDescription = "Alternative wording for the !oops command. See !help oops for full details.";
+            Usage = "!cancel\nor\n!cancel all\nor\n!cancel {number}\nor\n!cancel {name}";
+            RelatedCommands = new string[] { "oops", "consent", "no" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            new ChateauOops().Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -19,9 +19,9 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { "c", "accept" };
             Category = "General";
             ShortDescription = "Consent to a pending interaction";
-            LongDescription = "Give your consent to a pending interaction request from another character. When someone requests an interaction with you, you must !consent for it to actually happen and be recorded.\n\nPending requests expire after 10 minutes. If more than one interaction is awaiting your consent, you will be messaged a numbered list of the interactions, and can choose which interaction to consent to, or '!consent all' to consent to every interaction awaiting your consent.";
-            Usage = "!consent\nor\n!consent all\nor\n!consent {number}\nor\n!c\nor\n!c all\nor\n!c {number}";
-            RelatedCommands = new string[] { "kiss", "cuddle", "bully" };
+            LongDescription = "Give your consent to a pending interaction request from another character. When someone requests an interaction with you, you must !consent for it to actually happen and be recorded.\n\nPending requests expire after 10 minutes. If more than one interaction is awaiting your consent, you will be messaged a numbered list of the interactions, and can choose which interaction to consent to, '!consent {name}' to consent to a specific person's request, or '!consent all' to consent to every interaction awaiting your consent.\n\nIf the request is a group interaction, it resolves once everyone has either consented or declined (or the 10-minute timer runs out).";
+            Usage = "!consent\nor\n!consent all\nor\n!consent {number}\nor\n!consent {name}\nor\n!c\nor\n!c all\nor\n!c {number}";
+            RelatedCommands = new string[] { "kiss", "cuddle", "bully", "no" };
             CooldownDuration = null;
             CooldownAppliesTo = null;
             IdentifierCategory = null;
@@ -33,123 +33,104 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
-            List<PendingCommand> pendingList = MonDB.getPending(characterName);
-            int numToConsent = Utils.GetNumberFromInputs(terms);
-            string firstTerm = terms.FirstOrDefault();
-            string recipientDisplayName = string.Empty;
-            string initiatorDisplayName = string.Empty;
+            var database = MonDB.GetDatabase();
+            int pendingMinutesKeep = InteractionProcessors.GroupInteractionResolver.PendingMinutesKeep;
+            int maxNoSpoilerLength = 500;
             string privateMessage = string.Empty;
             string channelMessage = string.Empty;
-            int maxNoSpoilerLength = 500;
-            int pendingMinutesKeep = 10;
-            bool all = false;
-            foreach (PendingCommand pendingCommand in pendingList)
+
+            // Sweep expired pendings awaiting this character. A group seat that expires can
+            // let its group resolve with whoever else consented, so remember those groupIds.
+            var touchedGroups = new HashSet<string>();
+            foreach (PendingCommand pendingCommand in MonDB.getPending(characterName))
             {
-                if (pendingCommand.startTime.CompareTo(DateTime.UtcNow.AddMinutes(-pendingMinutesKeep)) < 0) //it has been more than the allotted time to keep the pending Interaction
+                if (pendingCommand.startTime.CompareTo(DateTime.UtcNow.AddMinutes(-pendingMinutesKeep)) < 0)
                 {
+                    if (pendingCommand.IsGroupSeat) touchedGroups.Add(pendingCommand.groupId);
                     MonDB.removePendingInteraction(pendingCommand.Id);
                 }
             }
-            pendingList = MonDB.getPending(characterName);
 
-            if (firstTerm != null)
-            {
-                if (firstTerm == "all"){
-                    all = true;
-                }
-            }
+            List<PendingCommand> pendingList = MonDB.getPending(characterName);
+            string firstTerm = terms.FirstOrDefault();
+            int numToConsent = Utils.GetNumberFromInputs(terms);
+            bool all = firstTerm == "all";
+
+            // Resolve the seats this !consent acts on, per the bare / all / # / <name> grammar.
+            List<PendingCommand> toActOn = new List<PendingCommand>();
             if (pendingList.Count == 0)
             {
                 privateMessage = "No one is awaiting your consent. Maybe you can make the first move?~";
             }
-            else if ((pendingList.Count == 1) || all)
+            else if (all)
             {
-                foreach (PendingCommand toConsent in pendingList)
-                {
-                    // Try new processor system first
-                    var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor(toConsent.pendingInteraction.type);
-                    if (processor != null)
-                    {
-                        // Process the interaction (saves to DB, updates profiles)
-                        processor.ProcessInteraction(toConsent);
-
-                        //get completion message
-                        Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
-                        Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
-                        channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
-                        channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
-
-                        // Drain any out-of-band private note the processor wants sent to
-                        // the initiator (e.g. corrupt/purify's TOCTOU exhaustion notice).
-                        string initiatorPrivate = processor.GetAndClearInitiatorPrivateMessage();
-                        if (!string.IsNullOrEmpty(initiatorPrivate))
-                        {
-                            bot.SendPrivateMessage(initiatorPrivate, toConsent.pendingInteraction.initiator);
-                        }
-                    }
-                    else
-                    {
-                        // Fallback for non-migrated interactions
-                        ChateauInteractionHandler.addInteraction(toConsent);
-                        //channelMessage += getInteractionMessage(toConsent.pendingInteraction.type, toConsent.pendingInteraction.identifier, toConsent.pendingInteraction.initiator, toConsent.pendingInteraction.recipient);
-                        channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
-                    }
-
-                    channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.initiator);
-                    channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.recipient);
-                }
-                if (channelMessage.Length > maxNoSpoilerLength)
-                {
-                    channelMessage = "Consent is such a wonderful thing~ This was a long one though, so the details are in the spoiler below. \n[spoiler]" + channelMessage + "[/spoiler]";
-                }
-            } 
-            else if ((numToConsent >= 0) && (numToConsent <= pendingList.Count))
+                toActOn.AddRange(pendingList);
+            }
+            else if (numToConsent >= 1 && numToConsent <= pendingList.Count)
             {
-                PendingCommand toConsent = pendingList.ElementAt(numToConsent - 1);
-                // Try new processor system first
-                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor(toConsent.pendingInteraction.type);
-                if (processor != null)
+                toActOn.Add(pendingList.ElementAt(numToConsent - 1));
+            }
+            else
+            {
+                PendingCommand named = FindSeatByInitiator(commandController, rawTerms, terms, pendingList);
+                if (named != null)
                 {
-                    // Process the interaction (saves to DB, updates profiles)
-                    processor.ProcessInteraction(toConsent);
-
-                    // Get the completion message
-                    Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
-                    Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
-                    channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
-                    channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
-
-                    // Drain any out-of-band private note the processor wants sent to
-                    // the initiator (e.g. corrupt/purify's TOCTOU exhaustion notice).
-                    string initiatorPrivate = processor.GetAndClearInitiatorPrivateMessage();
-                    if (!string.IsNullOrEmpty(initiatorPrivate))
-                    {
-                        bot.SendPrivateMessage(initiatorPrivate, toConsent.pendingInteraction.initiator);
-                    }
+                    toActOn.Add(named);
+                }
+                else if (pendingList.Count == 1)
+                {
+                    toActOn.Add(pendingList[0]);
                 }
                 else
                 {
-                    // Fallback for non-migrated interactions
-                    ChateauInteractionHandler.addInteraction(toConsent);
-                    //channelMessage += getInteractionMessage(toConsent.pendingInteraction.type, toConsent.pendingInteraction.identifier, toConsent.pendingInteraction.initiator, toConsent.pendingInteraction.recipient);
-                    channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
+                    privateMessage = "Use '!consent #' to consent to the correct interaction. You have the following interactions awaiting your consent:";
+                    int n = 1;
+                    foreach (PendingCommand seat in pendingList)
+                    {
+                        privateMessage += "\n" + n + ": [b]" + seat.pendingInteraction.type + "[/b] initiated by [user]" + seat.pendingInteraction.initiator + "[/user]";
+                        if (seat.IsGroupSeat) privateMessage += " (group)";
+                        n++;
+                    }
+                    channelMessage = "There's multiple people awaiting your consent, " + characterName + ". Either '!consent all', or refer to the list we just messaged you.";
                 }
-                channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.initiator);
-                channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.recipient);
             }
 
-            else
+            // Group seats defer (mark consented; resolve when the last seat clears); 1:1 seats
+            // process immediately as before.
+            foreach (PendingCommand seat in toActOn)
             {
-                privateMessage = "Use '!consent #' to consent to the correct interaction. You have the following interactions awaiting your consent:";
-                int n = 1;
-                foreach(PendingCommand toConsent in pendingList)
+                if (seat.IsGroupSeat)
                 {
-                    privateMessage += "\n" + n + ": [b]" + toConsent.pendingInteraction.type + "[/b] initiated by [user]" + toConsent.pendingInteraction.initiator + "[/user]";
-                    n++;
+                    InteractionProcessors.GroupInteractionResolver.MarkSeatConsented(database, seat);
+                    touchedGroups.Add(seat.groupId);
                 }
-                channelMessage = "There's multiple people awaiting your consent, " + characterName + ". Either '!consent all', or refer to the list we just messaged you.";
-               
+                else
+                {
+                    channelMessage += ProcessOneToOneSeat(bot, seat);
+                }
             }
+
+            // Fire any group whose last Pending seat just cleared.
+            foreach (string groupId in touchedGroups)
+            {
+                var resolution = InteractionProcessors.GroupInteractionResolver.CheckAndResolve(database, groupId);
+                if (resolution.Resolved && !string.IsNullOrEmpty(resolution.ChannelMessage))
+                {
+                    string groupMessage = resolution.ChannelMessage;
+                    foreach (string participant in resolution.Participants)
+                    {
+                        groupMessage = CheckAchievementsAndAppendToMessage(groupMessage, participant);
+                    }
+                    if (!string.IsNullOrEmpty(channelMessage)) channelMessage += "\n\n";
+                    channelMessage += groupMessage;
+                }
+            }
+
+            if (channelMessage.Length > maxNoSpoilerLength)
+            {
+                channelMessage = "Consent is such a wonderful thing~ This was a long one though, so the details are in the spoiler below. \n[spoiler]" + channelMessage + "[/spoiler]";
+            }
+
             if (channelMessage != string.Empty)
             {
                 bot.SendMessageInChannel(channelMessage, channel);
@@ -158,20 +139,78 @@ namespace FChatDicebot.BotCommands
             {
                 bot.SendPrivateMessage(privateMessage, characterName);
             }
+        }
 
-            string CheckAchievementsAndAppendToMessage(string message, string profile)
+        /// <summary>
+        /// Process one ordinary (non-group) 1:1 seat exactly as legacy !consent did: run the
+        /// processor, build the completion + rate-limit text, route any initiator-private note,
+        /// and append title notifications for both parties. Returns the channel fragment.
+        /// </summary>
+        private string ProcessOneToOneSeat(BotMain bot, PendingCommand toConsent)
+        {
+            string channelMessage = string.Empty;
+            var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor(toConsent.pendingInteraction.type);
+            if (processor != null)
             {
-                // Check for system title achievements
-                string titlesText = ChateauSystemTitles.CheckAndGrantTitles(profile);
+                // Process the interaction (saves to DB, updates profiles)
+                processor.ProcessInteraction(toConsent);
 
-                // Append title notifications to the message
-                if (!string.IsNullOrEmpty(titlesText))
+                Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
+                Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
+                channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
+                channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
+
+                // Drain any out-of-band private note the processor wants sent to the
+                // initiator (e.g. corrupt/purify's TOCTOU exhaustion notice).
+                string initiatorPrivate = processor.GetAndClearInitiatorPrivateMessage();
+                if (!string.IsNullOrEmpty(initiatorPrivate))
                 {
-                    message += titlesText;
+                    bot.SendPrivateMessage(initiatorPrivate, toConsent.pendingInteraction.initiator);
                 }
-
-                return message;
             }
+            else
+            {
+                // Fallback for non-migrated interactions
+                ChateauInteractionHandler.addInteraction(toConsent);
+                channelMessage += CheckRateLimitsAndGetMessage(toConsent.pendingInteraction);
+            }
+
+            channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.initiator);
+            channelMessage = CheckAchievementsAndAppendToMessage(channelMessage, toConsent.pendingInteraction.recipient);
+            return channelMessage;
+        }
+
+        /// <summary>
+        /// By-name targeting (B5.8): match a pending whose initiator equals the typed name —
+        /// either an explicit [user] tag or the first plain word. Returns null when no name was
+        /// supplied or none matches, so the caller can fall back to bare/list behavior.
+        /// </summary>
+        private PendingCommand FindSeatByInitiator(BotCommandController commandController, string[] rawTerms, string[] terms, List<PendingCommand> pendingList)
+        {
+            string tagged = commandController.GetUserNameFromCommandTerms(rawTerms);
+            string candidate = !string.IsNullOrEmpty(tagged) ? tagged : terms.FirstOrDefault();
+            if (string.IsNullOrEmpty(candidate)) return null;
+            if (string.Equals(candidate, "all", StringComparison.OrdinalIgnoreCase)) return null;
+            int ignored;
+            if (int.TryParse(candidate, out ignored)) return null;
+
+            return pendingList.FirstOrDefault(p =>
+                string.Equals(p.pendingInteraction.initiator, candidate, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(MonDB.getDisplayName(p.pendingInteraction.initiator) ?? string.Empty, candidate, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private string CheckAchievementsAndAppendToMessage(string message, string profile)
+        {
+            // Check for system title achievements
+            string titlesText = ChateauSystemTitles.CheckAndGrantTitles(profile);
+
+            // Append title notifications to the message
+            if (!string.IsNullOrEmpty(titlesText))
+            {
+                message += titlesText;
+            }
+
+            return message;
         }
 
         private string CheckRateLimitsAndGetMessage(Interaction interaction)

--- a/FChatDicebot/BotCommands/ChateauCuddle.cs
+++ b/FChatDicebot/BotCommands/ChateauCuddle.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
             Name = "cuddle";
             Aliases = new string[] { "hug" };
             Category = "Casual Interaction";
-            ShortDescription = "Cuddle with another resident";
+            ShortDescription = "Cuddle with another resident (or residents)";
             LongDescription = "Cuddle with another character as soon as they !consent. Whether it's spooning or a warm embrace, this is a favorite past time of Chateau residents.";
             Usage = "!cuddle [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "kiss", "handhold", "consent", "dossier" };
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "cuddle", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauDecline.cs
+++ b/FChatDicebot/BotCommands/ChateauDecline.cs
@@ -1,0 +1,33 @@
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!decline</c> — alias for <c>!no</c>. See <see cref="ChateauNo"/>.
+    /// </summary>
+    public class ChateauDecline : ChatBotCommand
+    {
+        public ChateauDecline()
+        {
+            Name = "decline";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !no";
+            LongDescription = "Alternative wording for the !no command. See !help no for full details.";
+            Usage = "!decline\nor\n!decline all\nor\n!decline {number}\nor\n!decline {name}";
+            RelatedCommands = new string[] { "no", "consent", "oops" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            new ChateauNo().Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHandhold.cs
+++ b/FChatDicebot/BotCommands/ChateauHandhold.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
             Name = "handhold";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Hold hands with another resident";
+            ShortDescription = "Hold hands with another resident (or residents)";
             LongDescription = "Hold hands with someone. The recipient must !consent before the forbidden act takes place. Maybe you should get a room first...";
             Usage = "!handhold [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "kiss", "cuddle", "consent", "dossier" };
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "handhold", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -96,6 +96,8 @@ namespace FChatDicebot.BotCommands
             List<string> roomCommands = new List<string>()
             {
                 "!consent [sub]!c, !accept[/sub] ",
+                "!no [sub]!refuse, !decline[/sub]",
+                "!oops [sub]!o, !withdraw, !cancel[/sub]",
                 "!pledge",
                 "!fulfill"
             };

--- a/FChatDicebot/BotCommands/ChateauKiss.cs
+++ b/FChatDicebot/BotCommands/ChateauKiss.cs
@@ -18,8 +18,8 @@ namespace FChatDicebot.BotCommands
             Name = "kiss";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Give another resident a kiss";
-            LongDescription = "Give another resident a kiss, as soon as they !consent. This is a sweet, affectionate gesture often used as a greeting.";
+            ShortDescription = "Give another resident (or residents) a kiss";
+            LongDescription = "Give another resident (or residents) a kiss, as soon as they !consent. This is a sweet, affectionate gesture often used as a greeting.";
             Usage = "!kiss [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "cuddle", "handhold", "consent", "dossier" };
             CooldownDuration = "30 Minutes";
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "kiss", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauLap.cs
+++ b/FChatDicebot/BotCommands/ChateauLap.cs
@@ -15,8 +15,8 @@ namespace FChatDicebot.BotCommands
             Name = "lap";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Pull another resident onto your lap";
-            LongDescription = "Pull another resident onto your lap once they !consent. If you'd rather be the one taking a seat, try !sit.";
+            ShortDescription = "Pull another resident (or residents) onto your lap";
+            LongDescription = "Pull another resident (or residents) onto your lap once they !consent. If you'd rather be the one taking a seat, try !sit.";
             Usage = "!lap [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "sit", "cuddle", "consent", "dossier" };
             CooldownDuration = "30 minutes (but can still interact without incrementing count)";

--- a/FChatDicebot/BotCommands/ChateauLick.cs
+++ b/FChatDicebot/BotCommands/ChateauLick.cs
@@ -18,8 +18,8 @@ namespace FChatDicebot.BotCommands
             Name = "lick";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Give another resident a lick";
-            LongDescription = "Give another resident a lick once they !consent. Whether to groom, or taste, one of the Queen's favorite acts to receive.";
+            ShortDescription = "Give another resident (or residents) a lick";
+            LongDescription = "Give another resident (or residents) a lick once they !consent. Whether to groom, or taste, one of the Queen's favorite acts to receive.";
             Usage = "!lick [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "boobhat", "kiss", "consent", "dossier" };
             CooldownDuration = "30 minutes (but can still interact without incrementing count)";
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "lick", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauNo.cs
+++ b/FChatDicebot/BotCommands/ChateauNo.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!no</c> (recipient side, B5) — clear a pending that's awaiting your consent, without
+    /// waiting out the 10-minute timer. Mirrors <c>!consent</c>'s bare / all / # /
+    /// <c>&lt;name&gt;</c> grammar. For a group seat, declining clears only your seat; the
+    /// shared moment still resolves with whoever else consented. Aliases <c>!refuse</c> /
+    /// <c>!decline</c> route here.
+    /// </summary>
+    public class ChateauNo : ChatBotCommand
+    {
+        // Owner-provided announcement (B5.7). Public, because the initiator didn't invoke the
+        // bot and so can't be PM'd.
+        public const string RefuseAnnouncement =
+            "Looks like {recipient} isn't in the mood. Remember, it's not true consent if you can't say 'no'!";
+
+        public ChateauNo()
+        {
+            Name = "no";
+            Aliases = new string[] { "refuse", "decline" };
+            Category = "General";
+            ShortDescription = "Decline a pending interaction awaiting your consent";
+            LongDescription = "Decline a pending interaction that's awaiting your consent, instead of waiting out the 10-minute timer. Works just like !consent: bare to decline your only pending, '!no all', '!no {number}', or '!no {name}' to decline a specific person's request. For a group interaction, this only removes your own seat — the rest can still go ahead.";
+            Usage = "!no\nor\n!no all\nor\n!no {number}\nor\n!no {name}";
+            RelatedCommands = new string[] { "consent", "oops" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            var database = MonDB.GetDatabase();
+            int pendingMinutesKeep = InteractionProcessors.GroupInteractionResolver.PendingMinutesKeep;
+            string channelMessage = string.Empty;
+            string privateMessage = string.Empty;
+
+            // Opportunistic expiry sweep; a swept group seat may let its group resolve.
+            var touchedGroups = new HashSet<string>();
+            foreach (PendingCommand seat in MonDB.getPending(characterName))
+            {
+                if (seat.startTime.CompareTo(DateTime.UtcNow.AddMinutes(-pendingMinutesKeep)) < 0)
+                {
+                    if (seat.IsGroupSeat) touchedGroups.Add(seat.groupId);
+                    MonDB.removePendingInteraction(seat.Id);
+                }
+            }
+
+            List<PendingCommand> pendingList = MonDB.getPending(characterName);
+            string firstTerm = terms.FirstOrDefault();
+            int numTarget = Utils.GetNumberFromInputs(terms);
+            bool all = firstTerm == "all";
+
+            List<PendingCommand> toRefuse = new List<PendingCommand>();
+            if (pendingList.Count == 0)
+            {
+                privateMessage = "No one is awaiting your consent, so there's nothing to decline.";
+            }
+            else if (all)
+            {
+                toRefuse.AddRange(pendingList);
+            }
+            else if (numTarget >= 1 && numTarget <= pendingList.Count)
+            {
+                toRefuse.Add(pendingList.ElementAt(numTarget - 1));
+            }
+            else
+            {
+                PendingCommand named = Support.LifecycleTargeting.FindByCounterparty(
+                    commandController, rawTerms, terms, pendingList, p => p.pendingInteraction.initiator);
+                if (named != null)
+                {
+                    toRefuse.Add(named);
+                }
+                else if (pendingList.Count == 1)
+                {
+                    toRefuse.Add(pendingList[0]);
+                }
+                else
+                {
+                    privateMessage = "Use '!no #' to decline the correct interaction. You have the following interactions awaiting your consent:";
+                    int n = 1;
+                    foreach (PendingCommand seat in pendingList)
+                    {
+                        privateMessage += "\n" + n + ": [b]" + seat.pendingInteraction.type + "[/b] initiated by [user]" + seat.pendingInteraction.initiator + "[/user]";
+                        if (seat.IsGroupSeat) privateMessage += " (group)";
+                        n++;
+                    }
+                    channelMessage = "There's more than one request awaiting you, " + characterName + ". Either '!no all', or refer to the list we just messaged you.";
+                }
+            }
+
+            // Clear the caller's own seat(s). For a group seat this leaves the rest intact.
+            foreach (PendingCommand seat in toRefuse)
+            {
+                if (seat.IsGroupSeat) touchedGroups.Add(seat.groupId);
+                MonDB.removePendingInteraction(seat.Id);
+            }
+
+            if (toRefuse.Count > 0)
+            {
+                Profile caller = MonDB.getProfile(characterName);
+                string callerName = caller != null ? caller.displayName : characterName;
+                channelMessage = RefuseAnnouncement.Replace("{recipient}", callerName);
+            }
+
+            // A declined group seat may complete the group for whoever else already consented.
+            foreach (string groupId in touchedGroups)
+            {
+                var resolution = InteractionProcessors.GroupInteractionResolver.CheckAndResolve(database, groupId);
+                if (resolution.Resolved && !string.IsNullOrEmpty(resolution.ChannelMessage))
+                {
+                    string groupMessage = resolution.ChannelMessage;
+                    foreach (string participant in resolution.Participants)
+                    {
+                        string titles = ChateauSystemTitles.CheckAndGrantTitles(participant);
+                        if (!string.IsNullOrEmpty(titles)) groupMessage += titles;
+                    }
+                    if (!string.IsNullOrEmpty(channelMessage)) channelMessage += "\n\n";
+                    channelMessage += groupMessage;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(channelMessage))
+            {
+                bot.SendMessageInChannel(channelMessage, channel);
+            }
+            if (!string.IsNullOrEmpty(privateMessage))
+            {
+                bot.SendPrivateMessage(privateMessage, characterName);
+            }
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauO.cs
+++ b/FChatDicebot/BotCommands/ChateauO.cs
@@ -1,0 +1,34 @@
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!o</c> — short alias for <c>!oops</c>. See <see cref="ChateauOops"/>. (The initiator's
+    /// counterpart to <c>!c</c>; <c>!w</c> is taken by <c>!work</c>, hence the rename.)
+    /// </summary>
+    public class ChateauO : ChatBotCommand
+    {
+        public ChateauO()
+        {
+            Name = "o";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !oops";
+            LongDescription = "Shorthand for the !oops command. See !help oops for full details.";
+            Usage = "!o\nor\n!o all\nor\n!o {number}\nor\n!o {name}";
+            RelatedCommands = new string[] { "oops", "consent", "no" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            new ChateauOops().Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauOops.cs
+++ b/FChatDicebot/BotCommands/ChateauOops.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!oops</c> (initiator side, B5) — cancel a pending you started, without waiting out the
+    /// 10-minute timer. Bare / all / # / <c>&lt;name&gt;</c> grammar like <c>!consent</c>, where
+    /// <c>&lt;name&gt;</c> is a recipient. For a group interaction, cancelling nukes every seat
+    /// of that group (you're calling off the whole pile). Aliases <c>!o</c> / <c>!withdraw</c> /
+    /// <c>!cancel</c> route here.
+    /// </summary>
+    public class ChateauOops : ChatBotCommand
+    {
+        // Owner-provided announcement (B5.7). Public — the recipient(s) didn't invoke the bot.
+        public const string WithdrawAnnouncement =
+            "Nevermind! {initiator} says that was a clerical error.";
+
+        public ChateauOops()
+        {
+            Name = "oops";
+            Aliases = new string[] { "o", "withdraw", "cancel" };
+            Category = "General";
+            ShortDescription = "Cancel a pending interaction you started";
+            LongDescription = "Cancel a pending interaction you initiated, instead of waiting out the 10-minute timer. Works like !consent: bare to cancel your only outgoing request, '!oops all', '!oops {number}', or '!oops {name}' to cancel a specific person's request. Cancelling a group interaction removes the whole pile.";
+            Usage = "!oops\nor\n!oops all\nor\n!oops {number}\nor\n!oops {name}";
+            RelatedCommands = new string[] { "consent", "no" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            int pendingMinutesKeep = GroupInteractionResolver.PendingMinutesKeep;
+            string channelMessage = string.Empty;
+            string privateMessage = string.Empty;
+
+            // Opportunistic expiry sweep over this initiator's outgoing seats.
+            foreach (PendingCommand seat in MonDB.getPendingByInitiator(characterName))
+            {
+                if (seat.startTime.CompareTo(DateTime.UtcNow.AddMinutes(-pendingMinutesKeep)) < 0)
+                {
+                    MonDB.removePendingInteraction(seat.Id);
+                }
+            }
+
+            List<PendingCommand> outgoing = MonDB.getPendingByInitiator(characterName);
+
+            // Collapse group seats into one logical entry each (the initiator cancels the whole
+            // group at once); 1:1 seats stand alone. Order preserved by first appearance.
+            var logicalEntries = BuildLogicalEntries(outgoing);
+
+            string firstTerm = terms.FirstOrDefault();
+            int numTarget = Utils.GetNumberFromInputs(terms);
+            bool all = firstTerm == "all";
+
+            List<List<PendingCommand>> toWithdraw = new List<List<PendingCommand>>();
+            if (logicalEntries.Count == 0)
+            {
+                privateMessage = "You don't have any pending requests out right now.";
+            }
+            else if (all)
+            {
+                toWithdraw.AddRange(logicalEntries);
+            }
+            else if (numTarget >= 1 && numTarget <= logicalEntries.Count)
+            {
+                toWithdraw.Add(logicalEntries.ElementAt(numTarget - 1));
+            }
+            else
+            {
+                List<PendingCommand> named = FindEntryByRecipient(commandController, rawTerms, terms, logicalEntries);
+                if (named != null)
+                {
+                    toWithdraw.Add(named);
+                }
+                else if (logicalEntries.Count == 1)
+                {
+                    toWithdraw.Add(logicalEntries[0]);
+                }
+                else
+                {
+                    privateMessage = "Use '!oops #' to cancel the correct request. You currently have these requests out:";
+                    int n = 1;
+                    foreach (List<PendingCommand> entry in logicalEntries)
+                    {
+                        privateMessage += "\n" + n + ": [b]" + entry[0].pendingInteraction.type + "[/b] with " + DescribeRecipients(entry);
+                        if (entry[0].IsGroupSeat) privateMessage += " (group)";
+                        n++;
+                    }
+                    channelMessage = "You've got more than one request out, " + characterName + ". Either '!oops all', or refer to the list we just messaged you.";
+                }
+            }
+
+            int cleared = 0;
+            foreach (List<PendingCommand> entry in toWithdraw)
+            {
+                foreach (PendingCommand seat in entry)
+                {
+                    MonDB.removePendingInteraction(seat.Id);
+                    cleared++;
+                }
+            }
+
+            if (cleared > 0)
+            {
+                Profile caller = MonDB.getProfile(characterName);
+                string callerName = caller != null ? caller.displayName : characterName;
+                channelMessage = WithdrawAnnouncement.Replace("{initiator}", callerName);
+            }
+
+            if (!string.IsNullOrEmpty(channelMessage))
+            {
+                bot.SendMessageInChannel(channelMessage, channel);
+            }
+            if (!string.IsNullOrEmpty(privateMessage))
+            {
+                bot.SendPrivateMessage(privateMessage, characterName);
+            }
+        }
+
+        private static List<List<PendingCommand>> BuildLogicalEntries(List<PendingCommand> seats)
+        {
+            var entries = new List<List<PendingCommand>>();
+            var seenGroups = new HashSet<string>();
+            foreach (PendingCommand seat in seats)
+            {
+                if (seat.IsGroupSeat)
+                {
+                    if (seenGroups.Add(seat.groupId))
+                    {
+                        entries.Add(seats.Where(s => s.groupId == seat.groupId).ToList());
+                    }
+                }
+                else
+                {
+                    entries.Add(new List<PendingCommand> { seat });
+                }
+            }
+            return entries;
+        }
+
+        private static string DescribeRecipients(List<PendingCommand> entry)
+        {
+            var names = entry.Select(s => "[user]" + s.awaitingConsentFrom + "[/user]").ToList();
+            return InteractionProcessorBase.JoinNamesSerial(names);
+        }
+
+        private static List<PendingCommand> FindEntryByRecipient(
+            BotCommandController commandController, string[] rawTerms, string[] terms,
+            List<List<PendingCommand>> logicalEntries)
+        {
+            // Flatten, match a single seat by its recipient, then return that seat's entry.
+            var flat = logicalEntries.SelectMany(e => e).ToList();
+            PendingCommand match = Support.LifecycleTargeting.FindByCounterparty(
+                commandController, rawTerms, terms, flat, s => s.awaitingConsentFrom);
+            if (match == null) return null;
+            return logicalEntries.FirstOrDefault(e => e.Contains(match));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauRefuse.cs
+++ b/FChatDicebot/BotCommands/ChateauRefuse.cs
@@ -1,0 +1,33 @@
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!refuse</c> — alias for <c>!no</c>. See <see cref="ChateauNo"/>.
+    /// </summary>
+    public class ChateauRefuse : ChatBotCommand
+    {
+        public ChateauRefuse()
+        {
+            Name = "refuse";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !no";
+            LongDescription = "Alternative wording for the !no command. See !help no for full details.";
+            Usage = "!refuse\nor\n!refuse all\nor\n!refuse {number}\nor\n!refuse {name}";
+            RelatedCommands = new string[] { "no", "consent", "oops" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            new ChateauNo().Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauSit.cs
+++ b/FChatDicebot/BotCommands/ChateauSit.cs
@@ -15,8 +15,8 @@ namespace FChatDicebot.BotCommands
             Name = "sit";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Take a seat on another resident's lap";
-            LongDescription = "Sit on another resident's lap once they !consent. Rin's specialty. If you'd rather have someone else in your lap, try !lap.";
+            ShortDescription = "Take a seat on another resident's (or residents') lap";
+            LongDescription = "Sit on another resident's (or residents') lap once they !consent. Rin's specialty. If you'd rather have someone else in your lap, try !lap.";
             Usage = "!sit [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "lap", "cuddle", "consent", "dossier" };
             CooldownDuration = "30 minutes (but can still interact without incrementing count)";

--- a/FChatDicebot/BotCommands/ChateauSpank.cs
+++ b/FChatDicebot/BotCommands/ChateauSpank.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
             Name = "spank";
             Aliases = new string[] { };
             Category = "Casual Interaction";
-            ShortDescription = "Spank another resident";
+            ShortDescription = "Spank another resident (or residents)";
             LongDescription = "Punish someone with a playful spank, but you need !consent to raise your hand against another in the Chateau. Some people use this to cook turkey!";
             Usage = "!spank [noparse][user]NameInUserTag[/user][/noparse]";
             RelatedCommands = new string[] { "bully", "consent", "dossier" };
@@ -33,6 +33,13 @@ namespace FChatDicebot.BotCommands
 
         public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
         {
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "spank", groupTargets);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/BotCommands/ChateauWithdraw.cs
+++ b/FChatDicebot/BotCommands/ChateauWithdraw.cs
@@ -1,0 +1,33 @@
+using FChatDicebot.BotCommands.Base;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!withdraw</c> — alias for <c>!oops</c>. See <see cref="ChateauOops"/>.
+    /// </summary>
+    public class ChateauWithdraw : ChatBotCommand
+    {
+        public ChateauWithdraw()
+        {
+            Name = "withdraw";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Alias for !oops";
+            LongDescription = "Alternative wording for the !oops command. See !help oops for full details.";
+            Usage = "!withdraw\nor\n!withdraw all\nor\n!withdraw {number}\nor\n!withdraw {name}";
+            RelatedCommands = new string[] { "oops", "consent", "no" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, string characterName, string channel, UserGeneratedCommand command)
+        {
+            new ChateauOops().Run(bot, commandController, rawTerms, terms, characterName, channel, command);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/Support/CasualGroupCommandSupport.cs
+++ b/FChatDicebot/BotCommands/Support/CasualGroupCommandSupport.cs
@@ -1,0 +1,148 @@
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// Shared multi-target wiring for the casual interaction commands (B4). When a casual
+    /// command is invoked with more than one <c>[user]</c> tag it routes here, which:
+    ///   - drops the initiator's own name (with a whisper) and de-duplicates,
+    ///   - caps the recipient list at <see cref="MaxRecipients"/>,
+    ///   - whispers about any unregistered names and skips them,
+    ///   - mints one shared groupId and creates one seat per recipient, and
+    ///   - posts a single group consent announcement.
+    /// Each recipient then consents individually with plain <c>!consent</c>; the shared
+    /// moment resolves via <see cref="GroupInteractionResolver"/> once no seat is left Pending.
+    ///
+    /// If the list collapses to a single valid recipient the call degrades to an ordinary
+    /// 1:1 pending so the nicer 1:1 announcement is used.
+    ///
+    /// Lives outside the <c>FChatDicebot.BotCommands</c> namespace so the reflection-based
+    /// command loader doesn't treat it as a chat command.
+    /// </summary>
+    public static class CasualGroupCommandSupport
+    {
+        public const int MaxRecipients = 10;
+
+        // Owner-provided self-target whisper (B4.6).
+        public const string SelfTargetWhisper =
+            "You're already interacting with the other residents, you don't need to also interact with yourself!";
+
+        /// <summary>
+        /// Build a group (or degenerate 1:1) casual pending from a list of target names.
+        /// </summary>
+        /// <param name="interactionType">The processor type key (e.g. "cuddle", or "lap"/"sit").</param>
+        /// <param name="identifier">Identifier carried on each seat (the verb for lapsit; null otherwise).</param>
+        public static void Run(BotMain bot, string characterName, string channel,
+            string interactionType, IReadOnlyList<string> targetNames, string identifier = null)
+        {
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (initiatorProfile == null) return; // dispatcher already guards registration
+
+            var processor = InteractionProcessorRegistry.GetProcessor(interactionType);
+
+            // De-dupe (case-insensitive), drop self-targets, remember if we dropped self.
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var ordered = new List<string>();
+            bool droppedSelf = false;
+            foreach (var name in targetNames)
+            {
+                if (string.IsNullOrWhiteSpace(name)) continue;
+                if (string.Equals(name, characterName, StringComparison.OrdinalIgnoreCase))
+                {
+                    droppedSelf = true;
+                    continue;
+                }
+                if (seen.Add(name)) ordered.Add(name);
+            }
+
+            if (droppedSelf)
+            {
+                bot.SendPrivateMessage(SelfTargetWhisper, characterName);
+            }
+
+            // Resolve profiles; collect unregistered names to report.
+            var recipientProfiles = new List<Profile>();
+            var notFound = new List<string>();
+            foreach (var name in ordered)
+            {
+                Profile profile = MonDB.getProfile(name);
+                if (profile == null) notFound.Add(name);
+                else recipientProfiles.Add(profile);
+            }
+
+            if (notFound.Count > 0)
+            {
+                bot.SendPrivateMessage(
+                    "These residents aren't registered, so they were left out: " + string.Join(", ", notFound),
+                    characterName);
+            }
+
+            // Cap the recipient list, whispering if we truncated.
+            if (recipientProfiles.Count > MaxRecipients)
+            {
+                int dropped = recipientProfiles.Count - MaxRecipients;
+                recipientProfiles = recipientProfiles.Take(MaxRecipients).ToList();
+                bot.SendPrivateMessage(
+                    $"That's a lot of people! Only the first {MaxRecipients} were included this time ({dropped} left out).",
+                    characterName);
+            }
+
+            if (recipientProfiles.Count == 0)
+            {
+                bot.SendPrivateMessage("There was no one left to interact with after sorting out that list.", characterName);
+                return;
+            }
+
+            // Single valid recipient → ordinary 1:1 pending (nicer 1:1 announcement).
+            if (recipientProfiles.Count == 1)
+            {
+                Profile only = recipientProfiles[0];
+                MonDB.addPendingCommand(new PendingCommand
+                {
+                    pendingInteraction = BuildInteraction(characterName, only.userName, interactionType, identifier),
+                    awaitingConsentFrom = only.userName
+                });
+
+                string single = processor != null
+                    ? processor.GetConsentWarning(initiatorProfile, only, identifier)
+                    : initiatorProfile.displayName + " wants to interact with " + only.displayName + ". Do you !consent?";
+                bot.SendMessageInChannel(single, channel);
+                return;
+            }
+
+            // Group: one shared id, one seat per recipient, all awaiting their own consent.
+            string groupId = Guid.NewGuid().ToString("N");
+            foreach (var recipient in recipientProfiles)
+            {
+                MonDB.addPendingCommand(new PendingCommand
+                {
+                    pendingInteraction = BuildInteraction(characterName, recipient.userName, interactionType, identifier),
+                    awaitingConsentFrom = recipient.userName,
+                    groupId = groupId,
+                    consentState = PendingCommand.PendingConsentState
+                });
+            }
+
+            string announcement = processor != null
+                ? processor.GetGroupConsentWarning(initiatorProfile, recipientProfiles, identifier)
+                : initiatorProfile.displayName + " wants to interact with several residents. Each of you, do you !consent?";
+            bot.SendMessageInChannel(announcement, channel);
+        }
+
+        private static Interaction BuildInteraction(string initiator, string recipient, string type, string identifier)
+        {
+            return new Interaction
+            {
+                initiator = initiator,
+                recipient = recipient,
+                type = type,
+                identifier = identifier,
+                investmentLevel = "casual"
+            };
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/Support/LifecycleTargeting.cs
+++ b/FChatDicebot/BotCommands/Support/LifecycleTargeting.cs
@@ -1,0 +1,41 @@
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// Shared by-name targeting for the pending-lifecycle verbs (B5.8). Given the typed terms
+    /// and a way to pull the relevant counterparty off a seat (the initiator for <c>!refuse</c>,
+    /// the recipient for <c>!withdraw</c>), returns the first matching seat — by login name or
+    /// display name, case-insensitively. Returns null when no name was supplied (so the caller
+    /// can fall back to its bare / all / # handling).
+    ///
+    /// Lives in the <c>.Support</c> namespace (not <c>FChatDicebot.BotCommands</c>) so the
+    /// reflection-based command loader — which <c>Activator.CreateInstance</c>s every type in
+    /// that namespace — doesn't choke on this static class.
+    /// </summary>
+    public static class LifecycleTargeting
+    {
+        public static PendingCommand FindByCounterparty(
+            BotCommandController commandController, string[] rawTerms, string[] terms,
+            IEnumerable<PendingCommand> seats, Func<PendingCommand, string> counterpartySelector)
+        {
+            string tagged = commandController.GetUserNameFromCommandTerms(rawTerms);
+            string candidate = !string.IsNullOrEmpty(tagged) ? tagged : (terms != null ? terms.FirstOrDefault() : null);
+            if (string.IsNullOrEmpty(candidate)) return null;
+            if (string.Equals(candidate, "all", StringComparison.OrdinalIgnoreCase)) return null;
+            int ignored;
+            if (int.TryParse(candidate, out ignored)) return null;
+
+            return seats.FirstOrDefault(s =>
+            {
+                string counterparty = counterpartySelector(s);
+                if (string.IsNullOrEmpty(counterparty)) return false;
+                return string.Equals(counterparty, candidate, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(MonDB.getDisplayName(counterparty) ?? string.Empty, candidate, StringComparison.OrdinalIgnoreCase);
+            });
+        }
+    }
+}

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -150,6 +150,51 @@ namespace FChatDicebot.Database
             return true;
         }
 
+        public bool ChangeCountByWithRateLimit(string userName, string countLabel, int changeAmount, TimeSpan rateLimitDuration)
+        {
+            // +N variant of IncrementCountWithRateLimit used by group resolution: one
+            // rate-limit check per (participant, key); if not limited apply the full
+            // changeAmount and arm the timer, otherwise apply nothing and report false so
+            // the caller can surface the "clerks were busy" sub-note for that participant.
+            var collection = Database.GetCollection<Profile>("RegisteredProfiles");
+            var filter = Builders<Profile>.Filter.Eq("userName", userName);
+            var profile = collection.Find(filter).FirstOrDefault();
+
+            if (profile == null) return false;
+
+            string timerKey = $"ratelimit_{countLabel}";
+
+            if (profile.timers != null && profile.timers.ContainsKey(timerKey))
+            {
+                if (DateTime.UtcNow < profile.timers[timerKey].timerEnd)
+                {
+                    // Still on cooldown, don't apply anything.
+                    return false;
+                }
+            }
+
+            if (profile.counts.ContainsKey(countLabel))
+            {
+                profile.counts[countLabel] += changeAmount;
+            }
+            else
+            {
+                profile.counts.Add(countLabel, changeAmount);
+            }
+
+            CoolDown rateLimitTimer = new CoolDown();
+            rateLimitTimer.timerEnd = DateTime.UtcNow.Add(rateLimitDuration);
+            if (profile.timers == null)
+            {
+                profile.timers = new Dictionary<string, CoolDown>();
+            }
+            profile.timers[timerKey] = rateLimitTimer;
+
+            collection.ReplaceOne(filter, profile);
+
+            return true;
+        }
+
         public bool IsCountRateLimited(string userName, string countLabel)
         {
             Profile profile = GetProfile(userName);
@@ -397,6 +442,13 @@ namespace FChatDicebot.Database
             collection.InsertOne(toAdd.ToBsonDocument());
         }
 
+        public void UpdatePendingCommand(PendingCommand updated)
+        {
+            var collection = Database.GetCollection<BsonDocument>("PendingCommands");
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", updated.Id);
+            collection.ReplaceOne(filter, updated.ToBsonDocument());
+        }
+
         public PendingCommand GetPendingCommand(ObjectId commandId)
         {
             var collection = Database.GetCollection<BsonDocument>("PendingCommands");
@@ -408,6 +460,27 @@ namespace FChatDicebot.Database
                 return BsonSerializer.Deserialize<PendingCommand>(document);
             }
             return null;
+        }
+
+        public List<PendingCommand> GetPendingCommandsByGroupId(string groupId)
+        {
+            var collection = Database.GetCollection<BsonDocument>("PendingCommands");
+            var filter = Builders<BsonDocument>.Filter.Eq("groupId", groupId);
+            var documents = collection.Find(filter).ToList();
+
+            return documents.Select(doc => BsonSerializer.Deserialize<PendingCommand>(doc)).ToList();
+        }
+
+        public List<PendingCommand> GetPendingCommandsByInitiator(string initiator)
+        {
+            // The initiator lives on the nested interaction document, so the filter has to
+            // reach through pendingInteraction.initiator. Used by !withdraw and by group
+            // resolution to recover every seat the initiator has out.
+            var collection = Database.GetCollection<BsonDocument>("PendingCommands");
+            var filter = Builders<BsonDocument>.Filter.Eq("pendingInteraction.initiator", initiator);
+            var documents = collection.Find(filter).ToList();
+
+            return documents.Select(doc => BsonSerializer.Deserialize<PendingCommand>(doc)).ToList();
         }
 
         public PendingCommand GetPendingCommandAwaitingConsent(string awaitingConsentFrom)

--- a/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/Database/Ichateaudatabase.cs
@@ -20,6 +20,7 @@ namespace FChatDicebot.Database
         void DecrementCount(string userName, string countLabel);
         void ChangeCount(string userName, string countLabel, int changeAmount);
         bool IncrementCountWithRateLimit(string userName, string countLabel, TimeSpan rateLimitDuration);
+        bool ChangeCountByWithRateLimit(string userName, string countLabel, int changeAmount, TimeSpan rateLimitDuration);
         bool IsCountRateLimited(string userName, string countLabel);
         void SetCharacteristic(string userName, string characteristicLabel, string characteristicValue);
         void AddToList(string userName, string listLabel, string listValue);
@@ -47,9 +48,12 @@ namespace FChatDicebot.Database
 
         // Pending Command Operations
         void AddPendingCommand(PendingCommand toAdd);
+        void UpdatePendingCommand(PendingCommand updated);
         PendingCommand GetPendingCommand(ObjectId commandId);
         PendingCommand GetPendingCommandAwaitingConsent(string awaitingConsentFrom);
         List<PendingCommand> GetPendingCommands(string awaitingConsentFrom);
+        List<PendingCommand> GetPendingCommandsByGroupId(string groupId);
+        List<PendingCommand> GetPendingCommandsByInitiator(string initiator);
         void DeletePendingCommand(ObjectId commandId);
 
         // Duty Operations

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -197,6 +197,7 @@
     <Compile Include="BotCommands\ChateauEconomics.cs" />
     <Compile Include="BotCommands\Support\ChateauStatisticsSupport.cs" />
     <Compile Include="BotCommands\Support\BondTreeSupport.cs" />
+    <Compile Include="BotCommands\Support\CasualGroupCommandSupport.cs" />
     <Compile Include="BotCommands\ChateauBondtree.cs" />
     <Compile Include="BotCommands\ChateauFamilytree.cs" />
     <Compile Include="BotCommands\ChateauIdentifiers.cs" />
@@ -240,6 +241,14 @@
     <Compile Include="BotCommands\CombinedCommands\GetRandomPotion.cs" />
     <Compile Include="BotCommands\GeneratePotionInfo.cs" />
     <Compile Include="BotCommands\ChateauConsent.cs" />
+    <Compile Include="BotCommands\ChateauNo.cs" />
+    <Compile Include="BotCommands\ChateauRefuse.cs" />
+    <Compile Include="BotCommands\ChateauDecline.cs" />
+    <Compile Include="BotCommands\ChateauOops.cs" />
+    <Compile Include="BotCommands\ChateauO.cs" />
+    <Compile Include="BotCommands\ChateauWithdraw.cs" />
+    <Compile Include="BotCommands\ChateauCancel.cs" />
+    <Compile Include="BotCommands\Support\LifecycleTargeting.cs" />
     <Compile Include="BotCommands\ModMessage.cs" />
     <Compile Include="BotCommands\CombinedCommands\MoveChips.cs" />
     <Compile Include="BotCommands\DeletePotion.cs" />
@@ -377,6 +386,8 @@
     <Compile Include="InteractionProcessors\Commitment\MarkProcessor.cs" />
     <Compile Include="InteractionProcessors\CooldownSpec.cs" />
     <Compile Include="InteractionProcessors\ConsentWarningText.cs" />
+    <Compile Include="InteractionProcessors\GroupSpec.cs" />
+    <Compile Include="InteractionProcessors\GroupInteractionResolver.cs" />
     <Compile Include="InteractionProcessors\IdentifierPayload.cs" />
     <Compile Include="InteractionProcessors\IInteractionProcessor.cs" />
     <Compile Include="InteractionProcessors\InteractionProcessorBase.cs" />

--- a/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -17,6 +18,18 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
 
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Directional group model: initiator +R boobhatgive, each recipient +1 boobhattake.
+        public override GroupSpec GroupSpec => GroupSpec.Directional("boobhatgive", "boobhattake");
+
+        private static readonly List<string> BoobhatDescriptors = new List<string>
+        {
+            "Nice hat!",
+            "How heavy are they?",
+            "Can you still see?",
+            "Soft, warm...",
+            "How forward!"
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -53,17 +66,16 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            // Owner-provided descriptors.
-            var boobhatDescriptors = new List<string>
-            {
-                "Nice hat!",
-                "How heavy are they?",
-                "Can you still see?",
-                "Soft, warm...",
-                "How forward!"
-            };
+            return $"{initiatorProfile.displayName} lets the full weight of their chest fall onto {recipientProfile.displayName}. {GetRandomDescriptor(BoobhatDescriptors)}";
+        }
 
-            return $"{initiatorProfile.displayName} lets the full weight of their chest fall onto {recipientProfile.displayName}. {GetRandomDescriptor(boobhatDescriptors)}";
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());
+            return $"{initiatorProfile.displayName} rests their chest atop {names}, one comfy hat at a time. {GetRandomDescriptor(BoobhatDescriptors)}";
         }
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)

--- a/FChatDicebot/InteractionProcessors/Casual/BullyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/BullyProcessor.cs
@@ -2,6 +2,7 @@
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -14,6 +15,19 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
 
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Directional group model: initiator +R bullygive, each recipient +1 bullytake.
+        public override GroupSpec GroupSpec => GroupSpec.Directional("bullygive", "bullytake");
+
+        private static readonly List<string> BullyDescriptors = new List<string>
+        {
+            "boolies them into submission!",
+            "shows them whose boss!",
+            "applies excessive force to their victim!",
+            "spins them right round!",
+            "establishes the pecking order!",
+            "instills fear..."
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -64,18 +78,16 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            var random = new Random();
-            var bullyDescriptors = new List<string>
-            {
-                "boolies them into submission!",
-                "shows them whose boss!",
-                "applies excessive force to their victim!",
-                "spins them right round!",
-                "establishes the pecking order!",
-                "instills fear..."
-            };
+            return $"{initiatorProfile.displayName} takes {recipientProfile.displayName} by the collar and {GetRandomDescriptor(BullyDescriptors)}";
+        }
 
-            return $"{initiatorProfile.displayName} takes {recipientProfile.displayName} by the collar and {GetRandomDescriptor(bullyDescriptors)}";
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());
+            return $"{initiatorProfile.displayName} rounds up {names} and {GetRandomDescriptor(BullyDescriptors)}";
         }
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)

--- a/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -14,6 +15,9 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
         //consideration: Make this a variable that mods can set per interaction type?
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Symmetric group model: every participant gets +(M-1) "cuddle".
+        public override GroupSpec GroupSpec => GroupSpec.Symmetric("cuddle");
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -59,16 +63,16 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            var cuddleDescriptors = new List<string> 
-            { 
-                "Cute.", 
-                "That's kind of lewd...", 
-                "So salatious.", 
-                "Hot!", 
-                "Looks cozy!", 
-                "Is there room for one more?", 
-                $"{initiatorProfile.displayName} is definitely the big spoon.", 
-                $"{recipientProfile.displayName} is definitely the little spoon." 
+            var cuddleDescriptors = new List<string>
+            {
+                "Cute.",
+                "That's kind of lewd...",
+                "So salatious.",
+                "Hot!",
+                "Looks cozy!",
+                "Is there room for one more?",
+                $"{initiatorProfile.displayName} is definitely the big spoon.",
+                $"{recipientProfile.displayName} is definitely the little spoon."
             };
 
             string message = $"{initiatorProfile.displayName} and {recipientProfile.displayName} cuddle up together. {GetRandomDescriptor(cuddleDescriptors)}";
@@ -84,6 +88,40 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 {
                     message += " [eicon]qchug[/eicon]";
                 }
+            }
+
+            return message;
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            // The big/little-spoon descriptors don't make sense for a pile, so the group
+            // pool drops them and adds a couple of cuddle-puddle-flavored lines instead.
+            var groupDescriptors = new List<string>
+            {
+                "Cute.",
+                "That's kind of lewd...",
+                "So salatious.",
+                "Hot!",
+                "Looks cozy!",
+                "Is there room for one more?",
+                "A proper cuddle puddle!",
+                "Everyone's invited."
+            };
+
+            string message = BuildSymmetricGroupMessage(
+                initiatorProfile, consentersInOrder, "cuddle up together", GetRandomDescriptor(groupDescriptors));
+
+            bool anyQueen = initiatorProfile.userName == "Queen Contract"
+                || consentersInOrder.Any(p => p.userName == "Queen Contract");
+            bool anyRin = initiatorProfile.userName == "The Corrupted Rin"
+                || consentersInOrder.Any(p => p.userName == "The Corrupted Rin");
+            if (anyQueen)
+            {
+                message += anyRin ? " [eicon]rin_lap[/eicon]" : " [eicon]qchug[/eicon]";
             }
 
             return message;

--- a/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -11,6 +12,19 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
         //consideration: Make this a variable that mods can set per interaction type?
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Symmetric group model: every participant gets +(M-1) "handhold".
+        public override GroupSpec GroupSpec => GroupSpec.Symmetric("handhold");
+
+        private static readonly List<string> HandholdDescriptors = new List<string>
+        {
+            "Cute.",
+            "That's kind of lewd...",
+            "So salatious.",
+            "Hot!",
+            "When's the wedding?",
+            "The forbidden act, out in the open..."
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -53,17 +67,17 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            var handholdDescriptors = new List<string> 
-            { 
-                "Cute.", 
-                "That's kind of lewd...", 
-                "So salatious.", 
-                "Hot!", 
-                "When's the wedding?", 
-                "The forbidden act, out in the open..."
-            };
+            return $"Ooh, {initiatorProfile.displayName} and {recipientProfile.displayName} hold hands! {GetRandomDescriptor(HandholdDescriptors)}";
+        }
 
-            return $"Ooh, {initiatorProfile.displayName} and {recipientProfile.displayName} hold hands! {GetRandomDescriptor(handholdDescriptors)}";
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            var names = new List<string> { initiatorProfile.displayName };
+            names.AddRange(consentersInOrder.Select(p => p.displayName));
+            return $"Ooh, {JoinNamesSerial(names)} hold hands in a chain! {GetRandomDescriptor(HandholdDescriptors)}";
         }
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)

--- a/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -15,6 +16,22 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
         //consideration: Make this a variable that mods can set per interaction type?
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Symmetric group model: every participant gets +(M-1) "kiss".
+        public override GroupSpec GroupSpec => GroupSpec.Symmetric("kiss");
+
+        private static readonly List<string> KissDescriptors = new List<string>
+        {
+            "cute.",
+            "that's kind of lewd...",
+            "so salatious.",
+            "hot!",
+            "it sounded quite wet.",
+            "short and sweet.",
+            "slow and sensual.",
+            "just a casual peck.",
+            "doki..."
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -46,23 +63,26 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            var random = new Random();
-            var kissDescriptors = new List<string>
-            {
-                "cute.",
-                "that's kind of lewd...",
-                "so salatious.",
-                "hot!",
-                "it sounded quite wet.",
-                "short and sweet.",
-                "slow and sensual.",
-                "just a casual peck.",
-                "doki..."
-            };
-
-            string message = $"Mwah! {initiatorProfile.displayName} and {recipientProfile.displayName} share a kiss, {GetRandomDescriptor(kissDescriptors)}";
+            string message = $"Mwah! {initiatorProfile.displayName} and {recipientProfile.displayName} share a kiss, {GetRandomDescriptor(KissDescriptors)}";
 
             // Special handling for Queen Contract (keeping your existing special case)
+            if (initiatorProfile.userName == "Queen Contract")
+            {
+                message += "[eicon]qckiss[/eicon]";
+            }
+
+            return message;
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            var names = new List<string> { initiatorProfile.displayName };
+            names.AddRange(consentersInOrder.Select(p => p.displayName));
+            string message = $"Mwah! {JoinNamesSerial(names)} share a flurry of kisses, {GetRandomDescriptor(KissDescriptors)}";
+
             if (initiatorProfile.userName == "Queen Contract")
             {
                 message += "[eicon]qckiss[/eicon]";

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
@@ -1,3 +1,4 @@
+using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 
 namespace FChatDicebot.InteractionProcessors.Casual
@@ -15,6 +16,15 @@ namespace FChatDicebot.InteractionProcessors.Casual
     {
         public static void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string characterName, string channel, string typedVerb)
         {
+            // Multi-target → lap stack. Type and identifier both carry the typed verb so the
+            // group resolver can credit per-position counts and render the right opener.
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                CasualGroupCommandSupport.Run(bot, characterName, channel, typedVerb, groupTargets, typedVerb);
+                return;
+            }
+
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -2,7 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
-using System.Runtime.Remoting.Messaging;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -32,6 +32,20 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
 
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Lapsit is group-capable with the special per-position rule; the lap stack is
+        // assembled and credited in the group overrides below.
+        public override GroupSpec GroupSpec => GroupSpec.LapStack();
+
+        // Owner-provided descriptors (shared by !lap and !sit, 1:1 and group).
+        private static readonly List<string> LapsitDescriptors = new List<string>
+        {
+            "Does it count as a stack if it's only two?",
+            "Lap! Lap! Lap!",
+            "We have normal chairs too, in case you didn't know...",
+            "That means {lapsitgiver} is on top, literally.",
+            "Always nice to have some support."
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -100,17 +114,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 ? initiatorProfile.displayName
                 : recipientProfile.displayName;
 
-            // Owner-provided descriptors (shared by !lap and !sit).
-            var lapsitDescriptors = new List<string>
-            {
-                "Does it count as a stack if it's only two?",
-                "Lap! Lap! Lap!",
-                "We have normal chairs too, in case you didn't know...",
-                "That means {lapsitgiver} is on top, literally.",
-                "Always nice to have some support."
-            };
-
-            string descriptor = GetRandomDescriptor(lapsitDescriptors)
+            string descriptor = GetRandomDescriptor(LapsitDescriptors)
                 .Replace("{lapsitgiver}", lapsitGiver);
 
             string opener;
@@ -145,6 +149,123 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 return initiatorProfile.displayName + " wants to sit on " + recipientProfile.displayName + "'s lap. Do you !consent to being their seat?";
             }
             return initiatorProfile.displayName + " wants to pull " + recipientProfile.displayName + " onto their lap. Do you !consent to taking a seat?";
+        }
+
+        public override string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
+        {
+            string names = JoinNamesSerial(recipients.Select(p => p.displayName).ToList());
+            if (InitiatorIsSitter(identifier))
+            {
+                // !sit: the first to consent becomes the bottom; the rest pile on above.
+                return initiatorProfile.displayName + " wants to start a lap stack with " + names + ". The first to !consent gets to be under " + initiatorProfile.displayName + "!";
+            }
+            return initiatorProfile.displayName + " starts a lap stack, looking to pull " + names + " onto their lap one at a time. Do you each !consent to taking a seat?";
+        }
+
+        /// <summary>
+        /// Per-position lapsit counts over the consented stack (B7.12). Position k (0 = bottom)
+        /// gets +(M-1-k) lapsittake (people sitting on them) and +k lapsitgive (people they're
+        /// sitting on). The verb on <paramref name="identifier"/> decides who claims the
+        /// bottom; see <see cref="BuildStack{T}"/>.
+        /// </summary>
+        public override string ApplyGroupCounts(IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier)
+        {
+            var stack = BuildStack(identifier, initiator, consentersInOrder); // bottom -> top
+            int stackSize = stack.Count; // M
+            var limited = new List<string>();
+
+            for (int position = 0; position < stackSize; position++)
+            {
+                ApplyGroupIncrement(database, stack[position], "lapsittake", stackSize - 1 - position, limited);
+                ApplyGroupIncrement(database, stack[position], "lapsitgive", position, limited);
+            }
+
+            return BuildGroupRateLimitNote(limited);
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            bool initiatorIsSitter = InitiatorIsSitter(identifier);
+            var stack = BuildStack(identifier, initiatorProfile, consentersInOrder); // bottom -> top
+            int stackSize = stack.Count; // M
+
+            // Opener forms the bottom pair (positions 0 and 1).
+            string opener;
+            if (initiatorIsSitter)
+            {
+                // !sit: the initiator sits on whoever claimed the bottom (stack[0]).
+                var sitOpeners = new List<string>
+                {
+                    $"{initiatorProfile.displayName} uses {stack[0].displayName} as a comfy lap to sit on.",
+                    $"{initiatorProfile.displayName} pulls themselves onto {stack[0].displayName}'s lap."
+                };
+                opener = GetRandomDescriptor(sitOpeners);
+            }
+            else
+            {
+                // !lap: the initiator is the bottom and pulls the first sitter (stack[1]) on.
+                opener = $"{initiatorProfile.displayName} pulls {stack[1].displayName} onto their lap.";
+            }
+
+            string message = opener;
+
+            // Group extension (stack >= 3): each person above the opening pair, in stack order.
+            if (stackSize >= 3)
+            {
+                var above = stack.Skip(2).Select(p => p.displayName).ToList();
+                string tail = " Then " + above[0] + " takes a seat";
+                for (int i = 1; i < above.Count; i++)
+                {
+                    tail += ", then " + above[i];
+                }
+                tail += $", forming a lap stack {stackSize} people tall!";
+                message += tail;
+            }
+
+            // {lapsitgiver} = the topmost sitter (the most lapsitgive), i.e. the top of stack.
+            string topmost = stack[stackSize - 1].displayName;
+            string descriptor = GetRandomDescriptor(LapsitDescriptors).Replace("{lapsitgiver}", topmost);
+
+            // Special handling for Queen Contract and The Corrupted Rin.
+            if (topmost == "The Corrupted Rin" && stack.Any(p => p.userName == "Queen Contract"))
+            {
+                descriptor += " [eicon]rin_lap[/eicon]";
+            }
+
+            return $"{message} {descriptor}";
+        }
+
+        /// <summary>
+        /// Assemble the lap stack bottom -> top from the typed verb and the consenters in
+        /// consent order. <c>!lap</c>: initiator is the bottom, consenters stack above in
+        /// order. <c>!sit</c>: the first consenter claims the open bottom, the initiator sits
+        /// at position 1, remaining consenters stack above in order.
+        /// </summary>
+        private static List<T> BuildStack<T>(string verb, T initiator, IReadOnlyList<T> consentersInOrder)
+        {
+            var stack = new List<T>();
+            if (InitiatorIsSitter(verb))
+            {
+                if (consentersInOrder.Count > 0)
+                {
+                    stack.Add(consentersInOrder[0]);  // bottom
+                    stack.Add(initiator);             // position 1
+                    for (int i = 1; i < consentersInOrder.Count; i++)
+                        stack.Add(consentersInOrder[i]);
+                }
+                else
+                {
+                    // No consenters (shouldn't resolve) — fall back to initiator alone.
+                    stack.Add(initiator);
+                }
+            }
+            else
+            {
+                stack.Add(initiator); // bottom
+                foreach (var consenter in consentersInOrder)
+                    stack.Add(consenter);
+            }
+            return stack;
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
@@ -2,6 +2,7 @@ using FChatDicebot.Database;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -16,6 +17,21 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
 
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Directional group model: initiator +R lickgive, each recipient +1 licktake.
+        public override GroupSpec GroupSpec => GroupSpec.Directional("lickgive", "licktake");
+
+        // {lickgiver} = the licker (initiator); {licktaker} = the licked (recipient; for a
+        // multi-target lick this resolves to the first consenter — see GetGroupCompletionMessage).
+        private static readonly List<string> LickDescriptors = new List<string>
+        {
+            "How many more licks to get to the center?",
+            "I bet they taste good.",
+            "In cat culture, that means {lickgiver} is in charge.",
+            "In bunny culture, that means {licktaker} is in charge.",
+            "Is this what it means to be groomed?",
+            "Mlem!"
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -52,19 +68,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            // Owner-provided descriptors. {lickgiver} = the licker (initiator); {licktaker} =
-            // the licked (recipient). Tokens are resolved against display names here.
-            var lickDescriptors = new List<string>
-            {
-                "How many more licks to get to the center?",
-                "I bet they taste good.",
-                "In cat culture, that means {lickgiver} is in charge.",
-                "In bunny culture, that means {licktaker} is in charge.",
-                "Is this what it means to be groomed?",
-                "Mlem!"
-            };
-
-            string descriptor = GetRandomDescriptor(lickDescriptors)
+            string descriptor = GetRandomDescriptor(LickDescriptors)
                 .Replace("{lickgiver}", initiatorProfile.displayName)
                 .Replace("{licktaker}", recipientProfile.displayName);
 
@@ -74,6 +78,27 @@ namespace FChatDicebot.InteractionProcessors.Casual
             }
 
             return $"{initiatorProfile.displayName} gives {recipientProfile.displayName} a slow lick. {descriptor}";
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            // {licktaker} in a multi-target lick resolves to the first consenter (B7 open
+            // item — pick first, deterministic).
+            string descriptor = GetRandomDescriptor(LickDescriptors)
+                .Replace("{lickgiver}", initiatorProfile.displayName)
+                .Replace("{licktaker}", consentersInOrder[0].displayName);
+
+            if (initiatorProfile.userName == "Queen Contract")
+            {
+                descriptor += "[eicon]qctongue[/eicon]";
+            }
+
+            // Spec's directional example: "Alice licks Bob, Carol, and Dave. {descriptor}".
+            string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());
+            return $"{initiatorProfile.displayName} licks {names}. {descriptor}";
         }
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)

--- a/FChatDicebot/InteractionProcessors/Casual/SpankProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/SpankProcessor.cs
@@ -2,6 +2,7 @@
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace FChatDicebot.InteractionProcessors.Casual
 {
@@ -14,6 +15,19 @@ namespace FChatDicebot.InteractionProcessors.Casual
         public override string InvestmentLevel => "casual";
 
         private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Directional group model: initiator +R spankgive, each recipient +1 spanktake.
+        public override GroupSpec GroupSpec => GroupSpec.Directional("spankgive", "spanktake");
+
+        private static readonly List<string> SpankDescriptors = new List<string>
+        {
+            "a sharp spank!",
+            "a love tap to the ass.",
+            "a smack that will leave a mark.",
+            "a red imprint on their derriere.",
+            "a surprisingly loving booty grope.",
+            "an impact with enough force to cook a lesser being."
+        };
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -49,20 +63,25 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            var random = new Random();
-            var spankDescriptors = new List<string>
-            {
-                "a sharp spank!",
-                "a love tap to the ass.",
-                "a smack that will leave a mark.",
-                "a red imprint on their derriere.",
-                "a surprisingly loving booty grope.",
-                "an impact with enough force to cook a lesser being."
-            };
-
-            string message = $"{initiatorProfile.displayName} winds up and gives {recipientProfile.displayName} {GetRandomDescriptor(spankDescriptors)}";
+            string message = $"{initiatorProfile.displayName} winds up and gives {recipientProfile.displayName} {GetRandomDescriptor(SpankDescriptors)}";
 
             if (recipientProfile.userName == "Queen Contract")
+            {
+                message += " [eicon]qcass[/eicon]";
+            }
+
+            return message;
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());
+            string message = $"{initiatorProfile.displayName} winds up and gives {names} {GetRandomDescriptor(SpankDescriptors)}";
+
+            if (consentersInOrder.Any(p => p.userName == "Queen Contract"))
             {
                 message += " [eicon]qcass[/eicon]";
             }

--- a/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
+++ b/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
@@ -1,0 +1,157 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Coordinates the hybrid group flow (B4): each recipient consents to their own seat with
+    /// plain <c>!consent</c>, but the shared "moment" only fires once no <c>Pending</c> seat
+    /// remains. Resolution gathers whoever consented, applies the group count math through the
+    /// processor, emits one combined completion message, and clears every seat of the group.
+    ///
+    /// Lives outside <c>FChatDicebot.BotCommands</c> so the reflection-based command loader
+    /// doesn't pick it up. Stateless and database-injected so it can be unit-tested against the
+    /// same <see cref="IChateauDatabase"/> the processors use; title-granting is intentionally
+    /// left to the command layer (which runs through MonDB) — the resolver only returns the
+    /// participant set so the caller can check titles.
+    /// </summary>
+    public static class GroupInteractionResolver
+    {
+        // Mirrors the 10-minute window ChateauConsent sweeps with.
+        public const int PendingMinutesKeep = 10;
+
+        /// <summary>
+        /// Stamp a group seat as consented: assign the next consent-order number for its group
+        /// and flip its state. Caller is expected to follow up with
+        /// <see cref="CheckAndResolve"/> for the same groupId.
+        /// </summary>
+        public static void MarkSeatConsented(IChateauDatabase database, PendingCommand seat)
+        {
+            var siblings = database.GetPendingCommandsByGroupId(seat.groupId);
+            int nextOrder = siblings
+                .Where(s => s.HasConsented)
+                .Select(s => s.consentedOrder)
+                .DefaultIfEmpty(0)
+                .Max() + 1;
+
+            seat.consentState = PendingCommand.ConsentedState;
+            seat.consentedOrder = nextOrder;
+            database.UpdatePendingCommand(seat);
+        }
+
+        /// <summary>
+        /// Resolve the group if it's ready. Expired un-consented seats are swept first (lazy
+        /// expiry — there is no background timer), then:
+        ///   - if any non-expired seat is still Pending, nothing happens (still waiting);
+        ///   - if every remaining seat has consented, the moment fires with that set;
+        ///   - if no seats remain at all (everyone refused/expired), the group dies silently.
+        /// </summary>
+        public static GroupResolutionResult CheckAndResolve(IChateauDatabase database, string groupId)
+        {
+            var result = new GroupResolutionResult();
+            if (string.IsNullOrEmpty(groupId)) return result;
+
+            var seats = database.GetPendingCommandsByGroupId(groupId);
+            if (seats.Count == 0) return result;
+
+            // Sweep expired, never-consented seats so a non-responding member can't wedge the
+            // group past the 10-minute mark.
+            DateTime cutoff = DateTime.UtcNow.AddMinutes(-PendingMinutesKeep);
+            var liveSeats = new List<PendingCommand>();
+            foreach (var seat in seats)
+            {
+                if (!seat.HasConsented && seat.startTime.CompareTo(cutoff) < 0)
+                {
+                    database.DeletePendingCommand(seat.Id);
+                }
+                else
+                {
+                    liveSeats.Add(seat);
+                }
+            }
+
+            if (liveSeats.Count == 0) return result;                  // silent expiry
+            if (liveSeats.Any(s => !s.HasConsented)) return result;   // still waiting on a seat
+
+            // Every remaining seat consented → fire with whoever consented.
+            var consented = liveSeats.OrderBy(s => s.consentedOrder).ToList();
+            var anySeat = consented[0];
+            string initiator = anySeat.pendingInteraction.initiator;
+            string type = anySeat.pendingInteraction.type;
+            string identifier = anySeat.pendingInteraction.identifier;
+            string investmentLevel = anySeat.pendingInteraction.investmentLevel;
+
+            var processor = InteractionProcessorRegistry.GetProcessor(type);
+            if (processor == null)
+            {
+                // No processor (shouldn't happen for a casual) — clear the seats and bail.
+                DeleteAllSeats(database, groupId);
+                return result;
+            }
+
+            var consenterNames = consented.Select(s => s.awaitingConsentFrom).ToList();
+
+            // History: record one interaction per consenting recipient, mirroring N
+            // independent 1:1 records so statistics / type counts stay consistent.
+            DateTime now = DateTime.UtcNow;
+            foreach (var recipient in consenterNames)
+            {
+                database.AddInteraction(new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = type,
+                    identifier = identifier,
+                    investmentLevel = investmentLevel,
+                    interactionTime = now
+                });
+            }
+
+            // Counts (processor owns the symmetric / directional / lapsit math + the +N helper).
+            string rateLimitNote = processor.ApplyGroupCounts(database, initiator, consenterNames, identifier);
+
+            // Combined completion message.
+            Profile initiatorProfile = database.GetProfile(initiator);
+            var consenterProfiles = consenterNames.Select(database.GetProfile).ToList();
+            string message = processor.GetGroupCompletionMessage(initiatorProfile, consenterProfiles, identifier);
+            if (!string.IsNullOrEmpty(rateLimitNote))
+            {
+                message += rateLimitNote;
+            }
+
+            DeleteAllSeats(database, groupId);
+
+            result.Resolved = true;
+            result.ChannelMessage = message;
+            result.Participants.Add(initiator);
+            result.Participants.AddRange(consenterNames);
+            return result;
+        }
+
+        private static void DeleteAllSeats(IChateauDatabase database, string groupId)
+        {
+            foreach (var seat in database.GetPendingCommandsByGroupId(groupId))
+            {
+                database.DeletePendingCommand(seat.Id);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Outcome of a <see cref="GroupInteractionResolver.CheckAndResolve"/> call.
+    /// </summary>
+    public class GroupResolutionResult
+    {
+        /// <summary>True when the group fired this call (counts applied, seats cleared).</summary>
+        public bool Resolved { get; set; }
+
+        /// <summary>Combined completion message to post in the channel (empty if not resolved).</summary>
+        public string ChannelMessage { get; set; } = string.Empty;
+
+        /// <summary>Initiator + consenting recipients — for the caller's title checks.</summary>
+        public List<string> Participants { get; set; } = new List<string>();
+    }
+}

--- a/FChatDicebot/InteractionProcessors/GroupSpec.cs
+++ b/FChatDicebot/InteractionProcessors/GroupSpec.cs
@@ -1,0 +1,59 @@
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// How a group-capable casual interaction credits counts when its shared "moment"
+    /// resolves (B4.3 / B7.12). Non-casual processors return no spec and are not
+    /// group-capable (they fall back to independent 1:1 fan-out).
+    /// </summary>
+    public enum GroupCountKind
+    {
+        /// <summary>
+        /// Symmetric (kiss / cuddle / handhold): every participant gets +(M-1) to a single
+        /// shared key — i.e. +1 per other participant.
+        /// </summary>
+        Symmetric,
+
+        /// <summary>
+        /// Directional one-to-many (spank / bully / boobhat / lick): the initiator gets +R
+        /// to the give key, each consenting recipient +1 to the take key.
+        /// </summary>
+        Directional,
+
+        /// <summary>
+        /// Lapsit's per-position rule: a person at stack position k gets +(M-1-k) lapsittake
+        /// and +k lapsitgive. Handled entirely inside <c>LapsitProcessor</c>.
+        /// </summary>
+        Lapsit
+    }
+
+    /// <summary>
+    /// Declares a casual processor's group count model so the shared resolution path can
+    /// apply the right increments without each processor reimplementing the +N math.
+    /// </summary>
+    public class GroupSpec
+    {
+        public GroupCountKind Kind { get; private set; }
+
+        // Symmetric: the single shared key both/all sides receive.
+        public string SymmetricKey { get; private set; }
+
+        // Directional: the initiator's "give" key and each recipient's "take" key.
+        public string GiveKey { get; private set; }
+        public string TakeKey { get; private set; }
+
+        public static GroupSpec Symmetric(string key)
+        {
+            return new GroupSpec { Kind = GroupCountKind.Symmetric, SymmetricKey = key };
+        }
+
+        public static GroupSpec Directional(string giveKey, string takeKey)
+        {
+            return new GroupSpec { Kind = GroupCountKind.Directional, GiveKey = giveKey, TakeKey = takeKey };
+        }
+
+        public static GroupSpec LapStack()
+        {
+            return new GroupSpec { Kind = GroupCountKind.Lapsit };
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -1,5 +1,6 @@
 using FChatDicebot.Model;
 using System;
+using System.Collections.Generic;
 using static FChatDicebot.InteractionProcessors.InteractionProcessorBase;
 
 namespace FChatDicebot.InteractionProcessors
@@ -81,6 +82,24 @@ namespace FChatDicebot.InteractionProcessors
         /// a private message.
         /// </summary>
         string GetAndClearInitiatorPrivateMessage();
+
+        // --- Group interaction support (B4). Non-group-capable processors return a null
+        // GroupSpec; the other members are only invoked once a group has been resolved. ---
+
+        /// <summary>Group count model, or null when the interaction isn't group-capable.</summary>
+        GroupSpec GroupSpec { get; }
+
+        /// <summary>True when this interaction supports the hybrid group flow (casuals).</summary>
+        bool SupportsGroup { get; }
+
+        /// <summary>Apply group counts over the consenting recipients (in consent order).</summary>
+        string ApplyGroupCounts(Database.IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier);
+
+        /// <summary>Combined completion message for a resolved group moment.</summary>
+        string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier);
+
+        /// <summary>Channel announcement shown when a multi-target casual command is invoked.</summary>
+        string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier);
     }
 
     /// <summary>

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -485,5 +485,155 @@ namespace FChatDicebot.InteractionProcessors
             Database.IncrementCount(initiator, initiatorLabel);
             Database.IncrementCount(recipient, recipientLabel);
         }
+
+        // ====================================================================
+        // Group interaction support (B4). Only casual processors opt in by
+        // overriding GroupSpec; everything below is a no-op for the rest.
+        // ====================================================================
+
+        /// <summary>
+        /// Declares how this interaction credits counts when resolved as a multi-person
+        /// "moment". Null means the interaction is not group-capable (non-casuals), in which
+        /// case multi-target commands fall back to independent 1:1 fan-out.
+        /// </summary>
+        public virtual GroupSpec GroupSpec => null;
+
+        /// <summary>True when this interaction supports the hybrid group flow.</summary>
+        public bool SupportsGroup => GroupSpec != null;
+
+        /// <summary>Rate-limit window applied to group count increments (all casuals: 30m).</summary>
+        protected virtual TimeSpan GroupRateLimit => TimeSpan.FromMinutes(30);
+
+        /// <summary>
+        /// Apply the group count math for a resolved moment over the consenting recipients,
+        /// in consent order. Default handles symmetric and directional models; lapsit
+        /// overrides for its per-position rule. Returns a "[sub]…clerks were busy…[/sub]"
+        /// note naming any participant whose increment was rate-limited (or empty).
+        ///
+        /// The database is threaded in by the resolver rather than using the processor's own
+        /// bound <see cref="Database"/>: registry instances bind to the live MonDB, so passing
+        /// the caller's database keeps counting on the same store as the rest of resolution
+        /// (and lets the resolver be unit-tested against the test database).
+        /// </summary>
+        public virtual string ApplyGroupCounts(IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier)
+        {
+            var spec = GroupSpec;
+            if (spec == null) return string.Empty;
+
+            int recipientCount = consentersInOrder.Count; // R
+            int participantCount = recipientCount + 1;     // M = R + 1
+            var limited = new List<string>();
+
+            if (spec.Kind == GroupCountKind.Symmetric)
+            {
+                // +1 per other participant → +(M-1) each.
+                ApplyGroupIncrement(database, initiator, spec.SymmetricKey, participantCount - 1, limited);
+                foreach (var c in consentersInOrder)
+                    ApplyGroupIncrement(database, c, spec.SymmetricKey, participantCount - 1, limited);
+            }
+            else if (spec.Kind == GroupCountKind.Directional)
+            {
+                ApplyGroupIncrement(database, initiator, spec.GiveKey, recipientCount, limited);
+                foreach (var c in consentersInOrder)
+                    ApplyGroupIncrement(database, c, spec.TakeKey, 1, limited);
+            }
+            // Lapsit handles its own counts in an override.
+
+            return BuildGroupRateLimitNote(limited);
+        }
+
+        /// <summary>
+        /// Apply a single rate-limited +N increment for a group participant against the given
+        /// database. A non-positive amount (e.g. the lap at position 0 has +0 lapsitgive) is a
+        /// silent no-op — no timer is armed and no rate-limit note is produced. Participants
+        /// whose increment is suppressed by their cooldown are collected (by display name).
+        /// </summary>
+        protected void ApplyGroupIncrement(IChateauDatabase database, string user, string countKey, int amount, List<string> limitedDisplayNames)
+        {
+            if (amount <= 0) return;
+            bool applied = database.ChangeCountByWithRateLimit(user, countKey, amount, GroupRateLimit);
+            if (!applied)
+            {
+                string displayName = database.GetDisplayName(user) ?? user;
+                if (!limitedDisplayNames.Contains(displayName))
+                    limitedDisplayNames.Add(displayName);
+            }
+        }
+
+        /// <summary>
+        /// Build the rate-limit sub-note for a resolved group, naming whichever participants'
+        /// dossiers were too busy to record. Empty when nobody was limited.
+        /// </summary>
+        protected string BuildGroupRateLimitNote(List<string> limitedDisplayNames)
+        {
+            if (limitedDisplayNames == null || limitedDisplayNames.Count == 0) return string.Empty;
+            string names = JoinNamesSerial(limitedDisplayNames);
+            string dossierWord = limitedDisplayNames.Count > 1 ? "dossiers" : "dossier";
+            return $"\n\n[sub]Looks like that didn't make it into {names}'s {dossierWord} though... The clerks were probably still busy processing their last {InteractionType}.[/sub]";
+        }
+
+        /// <summary>
+        /// Combined completion message for a resolved group moment, over the consenting
+        /// recipients in consent order. A single consenter degenerates to the 1:1 message.
+        /// Casual processors override this for their own flavor; the fallback just lists
+        /// everyone. (Casual interactions carry no status-effect contributors, so unlike the
+        /// 1:1 path this is not wrapped with status fragments.)
+        /// </summary>
+        public virtual string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            var names = new List<string> { initiatorProfile.displayName };
+            names.AddRange(consentersInOrder.Select(p => p.displayName));
+            return $"{JoinNamesSerial(names)} share a {InteractionType} moment together.";
+        }
+
+        /// <summary>
+        /// Directional group sentence helper: "Initiator {verbPresent} A, B, and C. {descriptor}".
+        /// </summary>
+        protected string BuildDirectionalGroupMessage(string initiatorDisplayName, IReadOnlyList<Profile> consenters, string verbPresent, string descriptor)
+        {
+            string names = JoinNamesSerial(consenters.Select(p => p.displayName).ToList());
+            string message = $"{initiatorDisplayName} {verbPresent} {names}.";
+            if (!string.IsNullOrEmpty(descriptor)) message += " " + descriptor;
+            return message;
+        }
+
+        /// <summary>
+        /// Symmetric group sentence helper: "A, B, and C {predicate}. {descriptor}" with the
+        /// initiator listed first.
+        /// </summary>
+        protected string BuildSymmetricGroupMessage(Profile initiatorProfile, IReadOnlyList<Profile> consenters, string predicate, string descriptor)
+        {
+            var names = new List<string> { initiatorProfile.displayName };
+            names.AddRange(consenters.Select(p => p.displayName));
+            string message = $"{JoinNamesSerial(names)} {predicate}.";
+            if (!string.IsNullOrEmpty(descriptor)) message += " " + descriptor;
+            return message;
+        }
+
+        /// <summary>
+        /// Group consent announcement shown when a multi-target casual command is invoked.
+        /// Default reads "{initiator} wants to {verb} A, B, and C. Each of you, do you
+        /// !consent?". Processors with awkward infinitives (lapsit) override.
+        /// </summary>
+        public virtual string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
+        {
+            string names = JoinNamesSerial(recipients.Select(p => p.displayName).ToList());
+            string verb = GetInteractionVerb(VerbTense.Infinitive);
+            return $"{initiatorProfile.displayName} wants to {verb} {names}. Do you each !consent? (or !no)";
+        }
+
+        /// <summary>
+        /// Serial-comma name join: "A" / "A and B" / "A, B, and C".
+        /// </summary>
+        public static string JoinNamesSerial(IReadOnlyList<string> names)
+        {
+            if (names == null || names.Count == 0) return string.Empty;
+            if (names.Count == 1) return names[0];
+            if (names.Count == 2) return names[0] + " and " + names[1];
+            return string.Join(", ", names.Take(names.Count - 1)) + ", and " + names[names.Count - 1];
+        }
     }
 }

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -132,10 +132,37 @@ namespace FChatDicebot.Model
         [BsonId]
         [BsonRepresentation(BsonType.ObjectId)]
         public ObjectId Id { get; set; }
-        public Interaction pendingInteraction { get; set; } 
-        public string awaitingConsentFrom { get; set; } 
+        public Interaction pendingInteraction { get; set; }
+        public string awaitingConsentFrom { get; set; }
         public DateTime startTime { get; set; } = DateTime.UtcNow;
 
+        // --- Group interaction fields (B4) ---
+        // For an ordinary 1:1 pending these stay null/default and the consent flow ignores
+        // them entirely (it processes the moment the single recipient consents). A
+        // multi-target casual command instead mints one shared groupId across every
+        // recipient's seat; each seat is consented individually but the shared "moment"
+        // only resolves once no Pending seat remains. [BsonIgnoreIfNull] keeps the field
+        // off legacy 1:1 documents so no migration is needed.
+
+        // Shared id linking every seat of one group invocation. Null/empty for 1:1.
+        [BsonIgnoreIfNull]
+        public string groupId { get; set; }
+
+        // PendingConsent / Consented. Only meaningful for group seats; a 1:1 pending never
+        // transitions (it is processed-then-deleted on consent). Default keeps legacy docs
+        // and 1:1 seats in the "still waiting" state.
+        public string consentState { get; set; } = PendingConsentState;
+
+        // Order in which this seat consented (1,2,3…); 0 until consented / for 1:1. Drives
+        // lapsit stack ordering and the serial-comma name order in the combined message.
+        [BsonIgnoreIfDefault]
+        public int consentedOrder { get; set; }
+
+        public const string PendingConsentState = "Pending";
+        public const string ConsentedState = "Consented";
+
+        public bool IsGroupSeat => !string.IsNullOrEmpty(groupId);
+        public bool HasConsented => consentState == ConsentedState;
     }
 
     public class Command

--- a/FChatDicebot/MonDB.cs
+++ b/FChatDicebot/MonDB.cs
@@ -115,6 +115,21 @@ namespace FChatDicebot
             return GetDatabase().GetPendingCommands(userName);
         }
 
+        internal static List<PendingCommand> getPendingByGroupId(string groupId)
+        {
+            return GetDatabase().GetPendingCommandsByGroupId(groupId);
+        }
+
+        internal static List<PendingCommand> getPendingByInitiator(string initiator)
+        {
+            return GetDatabase().GetPendingCommandsByInitiator(initiator);
+        }
+
+        internal static void updatePendingCommand(PendingCommand updated)
+        {
+            GetDatabase().UpdatePendingCommand(updated);
+        }
+
         internal static List<Duty> getDutiesByJob(string job)
         {
             return GetDatabase().GetDutiesByJob(job);

--- a/wiki-docs/specs/Future-Interactions/Group-Interactions-And-Pending-Lifecycle.md
+++ b/wiki-docs/specs/Future-Interactions/Group-Interactions-And-Pending-Lifecycle.md
@@ -1,6 +1,6 @@
 # Group Interactions, Pending Lifecycle, and New Casuals
 
-**Status:** Proposed (design-complete, owner-reviewed 2026-06-20). Final user-facing descriptor strings still pending owner wording review per the standing rule.
+**Status:** Shipped 2026-06-22 (B4 group system, B5 lifecycle + `!consent <name>`, the lapsit lap-stack). The new casuals (B7) had already shipped 1:1 on 2026-06-21. Build green, 15 new tests. The lifecycle verbs were renamed at owner request to dodge the `!w`/`!work` clash: recipient-side is **`!no`** (aliases `!refuse`, `!decline`), initiator-side is **`!oops`** (aliases `!o`, `!withdraw`, `!cancel`). Out of scope, as designed: the tall-stack *height* titles (owner design TODO).
 
 This spec covers the "Interactions" cluster from [Feature-Requests.md](../../Feature-Requests.md):
 


### PR DESCRIPTION
Implements the **Interactions** cluster from the spec ([Group-Interactions-And-Pending-Lifecycle.md](wiki-docs/specs/Future-Interactions/Group-Interactions-And-Pending-Lifecycle.md)) — B4 multi-person groups, B5 lifecycle commands, and the lapsit lap-stack. Builds on the B7 casuals that already shipped 1:1.

## B4 — hybrid group system (casuals only)
- `PendingCommand` gains `groupId` / `consentState` / `consentedOrder` (no migration; legacy 1:1 docs unaffected).
- A multi-target casual mints one shared `groupId` with a seat per recipient; each consents individually; the moment fires once no `Pending` seat remains — **with whoever consented** — via the new `GroupInteractionResolver`. Expiry is lazy (no scheduler), swept on the next consent/no/oops poke.
- Each casual processor declares a `GroupSpec` driving the count math: symmetric +(M−1) each, directional initiator +R / recipients +1, lapsit per-position. A new `ChangeCountByWithRateLimit` (+N) DB helper applies it.
- New queries `GetPendingCommandsByGroupId` / `GetPendingCommandsByInitiator`; multi-name parsing (`GetUserNamesFromCommandTerms`) with self-target drop+whisper and a 10-recipient cap (`CasualGroupCommandSupport`).

## B5 — lifecycle
- **`!no`** (recipient declines a seat; the group still resolves with the rest) and **`!oops`** (initiator cancels the whole group).
- By-name targeting added to `!consent`, `!no`, `!oops` (`LifecycleTargeting`).
- Renamed from `!refuse`/`!withdraw` to dodge the `!w`/`!work` clash. Aliases: `!no` ← `!refuse`, `!decline`; `!oops` ← `!o`, `!withdraw`, `!cancel`.
- `ChateauConsent` restructured to be group-aware (also fixes a latent `ElementAt(-1)` on bare multi-pending consent).

## Lapsit lap-stack
- `!lap` puts the initiator at the bottom; `!sit` lets the first consenter claim the bottom. Per-position `lapsittake`/`lapsitgive` counts and a "…forming a lap stack N people tall!" message.

## Help / wording
- Casual command descriptions shifted to "resident (or residents)" to signal multi-target.
- New group/lifecycle user-facing strings were reviewed with the owner.

## Tests
15 new tests (symmetric/directional/lapsit math, partial & zero consent, message rendering, new DB primitives). **Full suite: 1301 passing, 0 errors.**

Out of scope, as designed: tall-stack *height* titles (owner design TODO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)