### PR TITLE
Group-achievement titles (by resolved size / lap-stack position)

### DIFF
--- a/FChatDicebot.Tests/Unit/Groupachievementtitletests.cs
+++ b/FChatDicebot.Tests/Unit/Groupachievementtitletests.cs
@@ -1,0 +1,371 @@
+using FChatDicebot;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Pure-lookup tests for the group-achievement title tables in ChateauSystemTitles:
+    /// size-based titles (cumulative thresholds, per interaction type) and lapsit per-position
+    /// titles. No database — these validate the title text and the threshold math directly.
+    /// </summary>
+    public class GroupTitleLookupTests
+    {
+        [Theory]
+        // Below the first threshold → nothing yet.
+        [InlineData("cuddle", 2)]
+        [InlineData("kiss", 2)]
+        [InlineData("boobhat", 3)] // boobhat's first tier is 4
+        public void GetGroupSizeTitles_BelowFirstThreshold_IsEmpty(string type, int size)
+        {
+            Assert.Empty(ChateauSystemTitles.GetGroupSizeTitles(type, size));
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_IsCumulative_GrantsEveryTierAtOrBelowSize()
+        {
+            Assert.Equal(new[] { "Cuddle Puddle" },
+                ChateauSystemTitles.GetGroupSizeTitles("cuddle", 3));
+            Assert.Equal(new[] { "Cuddle Puddle" },
+                ChateauSystemTitles.GetGroupSizeTitles("cuddle", 4)); // 4 >= 3 but < 5
+            Assert.Equal(new[] { "Cuddle Puddle", "Cuddle Pond", "Cuddle Lake" },
+                ChateauSystemTitles.GetGroupSizeTitles("cuddle", 7));
+            Assert.Equal(new[] { "Cuddle Puddle", "Cuddle Pond", "Cuddle Lake", "Cuddle Sea", "Cuddle Ocean" },
+                ChateauSystemTitles.GetGroupSizeTitles("cuddle", 11));
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_Kiss_ApexIsSpartakiss()
+        {
+            var titles = ChateauSystemTitles.GetGroupSizeTitles("kiss", 11);
+            Assert.Equal(new[] { "Kiss Kiss", "Kisstacular", "Kissimanjaro", "Kisspocalypse", "Spartakiss" }, titles);
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_Handhold_GeometricNames()
+        {
+            Assert.Equal(new[] { "Triangle", "Pentagon", "Septagon" },
+                ChateauSystemTitles.GetGroupSizeTitles("handhold", 7));
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_Spank_UsesItsOwn3_5_8_11Thresholds()
+        {
+            // "Seven Spanks" lands at size 8 (initiator + 7 spanked), not 7.
+            Assert.Equal(new[] { "Echo", "Thunder Storm" },
+                ChateauSystemTitles.GetGroupSizeTitles("spank", 7));
+            Assert.Equal(new[] { "Echo", "Thunder Storm", "Seven Spanks" },
+                ChateauSystemTitles.GetGroupSizeTitles("spank", 8));
+            Assert.Equal(new[] { "Echo", "Thunder Storm", "Seven Spanks", "Strike!" },
+                ChateauSystemTitles.GetGroupSizeTitles("spank", 11));
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_Boobhat_StartsAtFourWithReassignedHatTrick()
+        {
+            Assert.Equal(new[] { "Hat Trick" },
+                ChateauSystemTitles.GetGroupSizeTitles("boobhat", 4));
+            Assert.Equal(new[] { "Hat Trick", "Mad Hatter", "Capping" },
+                ChateauSystemTitles.GetGroupSizeTitles("boobhat", 11));
+        }
+
+        [Fact]
+        public void GetGroupSizeTitles_Bully_And_Lick_FullLadders()
+        {
+            Assert.Equal(new[] { "Intimidating", "Hazing", "Demands Respect", "Unbullyvable", "Decibully" },
+                ChateauSystemTitles.GetGroupSizeTitles("bully", 11));
+            Assert.Equal(new[] { "Free Sample", "Indecisive", "Can Tie A Knot In A Cherry Stem", "Tongue In Chic", "Lick A Ton" },
+                ChateauSystemTitles.GetGroupSizeTitles("lick", 11));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("objectify")] // not a group-size interaction
+        [InlineData("bond")]
+        public void GetGroupSizeTitles_UnknownOrNullType_IsEmpty(string type)
+        {
+            Assert.Empty(ChateauSystemTitles.GetGroupSizeTitles(type, 11));
+        }
+
+        [Fact]
+        public void GetLapsitPositionTitles_BelowLadder_IsCumulative()
+        {
+            Assert.Empty(ChateauSystemTitles.GetLapsitPositionTitles(0, 0));
+            Assert.Equal(new[] { "Elevated" }, ChateauSystemTitles.GetLapsitPositionTitles(2, 0));
+            Assert.Equal(new[] { "Elevated", "Laps All The Way Down" },
+                ChateauSystemTitles.GetLapsitPositionTitles(4, 0));
+            Assert.Equal(new[] { "Elevated", "Laps All The Way Down", "Can See Their House From Here", "King Of The World", "Lap of Babel" },
+                ChateauSystemTitles.GetLapsitPositionTitles(10, 0));
+        }
+
+        [Fact]
+        public void GetLapsitPositionTitles_AboveLadder_IsCumulative()
+        {
+            Assert.Equal(new[] { "Shortstacked" }, ChateauSystemTitles.GetLapsitPositionTitles(0, 2));
+            Assert.Equal(new[] { "Shortstacked", "Buried" }, ChateauSystemTitles.GetLapsitPositionTitles(0, 5));
+            Assert.Equal(new[] { "Shortstacked", "Buried", "Foundational" },
+                ChateauSystemTitles.GetLapsitPositionTitles(0, 10));
+        }
+
+        [Fact]
+        public void GetLapsitPositionTitles_MidStack_EarnsBothBelowAndAbove()
+        {
+            // 2 people below AND 2 above: one of each ladder's first tier.
+            Assert.Equal(new[] { "Elevated", "Shortstacked" },
+                ChateauSystemTitles.GetLapsitPositionTitles(2, 2));
+        }
+
+        // ---- FormatGroupTitleNotification: one banner, grouped by title ----
+
+        private static GroupTitleGrant Grant(string displayName, params string[] titles)
+        {
+            return new GroupTitleGrant { UserName = displayName, DisplayName = displayName, NewTitles = titles.ToList() };
+        }
+
+        private static int Occurrences(string haystack, string needle)
+        {
+            int count = 0, i = 0;
+            while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0) { count++; i += needle.Length; }
+            return count;
+        }
+
+        [Fact]
+        public void FormatGroupTitleNotification_NoNewTitles_IsEmpty()
+        {
+            Assert.Equal(string.Empty, ChateauSystemTitles.FormatGroupTitleNotification(null));
+            Assert.Equal(string.Empty, ChateauSystemTitles.FormatGroupTitleNotification(new List<GroupTitleGrant>()));
+            Assert.Equal(string.Empty, ChateauSystemTitles.FormatGroupTitleNotification(
+                new List<GroupTitleGrant> { Grant("Alice" /* no titles */) }));
+        }
+
+        [Fact]
+        public void FormatGroupTitleNotification_SameTitleManyEarners_OneBannerSerialComma()
+        {
+            var grants = new List<GroupTitleGrant>
+            {
+                Grant("Alice", "Cuddle Puddle"),
+                Grant("Bob", "Cuddle Puddle"),
+                Grant("Carol", "Cuddle Puddle"),
+            };
+
+            string msg = ChateauSystemTitles.FormatGroupTitleNotification(grants);
+
+            Assert.Equal(1, Occurrences(msg, "═══ Title Time! ═══"));
+            Assert.Contains("Alice, Bob, and Carol earned the title [b]·Cuddle Puddle·[/b]!", msg);
+            Assert.EndsWith("[sub]View all your titles with !titles[/sub]", msg);
+        }
+
+        [Fact]
+        public void FormatGroupTitleNotification_DifferentTitles_GroupedByTitleInFirstSeenOrder()
+        {
+            // Lapsit-shaped: each rider's own below/above titles, granted in stack order.
+            var grants = new List<GroupTitleGrant>
+            {
+                Grant("Alice", "Shortstacked", "Buried"),
+                Grant("Bob", "Shortstacked"),
+                Grant("Carol", "Elevated", "Shortstacked"),
+            };
+
+            string msg = ChateauSystemTitles.FormatGroupTitleNotification(grants);
+
+            Assert.Equal(1, Occurrences(msg, "═══ Title Time! ═══"));
+            Assert.Contains("Alice, Bob, and Carol earned the title [b]·Shortstacked·[/b]!", msg);
+            Assert.Contains("Alice earned the title [b]·Buried·[/b]!", msg);
+            Assert.Contains("Carol earned the title [b]·Elevated·[/b]!", msg);
+            // First-seen title order: Shortstacked, then Buried, then Elevated.
+            Assert.True(msg.IndexOf("·Shortstacked·", StringComparison.Ordinal)
+                      < msg.IndexOf("·Buried·", StringComparison.Ordinal));
+            Assert.True(msg.IndexOf("·Buried·", StringComparison.Ordinal)
+                      < msg.IndexOf("·Elevated·", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void FormatGroupTitleNotification_SingleEarner_NoSerialComma()
+        {
+            string msg = ChateauSystemTitles.FormatGroupTitleNotification(
+                new List<GroupTitleGrant> { Grant("Alice", "Echo") });
+
+            Assert.Contains("Alice earned the title [b]·Echo·[/b]!", msg);
+            Assert.DoesNotContain(",", msg);
+        }
+    }
+
+    /// <summary>
+    /// Grant-path tests: GroupInteractionResolver.CheckAndResolve hands off to the processor's
+    /// GrantGroupTitles, which persists the size / position titles through the injected test
+    /// database and reports them on the result. Mirrors the count-math resolver tests.
+    /// </summary>
+    [Collection("Database")]
+    public class GroupAchievementTitleGrantTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public GroupAchievementTitleGrantTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        [Fact]
+        public void Symmetric_ThreePersonCuddle_EveryParticipantEarnsCuddlePuddle()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(seats);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            foreach (var name in new[] { "Alice", "Bob", "Carol" })
+            {
+                Assert.True(HasSystemTitle(name, "Cuddle Puddle"), $"{name} should have Cuddle Puddle");
+            }
+            Assert.Equal(3, result.GroupTitleGrants.Count);
+            Assert.All(result.GroupTitleGrants, g => Assert.Equal(new[] { "Cuddle Puddle" }, g.NewTitles));
+        }
+
+        [Fact]
+        public void Directional_ThreePersonSpank_OnlyInitiatorEarnsTheTitle()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "spank", null, "Bob", "Carol");
+            ConsentInOrder(seats);
+
+            var result = GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.True(HasSystemTitle("Alice", "Echo"));
+            Assert.False(HasSystemTitle("Bob", "Echo"));
+            Assert.False(HasSystemTitle("Carol", "Echo"));
+
+            var grant = Assert.Single(result.GroupTitleGrants);
+            Assert.Equal("Alice", grant.UserName);
+            Assert.Equal(new[] { "Echo" }, grant.NewTitles);
+        }
+
+        [Fact]
+        public void Directional_FivePersonSpank_InitiatorEarnsCumulativeLadder()
+        {
+            SeedProfiles("Alice", "Bob", "Carol", "Dave", "Erin");
+            var seats = CreateGroup("Alice", "spank", null, "Bob", "Carol", "Dave", "Erin"); // M = 5
+            ConsentInOrder(seats);
+
+            GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            Assert.True(HasSystemTitle("Alice", "Echo"));
+            Assert.True(HasSystemTitle("Alice", "Thunder Storm"));
+            Assert.False(HasSystemTitle("Alice", "Seven Spanks")); // needs size 8
+        }
+
+        [Fact]
+        public void Lapsit_SixTallStack_PerPositionTitles()
+        {
+            SeedProfiles("Alice", "Bob", "Carol", "Dave", "Erin", "Frank");
+            // !lap: Alice is the bottom; consenters stack above in consent order.
+            var seats = CreateGroup("Alice", "lap", "lap", "Bob", "Carol", "Dave", "Erin", "Frank");
+            ConsentInOrder(seats); // stack bottom->top: Alice,Bob,Carol,Dave,Erin,Frank (M=6)
+
+            GroupInteractionResolver.CheckAndResolve(_database, seats[0].groupId);
+
+            // Alice (bottom, 0 below / 5 above): Shortstacked + Buried, no below titles.
+            Assert.True(HasSystemTitle("Alice", "Shortstacked"));
+            Assert.True(HasSystemTitle("Alice", "Buried"));
+            Assert.False(HasSystemTitle("Alice", "Elevated"));
+
+            // Carol (2 below / 3 above): earns from both ladders.
+            Assert.True(HasSystemTitle("Carol", "Elevated"));
+            Assert.True(HasSystemTitle("Carol", "Shortstacked"));
+
+            // Frank (top, 5 below / 0 above): below ladder only.
+            Assert.True(HasSystemTitle("Frank", "Elevated"));
+            Assert.True(HasSystemTitle("Frank", "Laps All The Way Down"));
+            Assert.False(HasSystemTitle("Frank", "Shortstacked"));
+        }
+
+        [Fact]
+        public void AlreadyHeld_IsNotRegrantedOrDoubleAnnounced()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+
+            // First 3-cuddle grants Cuddle Puddle to all.
+            var first = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(first);
+            GroupInteractionResolver.CheckAndResolve(_database, first[0].groupId);
+
+            // A second identical 3-cuddle: no new titles to announce, no duplicates stored.
+            var second = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(second);
+            var result = GroupInteractionResolver.CheckAndResolve(_database, second[0].groupId);
+
+            Assert.Empty(result.GroupTitleGrants);
+            foreach (var name in new[] { "Alice", "Bob", "Carol" })
+            {
+                int count = _database.GetProfile(name).titles
+                    .Count(t => t.IsSystemTitle && t.titleText == "Cuddle Puddle");
+                Assert.Equal(1, count);
+            }
+        }
+
+        // ---- Helpers (mirror GroupInteractionResolverTests) ----
+
+        private bool HasSystemTitle(string userName, string titleText)
+        {
+            var profile = _database.GetProfile(userName);
+            return profile.titles != null &&
+                profile.titles.Any(t => t.IsSystemTitle && t.titleText == titleText);
+        }
+
+        private void SeedProfiles(params string[] names)
+        {
+            foreach (var name in names)
+            {
+                new ProfileBuilder().WithUserName(name).WithDisplayName(name).BuildAndSave(_database);
+            }
+        }
+
+        private List<PendingCommand> CreateGroup(string initiator, string type, string identifier, params string[] recipients)
+        {
+            string groupId = Guid.NewGuid().ToString("N");
+            var seats = new List<PendingCommand>();
+            foreach (var recipient in recipients)
+            {
+                var seat = new PendingCommand
+                {
+                    Id = ObjectId.GenerateNewId(),
+                    pendingInteraction = new Interaction
+                    {
+                        initiator = initiator,
+                        recipient = recipient,
+                        type = type,
+                        identifier = identifier,
+                        investmentLevel = "casual"
+                    },
+                    awaitingConsentFrom = recipient,
+                    groupId = groupId,
+                    consentState = PendingCommand.PendingConsentState
+                };
+                _database.AddPendingCommand(seat);
+                seats.Add(seat);
+            }
+            return seats;
+        }
+
+        private void ConsentInOrder(List<PendingCommand> seats)
+        {
+            foreach (var seat in seats) GroupInteractionResolver.MarkSeatConsented(_database, seat);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -117,10 +117,19 @@ namespace FChatDicebot.BotCommands
                 if (resolution.Resolved && !string.IsNullOrEmpty(resolution.ChannelMessage))
                 {
                     string groupMessage = resolution.ChannelMessage;
+
+                    // One consolidated "Title Time!" banner for the whole moment, grouped by
+                    // title. Fold each participant's lifetime-count title wins (granted now that
+                    // the group counts have been applied) in with the group-achievement titles
+                    // (by resolved size / lap-stack position) already granted during resolution.
+                    var allTitleGrants = new List<InteractionProcessors.GroupTitleGrant>(resolution.GroupTitleGrants);
                     foreach (string participant in resolution.Participants)
                     {
-                        groupMessage = CheckAchievementsAndAppendToMessage(groupMessage, participant);
+                        var countGrant = ChateauSystemTitles.CheckAndGrantCountTitles(participant);
+                        if (countGrant != null) allTitleGrants.Add(countGrant);
                     }
+                    groupMessage += ChateauSystemTitles.FormatGroupTitleNotification(allTitleGrants);
+
                     if (!string.IsNullOrEmpty(channelMessage)) channelMessage += "\n\n";
                     channelMessage += groupMessage;
                 }

--- a/FChatDicebot/BotCommands/ChateauSystemTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauSystemTitles.cs
@@ -19,8 +19,24 @@ namespace FChatDicebot
         /// <returns>Notification text for earned titles, or empty string</returns>
         public static string CheckAndGrantTitles(string userName)
         {
+            var grant = CheckAndGrantCountTitles(userName);
+            if (grant == null) return string.Empty;
+            return FormatTitleNotification(grant.DisplayName, grant.NewTitles);
+        }
+
+        /// <summary>
+        /// Grant any newly-earned count / daily-climax titles for the user and return them as a
+        /// <see cref="InteractionProcessors.GroupTitleGrant"/> (display name + the new title
+        /// texts), or null if none were earned. This lets the group-resolution path fold a
+        /// participant's count-title wins into the same consolidated "Title Time!" banner as the
+        /// group-achievement titles, instead of emitting a separate per-person banner.
+        /// <see cref="CheckAndGrantTitles"/> wraps this for the 1:1 / single-actor callers that
+        /// just want the formatted string.
+        /// </summary>
+        public static InteractionProcessors.GroupTitleGrant CheckAndGrantCountTitles(string userName)
+        {
             Profile profile = MonDB.getProfile(userName);
-            if (profile == null) return string.Empty;
+            if (profile == null) return null;
 
             List<string> newTitles = new List<string>();
 
@@ -33,17 +49,17 @@ namespace FChatDicebot
             // newTitles.AddRange(CheckEmploymentTitles(profile));
             // newTitles.AddRange(CheckTransformationTitles(profile));
 
-            // Grant any new titles
-            if (newTitles.Count > 0)
+            if (newTitles.Count == 0) return null;
+
+            // Save profile with new titles.
+            MonDB.setProfile(userName, profile);
+
+            return new InteractionProcessors.GroupTitleGrant
             {
-                // Save profile with new titles
-                MonDB.setProfile(userName, profile);
-
-                // Build notification message
-                return FormatTitleNotification(profile.displayName, newTitles);
-            }
-
-            return string.Empty;
+                UserName = userName,
+                DisplayName = profile.displayName,
+                NewTitles = newTitles,
+            };
         }
 
         /// <summary>
@@ -312,7 +328,9 @@ namespace FChatDicebot
 
                 // Objectifying - giving
                 ("objectifygive", 1, "Objectifier"),
-                ("objectifygive", 3, "Hat Trick"),
+                // "Hat Trick" moved to the boobhat group-size titles; the objectify tier-3
+                // title is now "Toy Maker" (see GetGroupSizeTitles below).
+                ("objectifygive", 3, "Toy Maker"),
                 ("objectifygive", 5, "Deanimator"),
                 ("objectifygive", 10, "Collector"),
 
@@ -546,10 +564,150 @@ namespace FChatDicebot
             return earnedTitles;
         }
 
+        // ====================================================================
+        // Group-achievement titles. Unlike the lifetime-count milestones above,
+        // these are awarded once at a group interaction's resolution, based on
+        // the size of the resolved group (or, for lapsit, a participant's stack
+        // position). Thresholds are cumulative: a resolved group of a given size
+        // grants every tier at or below it. The grant path lives in
+        // InteractionProcessorBase.GrantGroupTitles / LapsitProcessor; these
+        // tables and lookups are the single source of truth for the text.
+        // ====================================================================
+
         /// <summary>
-        /// Format the notification message for newly earned titles
+        /// Group-size titles keyed by the processor's InteractionType. Each tier is
+        /// (minGroupSize, title) where group size counts every participant including the
+        /// initiator. Symmetric interactions (kiss / cuddle / handhold) award these to every
+        /// participant; directional one-way ones (spank / bully / lick / boobhat) award them
+        /// to the initiator only. Boobhat's "Hat Trick" is the former objectifygive tier-3
+        /// title, reassigned here.
         /// </summary>
-        private static string FormatTitleNotification(string displayName, List<string> titles)
+        private static readonly Dictionary<string, (int size, string title)[]> GroupSizeTitleTables =
+            new Dictionary<string, (int size, string title)[]>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["kiss"] = new[]
+                {
+                    (3, "Kiss Kiss"),
+                    (5, "Kisstacular"),
+                    (7, "Kissimanjaro"),
+                    (9, "Kisspocalypse"),
+                    (11, "Spartakiss"),
+                },
+                ["handhold"] = new[]
+                {
+                    (3, "Triangle"),
+                    (5, "Pentagon"),
+                    (7, "Septagon"),
+                    (9, "Nonagon"),
+                    (11, "Undecagon"),
+                },
+                ["cuddle"] = new[]
+                {
+                    (3, "Cuddle Puddle"),
+                    (5, "Cuddle Pond"),
+                    (7, "Cuddle Lake"),
+                    (9, "Cuddle Sea"),
+                    (11, "Cuddle Ocean"),
+                },
+                ["spank"] = new[]
+                {
+                    (3, "Echo"),
+                    (5, "Thunder Storm"),
+                    (8, "Seven Spanks"),
+                    (11, "Strike!"),
+                },
+                ["bully"] = new[]
+                {
+                    (3, "Intimidating"),
+                    (5, "Hazing"),
+                    (7, "Demands Respect"),
+                    (9, "Unbullyvable"),
+                    (11, "Decibully"),
+                },
+                ["lick"] = new[]
+                {
+                    (3, "Free Sample"),
+                    (5, "Indecisive"),
+                    (7, "Can Tie A Knot In A Cherry Stem"),
+                    (9, "Tongue In Chic"),
+                    (11, "Lick A Ton"),
+                },
+                ["boobhat"] = new[]
+                {
+                    (4, "Hat Trick"),
+                    (7, "Mad Hatter"),
+                    (11, "Capping"),
+                },
+            };
+
+        /// <summary>
+        /// Lapsit "below" titles: earned for the number of people stacked underneath a
+        /// participant (their stack position). Cumulative, like the size tables.
+        /// </summary>
+        private static readonly (int othersBelow, string title)[] LapsitBelowTitles = new[]
+        {
+            (2, "Elevated"),
+            (4, "Laps All The Way Down"),
+            (6, "Can See Their House From Here"),
+            (8, "King Of The World"),
+            (10, "Lap of Babel"),
+        };
+
+        /// <summary>
+        /// Lapsit "above" titles: earned for the number of people stacked on top of a
+        /// participant. Cumulative. A mid-stack participant can earn both below and above.
+        /// </summary>
+        private static readonly (int othersAbove, string title)[] LapsitAboveTitles = new[]
+        {
+            (2, "Shortstacked"),
+            (5, "Buried"),
+            (10, "Foundational"),
+        };
+
+        /// <summary>
+        /// Title texts earned by participating in a resolved group of the given size for the
+        /// given interaction type — every cumulative tier at or below <paramref name="groupSize"/>,
+        /// in ascending order. Empty when the type has no group titles or the group is below
+        /// the first threshold. Pure lookup; does not touch the database.
+        /// </summary>
+        public static IReadOnlyList<string> GetGroupSizeTitles(string interactionType, int groupSize)
+        {
+            var earned = new List<string>();
+            if (string.IsNullOrEmpty(interactionType)) return earned;
+            if (!GroupSizeTitleTables.TryGetValue(interactionType, out var tiers)) return earned;
+
+            foreach (var tier in tiers)
+            {
+                if (groupSize >= tier.size) earned.Add(tier.title);
+            }
+            return earned;
+        }
+
+        /// <summary>
+        /// Title texts earned by a single lap-stack position: cumulative "below" titles for the
+        /// number of people stacked under this participant, then cumulative "above" titles for
+        /// the number stacked over them. A mid-stack participant can earn both. Pure lookup.
+        /// </summary>
+        public static IReadOnlyList<string> GetLapsitPositionTitles(int othersBelow, int othersAbove)
+        {
+            var earned = new List<string>();
+            foreach (var tier in LapsitBelowTitles)
+            {
+                if (othersBelow >= tier.othersBelow) earned.Add(tier.title);
+            }
+            foreach (var tier in LapsitAboveTitles)
+            {
+                if (othersAbove >= tier.othersAbove) earned.Add(tier.title);
+            }
+            return earned;
+        }
+
+        /// <summary>
+        /// Format the notification message for newly earned titles. Public so the group
+        /// resolution path (which grants by size / lap-stack position rather than lifetime
+        /// counts) can surface the same "Title Time!" banner for its awards.
+        /// </summary>
+        public static string FormatTitleNotification(string displayName, List<string> titles)
         {
             if (titles.Count == 0) return string.Empty;
 
@@ -569,6 +727,52 @@ namespace FChatDicebot
                 message = message.TrimEnd('\n');
             }
 
+            message += "\n[sub]View all your titles with !titles[/sub]";
+
+            return message;
+        }
+
+        /// <summary>
+        /// Consolidate a resolved group's title grants into a single "Title Time!" banner: one
+        /// line per distinct newly-earned title, naming everyone who earned it with a serial-comma
+        /// list ("Alice" / "Alice and Bob" / "Alice, Bob, and Carol"). Titles are listed in
+        /// first-earned order across <paramref name="grants"/>; names within a title keep grant
+        /// order. Returns empty string when nobody earned anything new. Grants may mix
+        /// group-achievement titles and (folded in by the caller) lifetime-count titles — a
+        /// participant can appear in several grant entries; grouping by title merges them.
+        /// </summary>
+        public static string FormatGroupTitleNotification(IReadOnlyList<InteractionProcessors.GroupTitleGrant> grants)
+        {
+            if (grants == null) return string.Empty;
+
+            // Invert to title -> earners, preserving first-appearance order for both.
+            var orderedTitles = new List<string>();
+            var earnersByTitle = new Dictionary<string, List<string>>();
+            foreach (var grant in grants)
+            {
+                if (grant?.NewTitles == null) continue;
+                foreach (string title in grant.NewTitles)
+                {
+                    if (!earnersByTitle.TryGetValue(title, out var earners))
+                    {
+                        earners = new List<string>();
+                        earnersByTitle[title] = earners;
+                        orderedTitles.Add(title);
+                    }
+                    // Defensive: a title shouldn't be earned twice by the same name, but guard.
+                    if (!earners.Contains(grant.DisplayName)) earners.Add(grant.DisplayName);
+                }
+            }
+
+            if (orderedTitles.Count == 0) return string.Empty;
+
+            string message = "\n\n[b][color=purple]═══ Title Time! ═══[/color][/b]\n";
+            foreach (string title in orderedTitles)
+            {
+                string names = InteractionProcessors.InteractionProcessorBase.JoinNamesSerial(earnersByTitle[title]);
+                message += $"{names} earned the title [b]·{title}·[/b]!\n";
+            }
+            message = message.TrimEnd('\n');
             message += "\n[sub]View all your titles with !titles[/sub]";
 
             return message;

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -183,6 +183,30 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return BuildGroupRateLimitNote(limited);
         }
 
+        /// <summary>
+        /// Per-position lapsit titles: each participant earns "below" titles for the number of
+        /// people stacked under them and "above" titles for the number stacked over them, so a
+        /// mid-stack rider can earn both. Mirrors the per-position count split in
+        /// <see cref="ApplyGroupCounts"/>; the verb on <paramref name="identifier"/> decides who
+        /// claims the bottom (see <see cref="BuildStack{T}"/>).
+        /// </summary>
+        public override List<GroupTitleGrant> GrantGroupTitles(IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier)
+        {
+            var grants = new List<GroupTitleGrant>();
+            var stack = BuildStack(identifier, initiator, consentersInOrder); // bottom -> top
+            int stackSize = stack.Count; // M
+
+            for (int position = 0; position < stackSize; position++)
+            {
+                int othersBelow = position;
+                int othersAbove = stackSize - 1 - position;
+                var titles = ChateauSystemTitles.GetLapsitPositionTitles(othersBelow, othersAbove);
+                AddTitleGrant(database, stack[position], titles, grants);
+            }
+
+            return grants;
+        }
+
         public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
         {
             bool initiatorIsSitter = InitiatorIsSitter(identifier);

--- a/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
+++ b/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
@@ -113,6 +113,12 @@ namespace FChatDicebot.InteractionProcessors
             // Counts (processor owns the symmetric / directional / lapsit math + the +N helper).
             string rateLimitNote = processor.ApplyGroupCounts(database, initiator, consenterNames, identifier);
 
+            // Group-achievement titles, by resolved size (symmetric: everyone; directional:
+            // the initiator) or lap-stack position. Granting runs through the injected database
+            // so it stays on the same store and unit-testable; the command layer formats the
+            // per-participant "Title Time!" notifications from the returned grants.
+            result.GroupTitleGrants = processor.GrantGroupTitles(database, initiator, consenterNames, identifier);
+
             // Combined completion message.
             Profile initiatorProfile = database.GetProfile(initiator);
             var consenterProfiles = consenterNames.Select(database.GetProfile).ToList();
@@ -153,5 +159,12 @@ namespace FChatDicebot.InteractionProcessors
 
         /// <summary>Initiator + consenting recipients — for the caller's title checks.</summary>
         public List<string> Participants { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Group-achievement titles granted this resolution (by size / lap-stack position),
+        /// one entry per participant who earned at least one new title. Already persisted to
+        /// the database during resolution; the command layer only formats the notifications.
+        /// </summary>
+        public List<GroupTitleGrant> GroupTitleGrants { get; set; } = new List<GroupTitleGrant>();
     }
 }

--- a/FChatDicebot/InteractionProcessors/GroupSpec.cs
+++ b/FChatDicebot/InteractionProcessors/GroupSpec.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace FChatDicebot.InteractionProcessors
 {
     /// <summary>
@@ -55,5 +57,18 @@ namespace FChatDicebot.InteractionProcessors
         {
             return new GroupSpec { Kind = GroupCountKind.Lapsit };
         }
+    }
+
+    /// <summary>
+    /// One participant's freshly-granted group-achievement titles from a resolved moment,
+    /// returned by <c>InteractionProcessorBase.GrantGroupTitles</c>. Titles the participant
+    /// already held are omitted, so an empty <see cref="NewTitles"/> means there's nothing new
+    /// to announce. The command layer turns each non-empty grant into a "Title Time!" banner.
+    /// </summary>
+    public class GroupTitleGrant
+    {
+        public string UserName { get; set; }
+        public string DisplayName { get; set; }
+        public List<string> NewTitles { get; set; } = new List<string>();
     }
 }

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -95,6 +95,12 @@ namespace FChatDicebot.InteractionProcessors
         /// <summary>Apply group counts over the consenting recipients (in consent order).</summary>
         string ApplyGroupCounts(Database.IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier);
 
+        /// <summary>
+        /// Grant group-achievement titles (by resolved size, or lap-stack position) and return
+        /// the newly-granted titles per participant so the command layer can announce them.
+        /// </summary>
+        List<GroupTitleGrant> GrantGroupTitles(Database.IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier);
+
         /// <summary>Combined completion message for a resolved group moment.</summary>
         string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier);
 

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -543,6 +543,84 @@ namespace FChatDicebot.InteractionProcessors
         }
 
         /// <summary>
+        /// Grant group-achievement titles for a resolved moment and return, per participant,
+        /// the titles that were newly added. Default model:
+        ///   - Symmetric (kiss / cuddle / handhold): every participant earns the interaction's
+        ///     size titles — participating is enough.
+        ///   - Directional one-way (spank / bully / lick / boobhat): only the initiator earns
+        ///     them — they're the one doing it.
+        /// Lapsit overrides this for its per-position rule; non-group interactions grant
+        /// nothing. Size is M = recipients + 1 (the initiator), counting everyone.
+        ///
+        /// Mirrors <see cref="ApplyGroupCounts"/>: the database is threaded in by the resolver
+        /// so granting hits the same store the rest of resolution uses (and stays unit-testable).
+        /// </summary>
+        public virtual List<GroupTitleGrant> GrantGroupTitles(IChateauDatabase database, string initiator, IReadOnlyList<string> consentersInOrder, string identifier)
+        {
+            var grants = new List<GroupTitleGrant>();
+            var spec = GroupSpec;
+            if (spec == null) return grants;
+
+            int participantCount = consentersInOrder.Count + 1; // M
+            var sizeTitles = ChateauSystemTitles.GetGroupSizeTitles(InteractionType, participantCount);
+            if (sizeTitles.Count == 0) return grants;
+
+            if (spec.Kind == GroupCountKind.Symmetric)
+            {
+                AddTitleGrant(database, initiator, sizeTitles, grants);
+                foreach (var consenter in consentersInOrder)
+                    AddTitleGrant(database, consenter, sizeTitles, grants);
+            }
+            else if (spec.Kind == GroupCountKind.Directional)
+            {
+                // One-way interaction: only the initiator is credited with the moment's size.
+                AddTitleGrant(database, initiator, sizeTitles, grants);
+            }
+            // Lapsit (per-position) is handled in an override.
+
+            return grants;
+        }
+
+        /// <summary>
+        /// Grant the given achievement title texts to a user through the supplied database,
+        /// skipping any already held, and append a <see cref="GroupTitleGrant"/> to
+        /// <paramref name="grants"/> only when at least one title was actually new. Shared by
+        /// the base group-title path and the lapsit per-position override.
+        /// </summary>
+        protected void AddTitleGrant(IChateauDatabase database, string userName, IReadOnlyList<string> titleTexts, List<GroupTitleGrant> grants)
+        {
+            if (titleTexts == null || titleTexts.Count == 0) return;
+            Profile profile = database.GetProfile(userName);
+            if (profile == null) return;
+            if (profile.titles == null) profile.titles = new List<Title>();
+
+            var newlyGranted = new List<string>();
+            foreach (var titleText in titleTexts)
+            {
+                bool alreadyHas = profile.titles.Any(t =>
+                    t.IsSystemTitle && t.titleText.Equals(titleText, StringComparison.OrdinalIgnoreCase));
+                if (alreadyHas) continue;
+
+                profile.titles.Add(new Title
+                {
+                    titleText = titleText,
+                    givenBy = "Chateau",
+                    grantedTime = DateTime.UtcNow,
+                });
+                newlyGranted.Add(titleText);
+            }
+
+            if (newlyGranted.Count == 0) return;
+            database.SetProfile(userName, profile);
+            grants.Add(new GroupTitleGrant
+            {
+                UserName = userName,
+                DisplayName = profile.displayName,
+                NewTitles = newlyGranted,
+            });
+        }
+
+        /// <summary>
         /// Apply a single rate-limited +N increment for a group participant against the given
         /// database. A non-positive amount (e.g. the lap at position 0 has +0 lapsitgive) is a
         /// silent no-op — no timer is armed and no rate-limit note is produced. Participants

--- a/wiki-docs/specs/Future-Interactions/Group-Interactions-And-Pending-Lifecycle.md
+++ b/wiki-docs/specs/Future-Interactions/Group-Interactions-And-Pending-Lifecycle.md
@@ -1,6 +1,6 @@
 # Group Interactions, Pending Lifecycle, and New Casuals
 
-**Status:** Shipped 2026-06-22 (B4 group system, B5 lifecycle + `!consent <name>`, the lapsit lap-stack). The new casuals (B7) had already shipped 1:1 on 2026-06-21. Build green, 15 new tests. The lifecycle verbs were renamed at owner request to dodge the `!w`/`!work` clash: recipient-side is **`!no`** (aliases `!refuse`, `!decline`), initiator-side is **`!oops`** (aliases `!o`, `!withdraw`, `!cancel`). Out of scope, as designed: the tall-stack *height* titles (owner design TODO).
+**Status:** Shipped 2026-06-22 (B4 group system, B5 lifecycle + `!consent <name>`, the lapsit lap-stack). The new casuals (B7) had already shipped 1:1 on 2026-06-21. Build green, 15 new tests. The lifecycle verbs were renamed at owner request to dodge the `!w`/`!work` clash: recipient-side is **`!no`** (aliases `!refuse`, `!decline`), initiator-side is **`!oops`** (aliases `!o`, `!withdraw`, `!cancel`). **Group-achievement titles shipped 2026-06-22** (a follow-up): size-based titles for the group-capable casuals and the lapsit per-position "height" titles, owner-provided — see [Group-achievement titles](#group-achievement-titles-by-resolved-size--lap-stack-position) below.
 
 This spec covers the "Interactions" cluster from [Feature-Requests.md](../../Feature-Requests.md):
 
@@ -172,7 +172,7 @@ First consenter Bob claims the bottom. Stack bottom→top: Bob(0), Initiator(1),
 
 Example — `!lap Bob Carol David Erwin`, all consent: *"Alice pulls Bob onto their lap. Then Carol takes a seat, then David, then Erwin, forming a lap stack 5 people tall!"* + descriptor.
 
-**Tall-stack height titles (new title type, separate from the lifetime count ladders below):** award titles for participating in a tall stack at a given height — measured as **X above the floor** (position from the bottom) and/or **Y below the highest person** (position from the top). These gate on a single stack's size/position rather than lifetime counts (closer in spirit to the daily-climax titles than the count ladders). Specific heights and title wording **TBD** (owner).
+**Lap-stack height titles** award titles for a participant's position in a resolved stack — by how many others sit **below** them and how many sit **above** them. These gate on a single stack's size/position rather than lifetime counts, so they live outside the count ladders. **Shipped** with the rest of the group-achievement titles — see [Group-achievement titles](#group-achievement-titles-by-resolved-size--lap-stack-position).
 
 ### Dossier, specialist text, and counts
 
@@ -195,7 +195,42 @@ lickgive:    1 :P                10 Mlem                50 Talented Tongue   100
 licktake:    1 Licked            10 Tasty               50 Salt Lick         100 Spit Shined                500 Tootsie Pop
 ```
 
-Add all to the `interactionMilestones` table in [ChateauSystemTitles.cs:64](../../../FChatDicebot/BotCommands/ChateauSystemTitles.cs). (The tall-stack *height* titles above are a separate, still-TBD title type.)
+Add all to the `interactionMilestones` table in [ChateauSystemTitles.cs:64](../../../FChatDicebot/BotCommands/ChateauSystemTitles.cs). (The lap-stack *height* titles above are a separate title type — see the next section.)
+
+### Group-achievement titles (by resolved size / lap-stack position)
+
+**Shipped 2026-06-22 (follow-up).** A second, event-driven title type, distinct from the lifetime-count ladders above: awarded once when a *group* moment resolves, based on the size of the resolved group (or, for lapsit, a participant's stack position). Thresholds are **cumulative** — a resolved group of a given size grants every tier at or below it, the same way the count ladders backfill. Group size **M counts every participant including the initiator** (so a 3-person group = initiator + 2 recipients).
+
+Who is credited:
+
+- **Symmetric** (`kiss` / `cuddle` / `handhold`): **every participant** earns the size titles — participating is enough.
+- **Directional one-way** (`spank` / `bully` / `lick` / `boobhat`): **only the initiator** earns them.
+- **Lapsit:** **per position** — each participant earns "below" titles for the number of people stacked under them and "above" titles for the number over them, so a mid-stack rider can earn both.
+
+Size titles (M = participants incl. self), owner-provided:
+
+```
+kiss      3 Kiss Kiss   5 Kisstacular   7 Kissimanjaro   9 Kisspocalypse   11 Spartakiss
+handhold  3 Triangle    5 Pentagon      7 Septagon       9 Nonagon         11 Undecagon
+cuddle    3 Cuddle Puddle  5 Cuddle Pond  7 Cuddle Lake   9 Cuddle Sea      11 Cuddle Ocean
+spank     3 Echo        5 Thunder Storm  8 Seven Spanks   11 Strike!
+bully     3 Intimidating  5 Hazing       7 Demands Respect  9 Unbullyvable  11 Decibully
+lick      3 Free Sample  5 Indecisive   7 Can Tie A Knot In A Cherry Stem  9 Tongue In Chic  11 Lick A Ton
+boobhat   4 Hat Trick    7 Mad Hatter   11 Capping
+```
+
+Lapsit per-position titles, owner-provided:
+
+```
+others below:  2 Elevated   4 Laps All The Way Down   6 Can See Their House From Here   8 King Of The World   10 Lap of Babel
+others above:  2 Shortstacked   5 Buried   10 Foundational
+```
+
+`boobhat`'s **Hat Trick** is the former `objectifygive` tier-3 title, **renamed to "Toy Maker"** there (the lone holder had earned it both ways, so no migration was needed).
+
+**Implementation.** Tables + cumulative lookups live in [ChateauSystemTitles.cs](../../../FChatDicebot/BotCommands/ChateauSystemTitles.cs) (`GetGroupSizeTitles`, `GetLapsitPositionTitles`). Granting mirrors the count math: `InteractionProcessorBase.GrantGroupTitles` (symmetric/directional) and a `LapsitProcessor` override (per-position) persist through the injected database and return per-participant newly-granted titles; `GroupInteractionResolver` calls them during resolution and exposes the grants on `GroupResolutionResult.GroupTitleGrants`.
+
+**One consolidated banner.** A group moment surfaces a *single* "Title Time!" notification, **grouped by title**: each newly-earned title is listed once with everyone who earned it in a serial-comma name list ("Alice, Bob, and Carol earned the title ·Cuddle Puddle·!"). `ChateauConsent` folds in each participant's lifetime-count title wins (via `ChateauSystemTitles.CheckAndGrantCountTitles`, which now returns the same `GroupTitleGrant` shape) alongside the group-achievement grants, then renders them through `ChateauSystemTitles.FormatGroupTitleNotification`. The 1:1 consent path keeps its per-person banner.
 
 ### Descriptors (owner-provided)
 
@@ -253,7 +288,7 @@ Random completion descriptors per the casual pattern. Tokens: `{lapsitgiver}` = 
 
 ## Open items (confirm/decide at build time)
 
-1. **Tall-stack height titles** (design TODO, owner) — title set for stack height/position ("X above the floor" / "Y below the highest"); specific heights and wording TBD.
+1. ~~**Tall-stack height titles** (design TODO, owner)~~ — **Resolved/shipped 2026-06-22.** Owner provided the heights and wording; shipped as part of the broader [group-achievement titles](#group-achievement-titles-by-resolved-size--lap-stack-position) (size-based titles for every group-capable casual, plus the lapsit per-position "below"/"above" ladders).
 2. **No background scheduler** for timeout-fire of partially-consented groups — accept lazy resolution (see Implementation note) or build a timer.
 3. **Group state storage** — duplicate shared params on each seat vs. one small group record. Either is fine; pick whichever is cleaner against the existing DB layer.
 4. **`!r` / `!w` alias availability** — verify before wiring (part of the alias audit).


### PR DESCRIPTION
Awards titles when a **group** casual interaction resolves, based on the resolved group size — or, for lapsit, a participant's position in the stack. A second, event-driven title type, distinct from the lifetime-count ladders. Builds on the group-interaction system (PR #35).

## Behavior (owner-provided)
- **Cumulative thresholds** — a size-11 group backfills every lower tier, like the count ladders. Group size **M counts the initiator** (a "3" group = initiator + 2 recipients).
- **Symmetric** (kiss / cuddle / handhold): every participant earns the size title.
- **Directional one-way** (spank / bully / lick / boobhat): only the initiator.
- **Lapsit**: per stack position — "below" titles for people stacked under you, "above" titles for people over you (a mid-stack rider can earn both).

Size titles: kiss `3 Kiss Kiss · 5 Kisstacular · 7 Kissimanjaro · 9 Kisspocalypse · 11 Spartakiss`; handhold `Triangle/Pentagon/Septagon/Nonagon/Undecagon`; cuddle `Cuddle Puddle/Pond/Lake/Sea/Ocean`; spank `3 Echo · 5 Thunder Storm · 8 Seven Spanks · 11 Strike!`; bully `Intimidating/Hazing/Demands Respect/Unbullyvable/Decibully`; lick `Free Sample/Indecisive/Can Tie A Knot In A Cherry Stem/Tongue In Chic/Lick A Ton`; boobhat `4 Hat Trick · 7 Mad Hatter · 11 Capping`. Lapsit below `2/4/6/8/10 Elevated/Laps All The Way Down/Can See Their House From Here/King Of The World/Lap of Babel`; above `2/5/10 Shortstacked/Buried/Foundational`.

`boobhat`'s **Hat Trick** is the former `objectifygive` tier-3 title, **renamed to "Toy Maker"** there (the lone holder earned it both ways — no migration).

## One consolidated banner
A group moment surfaces a **single** "Title Time!" notification, grouped by title with serial-comma earner lists (e.g. `Alice, Bob, and Carol earned the title ·Cuddle Puddle·!`). Lifetime-count title wins crossed during the moment fold into the same banner. The 1:1 consent path keeps its per-person banner.

## Implementation
- Title tables + cumulative lookups (`GetGroupSizeTitles`, `GetLapsitPositionTitles`) in `ChateauSystemTitles`.
- `InteractionProcessorBase.GrantGroupTitles` (symmetric/directional) + `LapsitProcessor` override (per-position) grant through the **injected** database (mirrors the group count math, stays test-isolated); `GroupInteractionResolver` exposes grants on `GroupResolutionResult.GroupTitleGrants`.
- `CheckAndGrantCountTitles` refactored to return the same `GroupTitleGrant` shape so count wins fold in; `FormatGroupTitleNotification` renders the consolidated banner.

## Tests
25 new tests (pure lookups, resolver-path grants for symmetric/directional/lapsit + idempotency, and banner formatting). Full suite green: **1326 passed, 0 failed**.

Spec updated: the previously open "tall-stack height titles" owner TODO is now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)