### PR TITLE
Gate climax on the climaxer's chastity curse (solo + both verbs)

### DIFF
--- a/FChatDicebot.Tests/Unit/Climaxforprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Climaxforprocessortests.cs
@@ -146,6 +146,109 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.True(result.IsValid);
         }
 
+        [Fact]
+        public void ValidateInteraction_ClimaxforInitiatorChastity_Blocks()
+        {
+            // !climaxfor: the initiator is the climaxer, so the initiator's chastity blocks.
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+            CurseProcessor.ApplyCurse(alice, "chastity", "TestSetup");
+            _database.SetProfile("Alice", alice);
+
+            var result = _processor.ValidateInteraction(
+                "Alice", "Bob", ClimaxforProcessor.ComposeIdentifier(ClimaxforProcessor.ClimaxforType, 0));
+
+            Assert.False(result.IsValid);
+            Assert.Contains("chastity", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_ClimaxforRecipientChastity_PartnerStaysFree()
+        {
+            // !climaxfor: the recipient is only the partner, so their chastity must not block.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            CurseProcessor.ApplyCurse(bob, "chastity", "TestSetup");
+            _database.SetProfile("Bob", bob);
+
+            var result = _processor.ValidateInteraction(
+                "Alice", "Bob", ClimaxforProcessor.ComposeIdentifier(ClimaxforProcessor.ClimaxforType, 0));
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_ClimaxRecipientChastity_Blocks()
+        {
+            // !climax: the recipient is the climaxer, so the recipient's chastity blocks.
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            CurseProcessor.ApplyCurse(bob, "chastity", "TestSetup");
+            _database.SetProfile("Bob", bob);
+
+            var result = _processor.ValidateInteraction(
+                "Alice", "Bob", ClimaxforProcessor.ComposeIdentifier(ClimaxforProcessor.ClimaxType, 0));
+
+            Assert.False(result.IsValid);
+            Assert.Contains("chastity", result.ErrorMessage);
+        }
+
+        [Fact]
+        public void ValidateInteraction_ClimaxInitiatorChastity_PartnerStaysFree()
+        {
+            // !climax: the initiator is only the partner, so their chastity must not block.
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+            CurseProcessor.ApplyCurse(alice, "chastity", "TestSetup");
+            _database.SetProfile("Alice", alice);
+
+            var result = _processor.ValidateInteraction(
+                "Alice", "Bob", ClimaxforProcessor.ComposeIdentifier(ClimaxforProcessor.ClimaxType, 0));
+
+            Assert.True(result.IsValid);
+        }
+
+        // -------------------------------------------------------------------
+        // ValidateSelfTarget
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void ValidateSelfTarget_NoBlockers_Succeeds()
+        {
+            new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
+
+            var result = _processor.ValidateSelfTarget("Alice", ClimaxforProcessor.ClimaxforType);
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateSelfTarget_NonExistentUser_Fails()
+        {
+            var result = _processor.ValidateSelfTarget("Ghost", ClimaxforProcessor.ClimaxforType);
+
+            Assert.False(result.IsValid);
+            Assert.Contains("Ghost", result.ErrorMessage);
+        }
+
+        [Theory]
+        [InlineData("climax")]
+        [InlineData("climaxfor")]
+        public void ValidateSelfTarget_ChastityCurse_BlocksBothVerbs(string typeKey)
+        {
+            // Regression: a chastity-cursed resident's solo climax bypassed the consent flow
+            // and auto-resolved before the curse could gate it. The solo climaxer is always
+            // the same person, so chastity must block whichever verb they typed.
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            CurseProcessor.ApplyCurse(alice, "chastity", "TestSetup");
+            _database.SetProfile("Alice", alice);
+
+            var result = _processor.ValidateSelfTarget("Alice", typeKey);
+
+            Assert.False(result.IsValid);
+            Assert.Contains("chastity", result.ErrorMessage);
+        }
+
         // -------------------------------------------------------------------
         // PerformSelfTarget
         // -------------------------------------------------------------------

--- a/FChatDicebot.Tests/Unit/Cursestatuscontributortests.cs
+++ b/FChatDicebot.Tests/Unit/Cursestatuscontributortests.cs
@@ -98,19 +98,35 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void Contribute_ChastityBlocksBothClimaxVariants()
+        public void Contribute_ChastityBlocksClimaxerSide_PerVerb()
         {
-            // !climax (initiator-climaxer) and !climaxfor (recipient-climaxer).
+            // chastity blocks the climaxer. Per ResolveClimaxer the climaxer is the recipient
+            // of !climax and the initiator of !climaxfor, so each verb blocks the opposite side.
             var alice = BuildAliceWith("chastity");
             var bob = BuildBobWith("chastity");
 
-            var climaxResult = _contributor.Contribute(alice, StatusEffectCallSite.Consent, "climax", "", isInitiator: true);
-            var climaxForResult = _contributor.Contribute(bob, StatusEffectCallSite.Consent, "climaxfor", "", isInitiator: false);
+            var climaxResult = _contributor.Contribute(bob, StatusEffectCallSite.Consent, "climax", "", isInitiator: false);
+            var climaxForResult = _contributor.Contribute(alice, StatusEffectCallSite.Consent, "climaxfor", "", isInitiator: true);
 
             Assert.Single(climaxResult.Blockers);
-            Assert.True(climaxResult.Blockers[0].BlocksInitiator);
+            Assert.True(climaxResult.Blockers[0].BlocksRecipient);
             Assert.Single(climaxForResult.Blockers);
-            Assert.True(climaxForResult.Blockers[0].BlocksRecipient);
+            Assert.True(climaxForResult.Blockers[0].BlocksInitiator);
+        }
+
+        [Fact]
+        public void Contribute_ChastityLeavesPartnerSideFree_PerVerb()
+        {
+            // The partner (non-climaxer) of a climax can still help while cursed: the initiator
+            // of !climax and the recipient of !climaxfor are the partner, not the climaxer.
+            var alice = BuildAliceWith("chastity");
+            var bob = BuildBobWith("chastity");
+
+            var climaxPartner = _contributor.Contribute(alice, StatusEffectCallSite.Consent, "climax", "", isInitiator: true);
+            var climaxForPartner = _contributor.Contribute(bob, StatusEffectCallSite.Consent, "climaxfor", "", isInitiator: false);
+
+            Assert.Empty(climaxPartner.Blockers);
+            Assert.Empty(climaxForPartner.Blockers);
         }
 
         [Fact]

--- a/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
@@ -97,10 +97,14 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                     Bucket = CurseBucket.Disabler,
                     BlockedInteractions = new Dictionary<string, BlockSide>(StringComparer.OrdinalIgnoreCase)
                     {
-                        // !climax is initiator-climaxer; !climaxfor is recipient-climaxer.
-                        // Either way the climaxer slot is blocked.
-                        ["climax"] = BlockSide.Initiator,
-                        ["climaxfor"] = BlockSide.Recipient,
+                        // chastity blocks the *climaxer* — the person actually being made to
+                        // climax — and never the partner helping. Per ResolveClimaxer the
+                        // climaxer is the recipient of !climax ("you make me climax") and the
+                        // initiator of !climaxfor ("I climax for you"), so each verb blocks the
+                        // opposite side. Validation must pass the typed verb (not the
+                        // processor's single registered type) for this to gate correctly.
+                        ["climax"] = BlockSide.Recipient,
+                        ["climaxfor"] = BlockSide.Initiator,
                     },
                     CleanseCost = PurgeCostType.MissedWork,
                 },

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -385,16 +385,37 @@ namespace FChatDicebot.InteractionProcessors
             string parentIdentifier = null,
             bool isInitiator = false)
         {
+            return GetActiveStatusEffects(profile, callSite, InteractionType, parentIdentifier, isInitiator);
+        }
+
+        /// <summary>
+        /// Overload that surfaces contributors against an explicit
+        /// <paramref name="interactionType"/> rather than the processor's own
+        /// <see cref="InteractionType"/> property. Needed by
+        /// <see cref="Involved.ClimaxforProcessor"/>: one processor instance backs both
+        /// <c>!climax</c> and <c>!climaxfor</c>, and the two verbs flip which party is the
+        /// climaxer — so a side-keyed blocker (the <c>chastity</c> curse) must be evaluated
+        /// against the verb the user actually typed, not the single registered type. A null
+        /// or empty override falls back to <see cref="InteractionType"/>.
+        /// </summary>
+        protected StatusEffectFragments GetActiveStatusEffects(
+            Profile profile,
+            StatusEffectCallSite callSite,
+            string interactionType,
+            string parentIdentifier,
+            bool isInitiator)
+        {
             var merged = new StatusEffectFragments();
             if (profile == null) return merged;
 
             string safeIdentifier = parentIdentifier ?? string.Empty;
+            string effectiveType = string.IsNullOrEmpty(interactionType) ? InteractionType : interactionType;
             foreach (var contributor in StatusEffectRegistry.GetAllContributors())
             {
                 StatusEffectFragments contributed;
                 try
                 {
-                    contributed = contributor.Contribute(profile, callSite, InteractionType, safeIdentifier, isInitiator);
+                    contributed = contributor.Contribute(profile, callSite, effectiveType, safeIdentifier, isInitiator);
                 }
                 catch (Exception)
                 {

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxCommandSupport.cs
@@ -60,6 +60,18 @@ namespace FChatDicebot.InteractionProcessors.Involved
             // handler normally does both).
             if (isSelf)
             {
+                // Self-targets skip the consent flow, but must still honor status-effect
+                // blockers (e.g. the chastity curse) — otherwise a cursed resident's solo
+                // climax would auto-resolve before anything could stop it. ValidateInteraction
+                // can't be reused here (it rejects self-targets), so use the self-target check.
+                // Pass the typed verb so the right side of the chastity block is consulted.
+                var selfValidation = processor.ValidateSelfTarget(characterName, typedVerb);
+                if (!selfValidation.IsValid)
+                {
+                    bot.SendPrivateMessage(selfValidation.ErrorMessage, characterName);
+                    return;
+                }
+
                 string channelMessage = processor.PerformSelfTarget(characterName, typedVerb);
                 if (!string.IsNullOrEmpty(channelMessage))
                 {
@@ -74,10 +86,16 @@ namespace FChatDicebot.InteractionProcessors.Involved
             }
 
             // ----- Other-target: standard consent flow -----------------------
-            // Delegate validation to the processor so the command-time check uses the
-            // same rules as the consent-time recheck (profile existence, status-effect
-            // blockers, future cooldowns).
-            var validation = processor.ValidateInteraction(characterName, recipient, string.Empty);
+            // Pre-process identifier shape is "{typeKey}|0" — the processor overwrites the
+            // count portion with the post-increment daily count once it runs. We seed the
+            // typeKey now so both the verb-aware status-effect gate below and GetConsentWarning
+            // can read which verb was typed (the climaxer side a chastity block applies to
+            // flips between !climax and !climaxfor).
+            string preProcessIdentifier = ClimaxforProcessor.ComposeIdentifier(typedVerb, 0);
+
+            // Delegate validation to the processor (profile existence + status-effect blockers
+            // such as chastity, evaluated against the typed verb).
+            var validation = processor.ValidateInteraction(characterName, recipient, preProcessIdentifier);
             if (!validation.IsValid)
             {
                 bot.SendPrivateMessage(validation.ErrorMessage, characterName);
@@ -93,11 +111,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 // Type carries the user-typed verb so ProcessInteraction can pick the
                 // right climaxer (initiator for climaxfor, recipient for climax).
                 type = typedVerb,
-                // Pre-process identifier shape is "{typeKey}|0" — the processor will
-                // overwrite the count portion with the post-increment daily count once
-                // it runs. We seed the typeKey here so GetConsentWarning can render the
-                // right wording even before processing.
-                identifier = ClimaxforProcessor.ComposeIdentifier(typedVerb, 0),
+                identifier = preProcessIdentifier,
                 investmentLevel = "involved",
                 interactionTime = DateTime.UtcNow,
             };

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -198,19 +198,85 @@ namespace FChatDicebot.InteractionProcessors.Involved
 
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
         {
-            // Run the base validation first — gets us profile-existence checks plus any
-            // future status-effect blockers on the recipient.
-            var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
-            if (!baseValidation.IsValid) return baseValidation;
+            Profile initiatorProfile = Database.GetProfile(initiator);
+            Profile recipientProfile = Database.GetProfile(recipient);
+
+            if (initiatorProfile == null)
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.notFoundText(initiator));
+            }
+            if (recipientProfile == null)
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.notFoundText(recipient));
+            }
 
             // Self-target is allowed at the command layer through the PerformSelfTarget
             // shortcut, which never creates a PendingCommand. Reject self-target here as
             // a defensive guard so a stray self-pending can't sneak through and double-
-            // credit climaxtake via the rate-limited consent path.
+            // credit climaxtake via the rate-limited consent path. (Solo climaxes are
+            // status-gated separately via ValidateSelfTarget.)
             if (string.Equals(initiator, recipient, StringComparison.Ordinal))
             {
                 return ValidationResult.Failure(
                     "Self-climax is a shortcut handled at the command layer, not via the consent flow.");
+            }
+
+            // Gate on status-effect blockers against the verb the user actually typed
+            // (parsed from the identifier) rather than the processor's single registered
+            // type — chastity blocks whoever is the climaxer, and which side that is flips
+            // between !climax and !climaxfor.
+            return CheckClimaxStatusBlockers(
+                initiatorProfile, recipientProfile, ParseTypeFromIdentifier(identifier), identifier);
+        }
+
+        /// <summary>
+        /// Validation for the self-target shortcut. <see cref="ValidateInteraction"/> rejects
+        /// self-targets outright (defensive guard for the consent flow), so the command layer
+        /// can't reuse it to gate a solo <c>!climax</c> — yet a solo climax must still honor
+        /// status-effect blockers (e.g. the <c>chastity</c> curse). Without this, the
+        /// self-target branch ran <see cref="PerformSelfTarget"/> unconditionally and a cursed
+        /// resident could climax anyway.
+        ///
+        /// On a self-target the one person is both the initiator and the recipient (and always
+        /// the climaxer), so the shared both-sides check runs against that single profile with
+        /// the typed <paramref name="typeKey"/> — whichever side the verb's chastity block
+        /// keys to, the solo climaxer is on it.
+        /// </summary>
+        public ValidationResult ValidateSelfTarget(string user, string typeKey)
+        {
+            Profile profile = Database.GetProfile(user);
+            if (profile == null)
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.notFoundText(user));
+            }
+
+            return CheckClimaxStatusBlockers(profile, profile, typeKey, string.Empty);
+        }
+
+        /// <summary>
+        /// Shared status-effect gate for both the other-target consent path and the
+        /// self-target shortcut. Checks recipient-side then initiator-side blockers against
+        /// the typed <paramref name="typeKey"/>. The curse catalog only declares a chastity
+        /// block on the climaxer's side for each verb, so this naturally stops the climaxer
+        /// while leaving a (possibly also-cursed) partner free to help.
+        /// </summary>
+        private ValidationResult CheckClimaxStatusBlockers(
+            Profile initiatorProfile, Profile recipientProfile, string typeKey, string identifier)
+        {
+            var recipientBlocker = GetActiveStatusEffects(
+                    recipientProfile, StatusEffectCallSite.Consent, typeKey, identifier, isInitiator: false)
+                .Blockers.FirstOrDefault(b => b.BlocksRecipient);
+            if (recipientBlocker != null)
+            {
+                return ValidationResult.Failure(recipientBlocker.Reason);
+            }
+
+            var initiatorBlocker = GetActiveStatusEffects(
+                    initiatorProfile, StatusEffectCallSite.Consent, typeKey, identifier, isInitiator: true)
+                .Blockers.FirstOrDefault(b => b.BlocksInitiator);
+            if (initiatorBlocker != null)
+            {
+                return ValidationResult.Failure(initiatorBlocker.Reason);
             }
 
             return ValidationResult.Success();

--- a/wiki-docs/specs/Curse-and-Cleanse.md
+++ b/wiki-docs/specs/Curse-and-Cleanse.md
@@ -27,7 +27,7 @@ A new MongoDB collection `Curses`. v1 ships with these starter curses:
 
 | Name | Effect |
 |------|--------|
-| `chastity` | Blocks `!climaxfor` (recipient cannot climax). |
+| `chastity` | Blocks the climaxer of `!climax`/`!climaxfor`, including a solo climax — the cursed resident cannot be made to climax (by themselves or anyone else). They may still help a partner climax. |
 | `mute` | Blocks `!kiss`, `!feed` (recipient mouth-locked at the curse level — distinct from `break:mouth`). |
 | `frigid` | Blocks `!cuddle`, `!handhold`. |
 | `barren` | Blocks `!breed` recipient role. |


### PR DESCRIPTION
## Problem

A resident with the `chastity` curse could still be made to climax. Two gaps:

- **Solo `!climax` / `!climaxfor`** bypassed validation entirely — the self-target shortcut went straight to `PerformSelfTarget`, so the curse never got a chance to block.
- **Other-target `!climaxfor`** never blocked the cursed **initiator**. Validation always passed the processor's single registered type (`"climaxfor"`) to the curse contributor, ignoring the typed verb, and the curse catalog had the two verbs' climaxer sides reversed relative to `ResolveClimaxer`. The `!climax` recipient case only worked because those two errors cancelled out.

## Fix

Establishes a climaxer-centric invariant: **the climaxer can never have chastity** (solo, `!climax`, or `!climaxfor`), while a chastity-cursed *partner* may still help someone else climax.

- Correct the chastity catalog so each verb blocks the actual climaxer's side: `!climax` → `Recipient`, `!climaxfor` → `Initiator`.
- Add a `GetActiveStatusEffects` overload that evaluates contributors against an explicit interaction type; the existing call delegates to it (no behavior change for other processors).
- `ClimaxforProcessor` now validates against the **typed verb** via a shared `CheckClimaxStatusBlockers`; `ValidateSelfTarget` takes the verb too.
- `ClimaxCommandSupport` passes the verb into both validation paths.
- Update the `Curse-and-Cleanse` spec row; add per-verb climaxer-blocks / partner-stays-free tests (other-target, self-target, and contributor level).

## User-facing text

The block-reason template is unchanged, but two outputs now differ (both private to the initiator):
- Solo climax while cursed is now refused at all (previously succeeded silently): *"Alice is cursed with **chastity** and can't !climax right now."*
- The refusal now names the verb actually typed (`!climax` vs `!climaxfor`) instead of always `!climaxfor`.

## Testing

Full suite green — 1335 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)