### PR TITLE
Fix rename consent message; make milk & breed cooldowns per-direction

### DIFF
--- a/FChatDicebot.Tests/Unit/Breedprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Breedprocessortests.cs
@@ -236,7 +236,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void ProcessInteraction_SetsSymmetricPairCooldown()
+        public void ProcessInteraction_SetsDirectionCooldownOnInitiatorOnly()
         {
             new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
@@ -248,9 +248,11 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             var alice = _database.GetProfile("Alice");
             var bob = _database.GetProfile("Bob");
-            Assert.True(alice.timers.ContainsKey(BreedProcessor.PairTimerKey("Bob")));
-            Assert.True(bob.timers.ContainsKey(BreedProcessor.PairTimerKey("Alice")));
-            Assert.True(alice.timers[BreedProcessor.PairTimerKey("Bob")].timerEnd > DateTime.UtcNow);
+            // Only the breeder (Alice) is locked against the bred resident (Bob).
+            Assert.True(alice.timers.ContainsKey(BreedProcessor.DirectionTimerKey("Bob")));
+            Assert.True(alice.timers[BreedProcessor.DirectionTimerKey("Bob")].timerEnd > DateTime.UtcNow);
+            // Bob is NOT locked against Alice — he can breed her back the same day.
+            Assert.False(bob.timers != null && bob.timers.ContainsKey(BreedProcessor.DirectionTimerKey("Alice")));
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Milkprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Milkprocessortests.cs
@@ -153,12 +153,12 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void ValidateInteraction_PairLockActive_Fails()
+        public void ValidateInteraction_DirectionLockActive_Fails()
         {
             // Alice already milked Bob today — the timer on her side should block.
             new ProfileBuilder()
                 .WithUserName("Alice")
-                .WithTimer(MilkProcessor.PairTimerKey("Bob"), DateTime.UtcNow.AddHours(2))
+                .WithTimer(MilkProcessor.DirectionTimerKey("Bob"), DateTime.UtcNow.AddHours(2))
                 .BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
 
@@ -169,16 +169,32 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void ValidateInteraction_ExpiredPairLock_Allowed()
+        public void ValidateInteraction_ExpiredDirectionLock_Allowed()
         {
             // Timer is past — should be ignored.
             new ProfileBuilder()
                 .WithUserName("Alice")
-                .WithTimer(MilkProcessor.PairTimerKey("Bob"), DateTime.UtcNow.AddHours(-2))
+                .WithTimer(MilkProcessor.DirectionTimerKey("Bob"), DateTime.UtcNow.AddHours(-2))
                 .BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
 
             var result = _processor.ValidateInteraction("Alice", "Bob", "cum");
+
+            Assert.True(result.IsValid);
+        }
+
+        [Fact]
+        public void ValidateInteraction_RecipientCanMilkBack_SameDay()
+        {
+            // Alice milked Bob (so Alice holds the give-lock against Bob). The lock is
+            // directional, so Bob milking Alice back the same day must still be allowed.
+            new ProfileBuilder()
+                .WithUserName("Alice")
+                .WithTimer(MilkProcessor.DirectionTimerKey("Bob"), DateTime.UtcNow.AddHours(2))
+                .BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
+
+            var result = _processor.ValidateInteraction("Bob", "Alice", "cum");
 
             Assert.True(result.IsValid);
         }
@@ -227,7 +243,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void ProcessInteraction_SetsSymmetricPairLock()
+        public void ProcessInteraction_SetsDirectionLockOnInitiatorOnly()
         {
             new ProfileBuilder().WithUserName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").BuildAndSave(_database);
@@ -236,12 +252,13 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             var alice = _database.GetProfile("Alice");
             var bob = _database.GetProfile("Bob");
-            Assert.True(alice.timers.ContainsKey(MilkProcessor.PairTimerKey("Bob")));
-            Assert.True(bob.timers.ContainsKey(MilkProcessor.PairTimerKey("Alice")));
+            // Only the milker (Alice) is locked against the milked resident (Bob).
+            Assert.True(alice.timers.ContainsKey(MilkProcessor.DirectionTimerKey("Bob")));
+            // Bob is NOT locked against Alice — he can milk her back the same day.
+            Assert.False(bob.timers != null && bob.timers.ContainsKey(MilkProcessor.DirectionTimerKey("Alice")));
             // Locks until the next day boundary.
             DateTime expected = DateTime.UtcNow.Date.AddDays(1);
-            Assert.Equal(expected, alice.timers[MilkProcessor.PairTimerKey("Bob")].timerEnd);
-            Assert.Equal(expected, bob.timers[MilkProcessor.PairTimerKey("Alice")].timerEnd);
+            Assert.Equal(expected, alice.timers[MilkProcessor.DirectionTimerKey("Bob")].timerEnd);
         }
 
         [Fact]
@@ -470,21 +487,21 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void PairLockMessage_IncludesTimeUntilNextDay()
+        public void DirectionLockMessage_IncludesTimeUntilNextDay()
         {
             // Sanity check that we mention "in <time>" wording and avoid "UTC".
-            string message = MilkProcessor.PairLockMessage("Bob");
+            string message = MilkProcessor.DirectionLockMessage("Bob");
             Assert.Contains("already milked Bob today", message);
             Assert.Contains("milk them again in", message);
             Assert.DoesNotContain("UTC", message);
         }
 
         [Fact]
-        public void PairLockMessage_SelfVariant_UsesYourselfWording()
+        public void DirectionLockMessage_SelfVariant_UsesYourselfWording()
         {
             // Self-milk shortcut shouldn't read "You've already milked <your name>" — it
             // should say "yourself" both as the target and in the retry hint.
-            string message = MilkProcessor.PairLockMessage("Alice", isSelf: true);
+            string message = MilkProcessor.DirectionLockMessage("Alice", isSelf: true);
             Assert.Contains("already milked yourself today", message);
             Assert.Contains("milk yourself again in", message);
             Assert.DoesNotContain("Alice", message);

--- a/FChatDicebot.Tests/Unit/Renameprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Renameprocessortests.cs
@@ -154,6 +154,50 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
+        public void GetCompletionMessage_AfterProcess_ShowsOldNameThenNewName()
+        {
+            // Arrange
+            var initiator = new ProfileBuilder()
+                .WithUserName("Alice")
+                .WithDisplayName("Alice the Adventurer")
+                .BuildAndSave(_database);
+
+            var recipient = new ProfileBuilder()
+                .WithUserName("Bob")
+                .WithDisplayName("Bob the Bold")
+                .BuildAndSave(_database);
+
+            var pendingCommand = new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = "Alice",
+                    recipient = "Bob",
+                    type = "rename",
+                    identifier = "Sir Reginald",
+                    investmentLevel = "consequence",
+                    extraParameters = new BsonArray { "Sir Reginald" }
+                }
+            };
+
+            _database.AddPendingCommand(pendingCommand);
+
+            // Act: process applies the rename (mutating displayName to the strikethrough
+            // form), then the completion message is generated on the same instance.
+            _processor.ProcessInteraction(pendingCommand);
+            var recipientAfter = _database.GetProfile("Bob");
+            string message = _processor.GetCompletionMessage(initiator, recipientAfter, "Sir Reginald");
+
+            // Assert: clean old name in slot 1, new name in slot 2 — no blank, no
+            // strikethrough leaking into the "old name" slot.
+            Assert.Equal(
+                "Alice the Adventurer has made it known that Bob the Bold is to be known as Sir Reginald henceforth! All occurrences of their name in our records will be changed to reflect their new identity.",
+                message);
+            Assert.DoesNotContain("[s]", message);
+        }
+
+        [Fact]
         public void ValidateInteraction_BothUsersExist_ReturnsSuccess()
         {
             // Arrange

--- a/FChatDicebot/BotCommands/ChateauBreed.cs
+++ b/FChatDicebot/BotCommands/ChateauBreed.cs
@@ -13,11 +13,11 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Commitment Interaction";
             ShortDescription = "Breed another resident with new monster life";
-            LongDescription = "Breed a willing host. The host must !consent. Gestation duration varies per species. Multiple pregnancies can be carried at once. Once gestation completes, the host may give !birth at any time. Cooldowns are per breeder/bred pair - you can impregnate other people or be bred by others without waiting.";
+            LongDescription = "Breed a willing host. The host must !consent. Gestation duration varies per species. Multiple pregnancies can be carried at once. Once gestation completes, the host may give !birth at any time. The cooldown is per breeding direction - impregnating someone doesn't stop you breeding others, being bred by others, or even breeding that same partner back.";
             Usage = "!breed [noparse][user]NameInUserTag[/user][/noparse] {monster}";
             RelatedCommands = new string[] { "birth", "monsterize", "consent", "dossier" };
             CooldownDuration = "1 Day";
-            CooldownAppliesTo = "both";
+            CooldownAppliesTo = "initiator (per recipient)";
             IdentifierCategory = "monster";
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
@@ -46,15 +46,14 @@ namespace FChatDicebot.BotCommands
                 return;
             }
 
-            string pairKey = BreedProcessor.PairTimerKey(recipient);
-            if (initiatorProfile.timers.ContainsKey(pairKey)
-                && initiatorProfile.timers[pairKey].timerEnd.CompareTo(DateTime.UtcNow) > 0)
+            string directionKey = BreedProcessor.DirectionTimerKey(recipient);
+            if (initiatorProfile.timers.ContainsKey(directionKey)
+                && initiatorProfile.timers[directionKey].timerEnd.CompareTo(DateTime.UtcNow) > 0)
             {
-                string remaining = Utils.GetTimeSpanPrint(initiatorProfile.timers[pairKey].timerEnd - DateTime.UtcNow);
+                string remaining = Utils.GetTimeSpanPrint(initiatorProfile.timers[directionKey].timerEnd - DateTime.UtcNow);
                 bot.SendPrivateMessage(
-                    "You've already bred " + recipientProfile.displayName + " too recently. Please respect that 'Commitment' interactions are meant to be meaningful, and not spammed. " + recipientProfile.displayName + " will be available to bred by you again in " + remaining,
+                    "You've already bred " + recipientProfile.displayName + " too recently. Please respect that 'Commitment' interactions are meant to be meaningful, and not spammed. You'll be able to breed " + recipientProfile.displayName + " again in " + remaining,
                     characterName);
-                //test comment to confirm Claude sees this edit
                 return;
             }
 

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -332,7 +332,7 @@ namespace FChatDicebot.BotCommands
                     returnString = initiatorProfile.displayName + " takes " + recipientProfile.displayName + " by the collar and " + bullyDescriptors[random.Next(bullyDescriptors.Count)];
                     break;
                 case "rename":
-                    returnString = initiatorProfile.displayName + " has made it known that " + recipientProfile.displayName + " is to be known as " + recipientProfile.displayName + " henceforth! All occurences of their name in our records will be changed to reflect their new identity.";
+                    returnString = initiatorProfile.displayName + " has made it known that " + recipientProfile.displayName + " is to be known as " + recipientProfile.displayName + " henceforth! All occurrences of their name in our records will be changed to reflect their new identity.";
                     break;
                 case "monsterize":
                     identifier = Utils.AnOrA(identifier) + " " + identifier;

--- a/FChatDicebot/BotCommands/ChateauMilk.cs
+++ b/FChatDicebot/BotCommands/ChateauMilk.cs
@@ -7,14 +7,14 @@ namespace FChatDicebot.BotCommands
 {
     /// <summary>
     /// Milk a specific substance out of another resident. Produces 1–3 tagged bottles
-    /// (rolled at consent) in the initiator's milk inventory. One milking per pair per
-    /// day, regardless of substance. The Chateau provides the empties; no inventory
-    /// precondition.
+    /// (rolled at consent) in the initiator's milk inventory. One milking per direction
+    /// per day, regardless of substance — milking someone doesn't stop them milking you
+    /// back today. The Chateau provides the empties; no inventory precondition.
     ///
     /// Self-target is a shortcut: bypasses the consent flow and the milkInventory entry,
     /// instantly crediting the initiator with 1 copper + 1 bottle-currency (the same
     /// effective payout as milking and then immediately !selling one bottle of a
-    /// common-tier substance). Still consumes the daily pair-lock against yourself.
+    /// common-tier substance). Still consumes the daily self-direction lock.
     /// </summary>
     public class ChateauMilk : ChatBotCommand
     {
@@ -27,8 +27,8 @@ namespace FChatDicebot.BotCommands
             LongDescription = "Milk a specified substance from another resident, gaining 1 to 3 bottles. The bottles might be pure or corrupted based on who was milked. You can only milk a specified resident once per day.";
             Usage = "!milk [noparse][user]NameInUserTag[/user][/noparse] {substance}";
             RelatedCommands = new string[] { "sell", "feed", "golden", "consent", "dossier" };
-            CooldownDuration = "1 day, per-pair";
-            CooldownAppliesTo = "both initiator and recipient";
+            CooldownDuration = "1 day, per-direction";
+            CooldownAppliesTo = "initiator (per recipient)";
             IdentifierCategory = "substance";
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
@@ -71,10 +71,10 @@ namespace FChatDicebot.BotCommands
                     bot.SendPrivateMessage(ChateauInteractionHandler.typeNotFoundText(identifierType), characterName);
                     return;
                 }
-                if (MilkProcessor.HasActivePairLock(initiatorProfile, characterName))
+                if (MilkProcessor.HasActiveDirectionLock(initiatorProfile, characterName))
                 {
                     bot.SendPrivateMessage(
-                        MilkProcessor.PairLockMessage(initiatorProfile.displayName, isSelf: true),
+                        MilkProcessor.DirectionLockMessage(initiatorProfile.displayName, isSelf: true),
                         characterName);
                     return;
                 }
@@ -83,7 +83,7 @@ namespace FChatDicebot.BotCommands
                 {
                     initiatorProfile.timers = new System.Collections.Generic.Dictionary<string, CoolDown>();
                 }
-                initiatorProfile.timers[MilkProcessor.PairTimerKey(characterName)] = new CoolDown
+                initiatorProfile.timers[MilkProcessor.DirectionTimerKey(characterName)] = new CoolDown
                 {
                     timerEnd = DateTime.UtcNow.Date.AddDays(1)
                 };

--- a/FChatDicebot/BotCommands/ChateauRename.cs
+++ b/FChatDicebot/BotCommands/ChateauRename.cs
@@ -79,6 +79,9 @@ namespace FChatDicebot.BotCommands
                 rename.type = "rename";
                 rename.investmentLevel = "consequence";
                 rename.interactionTime = DateTime.UtcNow;
+                // Carry the new name in both identifier (read by the completion message)
+                // and extraParameters (read by ProcessInteraction when applying the rename).
+                rename.identifier = newName;
                 rename.extraParameters = new MongoDB.Bson.BsonArray
                 {
                     newName

--- a/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
@@ -169,9 +169,11 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             }
             recipientProfile.pregnancies.Add(pregnancy);
 
-            CoolDown pairTimer = new CoolDown { timerEnd = now.AddDays(1) };
-            initiatorProfile.timers[PairTimerKey(recipient)] = pairTimer;
-            recipientProfile.timers[PairTimerKey(initiator)] = pairTimer;
+            // Per-direction daily lock — stamped on the breeder only and scoped to the
+            // resident they bred, so being bred by someone (including breeding them back)
+            // is unaffected.
+            CoolDown directionTimer = new CoolDown { timerEnd = now.AddDays(1) };
+            initiatorProfile.timers[DirectionTimerKey(recipient)] = directionTimer;
 
             Database.SetProfile(initiator, initiatorProfile);
             Database.SetProfile(recipient, recipientProfile);
@@ -214,7 +216,9 @@ namespace FChatDicebot.InteractionProcessors.Commitment
         public static readonly CooldownSpec Cooldown = new CooldownSpec
         {
             Kind = CooldownKind.Cooldown,
-            Binds = CooldownBinds.Both,
+            // Per-direction: the breeder is locked against the specific resident they bred,
+            // so they can still be bred by others or breed that resident back the same day.
+            Binds = CooldownBinds.Initiator,
             PeriodDays = 1
         };
 
@@ -227,7 +231,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 : string.Empty;
 
             string seriousness = ConsentWarningText.Block(
-                ConsentWarningText.FrequencyBoth("breed", Cooldown.PeriodDays));
+                ConsentWarningText.FrequencyPerAxis(initiatorProfile.displayName, "breed you", Cooldown.PeriodDays));
 
             return initiatorProfile.displayName + " wants to breed " + recipientProfile.displayName
                 + " with new " + identifier + " life! " + seriousness
@@ -235,9 +239,14 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 + " Do you !consent to being bred?";
         }
 
-        public static string PairTimerKey(string otherUser)
+        /// <summary>
+        /// Key for the per-direction daily lock, stamped on the breeder only and scoped to
+        /// the resident they bred: alice has <c>breed_give_Bob</c> after breeding Bob.
+        /// Living only on the breeder's side means being bred back the same day is allowed.
+        /// </summary>
+        public static string DirectionTimerKey(string recipientUser)
         {
-            return "breed_pair_" + otherUser;
+            return "breed_give_" + recipientUser;
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
@@ -21,6 +21,15 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         {
         }
 
+        // The recipient's display name *before* the rename, captured during
+        // ProcessInteraction. By the time GetCompletionMessage runs, the profile's
+        // displayName has already been overwritten with the "[s]old[/s] new"
+        // strikethrough form, so we stash the clean old name here to render the
+        // "OLD is to be known as NEW" sentence. Mirrors the _lastInitiatorPrivateMessage
+        // instance-state idiom: ChateauConsent reuses the same processor instance for
+        // ProcessInteraction and the completion message within a single consent.
+        private string _lastOldDisplayName = string.Empty;
+
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
         {
             var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
@@ -45,6 +54,10 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             // Get the recipient's profile
             Profile recipientProfile = Database.GetProfile(recipient);
 
+            // Capture the old name before we overwrite it, so the completion message
+            // can read "OLD is to be known as NEW" cleanly.
+            _lastOldDisplayName = recipientProfile.displayName;
+
             // Create the new display name with strikethrough of old name
             string newName = command.pendingInteraction.extraParameters.FirstOrDefault().AsString;
             recipientProfile.displayName = "[s]" + recipient + "[/s] " + newName;
@@ -65,8 +78,12 @@ namespace FChatDicebot.InteractionProcessors.Consequence
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            string newName = identifier; // The new name should be passed as identifier in this context
-            return initiatorProfile.displayName + " has made it known that " + recipientProfile.displayName + " is to be known as " + newName + " henceforth! All occurences of their name in our records will be changed to reflect their new identity.";
+            // The new name arrives via identifier. The recipient profile's displayName has
+            // already been rewritten to the "[s]old[/s] new" strikethrough form by
+            // ProcessInteraction, so we use the old name captured before that overwrite.
+            string newName = identifier;
+            string oldName = !string.IsNullOrEmpty(_lastOldDisplayName) ? _lastOldDisplayName : recipientProfile.displayName;
+            return initiatorProfile.displayName + " has made it known that " + oldName + " is to be known as " + newName + " henceforth! All occurrences of their name in our records will be changed to reflect their new identity.";
         }
 
         public override CooldownSpec CooldownRule => Cooldown;

--- a/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
@@ -8,10 +8,11 @@ namespace FChatDicebot.InteractionProcessors.Involved
 {
     /// <summary>
     /// Processor for <c>!milk</c>. Produces 1–3 tagged bottles (rolled at process time)
-    /// in the initiator's <see cref="Profile.milkInventory"/> and applies a symmetric
-    /// 24-hour daily pair lock so the same (initiator, recipient) pair can only milk
-    /// once per Chateau day, regardless of substance. The Chateau provides the empty
-    /// bottles — no precondition on the initiator's inventory.
+    /// in the initiator's <see cref="Profile.milkInventory"/> and applies a 24-hour daily
+    /// per-direction lock so a given milker can only milk a given resident once per
+    /// Chateau day, regardless of substance. The lock is directional: it does not stop
+    /// the recipient from milking the initiator back the same day. The Chateau provides
+    /// the empty bottles — no precondition on the initiator's inventory.
     ///
     /// Self-target is allowed but handled inline by <see cref="BotCommands.ChateauMilk"/>
     /// as a special-cased self-sale: the consent flow is skipped and the initiator
@@ -54,33 +55,35 @@ namespace FChatDicebot.InteractionProcessors.Involved
         }
 
         /// <summary>
-        /// Key used for the symmetric per-pair daily lock. Same shape on both profiles:
-        /// alice has <c>milk_pair_Bob</c>, bob has <c>milk_pair_Alice</c>. For
-        /// self-milking the key is <c>milk_pair_&lt;self&gt;</c> on the single profile.
+        /// Key used for the per-direction daily lock, stamped on the milker (initiator)
+        /// only and scoped to the resident they milked: alice has <c>milk_give_Bob</c>
+        /// after milking Bob. Because it lives only on the milker's side, Bob milking
+        /// Alice back the same day is unaffected. For self-milking the key is
+        /// <c>milk_give_&lt;self&gt;</c> on the single profile.
         /// </summary>
-        public static string PairTimerKey(string otherUser) => "milk_pair_" + otherUser;
+        public static string DirectionTimerKey(string recipientUser) => "milk_give_" + recipientUser;
 
         /// <summary>
-        /// True when <paramref name="profile"/> has an active milk-pair lock against
-        /// <paramref name="otherUser"/>. Used by both the command's pre-check and the
-        /// processor's TOCTOU recheck.
+        /// True when <paramref name="profile"/> (the prospective milker) has already milked
+        /// <paramref name="recipientUser"/> today. Used by both the command's pre-check and
+        /// the processor's TOCTOU recheck.
         /// </summary>
-        public static bool HasActivePairLock(Profile profile, string otherUser)
+        public static bool HasActiveDirectionLock(Profile profile, string recipientUser)
         {
             if (profile?.timers == null) return false;
-            string key = PairTimerKey(otherUser);
+            string key = DirectionTimerKey(recipientUser);
             if (!profile.timers.TryGetValue(key, out var timer)) return false;
             return DateTime.UtcNow < timer.timerEnd;
         }
 
         /// <summary>
-        /// Channel-facing wording for the once-per-day pair lock. Centralized so the
-        /// command's pre-check and the (unlikely) TOCTOU path don't drift. Pass
+        /// Channel-facing wording for the once-per-day per-direction lock. Centralized so
+        /// the command's pre-check and the (unlikely) TOCTOU path don't drift. Pass
         /// <paramref name="isSelf"/>=true for the self-milk shortcut path so the message
         /// reads "You've already milked yourself" instead of the awkward
         /// "You've already milked &lt;your display name&gt;".
         /// </summary>
-        public static string PairLockMessage(string recipientDisplayOrName, bool isSelf = false)
+        public static string DirectionLockMessage(string recipientDisplayOrName, bool isSelf = false)
         {
             DateTime now = DateTime.UtcNow;
             string untilReset = Utils.GetTimeSpanPrint(now.Date.AddDays(1) - now);
@@ -132,11 +135,11 @@ namespace FChatDicebot.InteractionProcessors.Involved
             }
 
             Profile initiatorProfile = Database.GetProfile(initiator);
-            if (HasActivePairLock(initiatorProfile, recipient))
+            if (HasActiveDirectionLock(initiatorProfile, recipient))
             {
                 Profile recipientProfile = Database.GetProfile(recipient);
                 string recipientDisplay = recipientProfile?.displayName ?? recipient;
-                return ValidationResult.Failure(PairLockMessage(recipientDisplay));
+                return ValidationResult.Failure(DirectionLockMessage(recipientDisplay));
             }
 
             // Break gating by substance → bodypart map. BreakStatusContributor doesn't see
@@ -206,11 +209,11 @@ namespace FChatDicebot.InteractionProcessors.Involved
             Profile recipientProfile = Database.GetProfile(recipient);
 
             // TOCTOU recheck. Between !milk being typed and consent being given, another
-            // pending milk against the same recipient could have landed. If the pair lock
-            // is now active, stamp produced=0 and let GetCompletionMessage suppress
+            // pending milk against the same recipient could have landed. If the direction
+            // lock is now active, stamp produced=0 and let GetCompletionMessage suppress
             // channel output.
             int produced = 0;
-            if (!HasActivePairLock(initiatorProfile, recipient))
+            if (!HasActiveDirectionLock(initiatorProfile, recipient))
             {
                 int rolled = Rng.Next(ChateauCurrency.MilkRollMin, ChateauCurrency.MilkRollMax + 1);
                 // The Chateau provides empty bottles — no clamp against initiator inventory.
@@ -234,16 +237,13 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 }
                 initiatorProfile.milkInventory.Add(bottle);
 
-                // Symmetric 24h pair lock — until the *next* day-boundary regardless of
-                // time-of-day. Same shape both sides so either party's command-time check
-                // catches a re-milk attempt.
-                var pairTimer = new CoolDown { timerEnd = DateTime.UtcNow.Date.AddDays(1) };
+                // Per-direction 24h lock — until the *next* day-boundary regardless of
+                // time-of-day. Stamped on the milker only and scoped to the milked
+                // resident, so the recipient can still milk the initiator back today.
+                var directionTimer = new CoolDown { timerEnd = DateTime.UtcNow.Date.AddDays(1) };
                 if (initiatorProfile.timers == null)
                     initiatorProfile.timers = new Dictionary<string, CoolDown>();
-                if (recipientProfile.timers == null)
-                    recipientProfile.timers = new Dictionary<string, CoolDown>();
-                initiatorProfile.timers[PairTimerKey(recipient)] = pairTimer;
-                recipientProfile.timers[PairTimerKey(initiator)] = pairTimer;
+                initiatorProfile.timers[DirectionTimerKey(recipient)] = directionTimer;
             }
 
             // Stamp the truthful produced quantity onto the in-memory PendingCommand so


### PR DESCRIPTION
## Summary
- **Rename consent message bug** — the message showed the new name where the old name belonged and left the new-name slot blank. Two compounding causes: the new name was only stored in `extraParameters` (never `identifier`, which the message reads), and `ProcessInteraction` had already overwritten the recipient's `displayName` with the `[s]old[/s] new` strikethrough form before the message rendered. Now the command flows the new name through `identifier`, and the processor captures the clean old name before the overwrite. Output now reads:
  > Celeste Kristoph has made it known that Kohana Tsuzardo is to be known as Celeste's Giant Golden Dildo henceforth! ...
- **Milk cooldown → per-direction** — was a symmetric pair-lock (stamped on both parties), so milking someone blocked them from milking you back the same day. Now stamped on the milker only, scoped to the recipient (`milk_give_<recipient>`).
- **Breed cooldown → per-direction** — same symmetric-lock issue and same fix (`breed_give_<recipient>`); spec `Binds` changed `Both` → `Initiator`, with consent-warning and help text updated to match.
- **Train left per-pair** — it's a genuinely mutual activity (`ApplyProgression` advances *both* parties, both earn titles and `traingive`+`traintake` counts, lock spans all trainings), so a directional split would be meaningless.
- Fixed the long-standing `occurences` → `occurrences` misspelling in the rename message (live + defunct fallback path).

## User-facing string changes
- Rename completion message: old/new name now in the correct slots; `occurences` → `occurrences`.
- Milk help: `1 day, per-pair` → `1 day, per-direction`; applies-to `both initiator and recipient` → `initiator (per recipient)`.
- Breed consent warning: "You can only breed between the two of you once per day." → "_[Breeder]_ can only breed you once per day."
- Breed too-soon error: fixed broken grammar ("will be available to bred by you again" → "You'll be able to breed _[name]_ again in _[time]_").
- Breed long description: now states the cooldown is per breeding direction.

## Testing
- Updated milk/breed tests to assert the directional behavior (initiator-only stamp; recipient can act back the same day) and added a rename completion-message test.
- Full suite green: **1337 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)