### PR TITLE
Add ambient random events (!random)

### DIFF
--- a/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
+++ b/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
@@ -46,6 +46,7 @@ namespace FChatDicebot.Tests.Fixtures
             Database.ClearCollection("MonsterStats");
             Database.ClearCollection("Feedback");
             Database.ClearCollection("SlotsJackpots");
+            Database.ClearCollection("RandomEvents");
         }
 
         /// <summary>

--- a/FChatDicebot.Tests/Unit/Randomeventenginetests.cs
+++ b/FChatDicebot.Tests/Unit/Randomeventenginetests.cs
@@ -1,0 +1,461 @@
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Pure unit tests for the B12 random-events engine — selection, response validation, winner
+    /// rules, reward application, and the in-memory scheduler. Profiles live in an in-memory
+    /// dictionary (no Mongo) via the engine's injected accessors.
+    /// </summary>
+    public class RandomEventEngineTests
+    {
+        private const string Channel = "ADH-testchannel";
+
+        // ---- in-memory profile store wired into the engine ----
+        private readonly Dictionary<string, Profile> _profiles = new Dictionary<string, Profile>();
+        private int _setProfileCalls;
+
+        private RandomEventEngine NewEngine(int seed = 12345)
+        {
+            return new RandomEventEngine(
+                userName => _profiles.TryGetValue(userName, out var p) ? p : null,
+                (userName, p) => { _profiles[userName] = p; _setProfileCalls++; },
+                new Random(seed));
+        }
+
+        private Profile AddProfile(string userName, string displayName = null)
+        {
+            var p = new Profile { userName = userName, displayName = displayName ?? userName };
+            _profiles[userName] = p;
+            return p;
+        }
+
+        private static EventReward Reward(string type, string key, int min, int max)
+        {
+            return new EventReward { type = type, key = key, min = min, max = max };
+        }
+
+        private static RandomEvent EventWith(string responseType, string winnerRule, int winnerN = 0,
+            int windowSeconds = 60, params EventReward[] rewards)
+        {
+            return new RandomEvent
+            {
+                label = "test",
+                weight = 1,
+                announceText = "An event happens.",
+                responseType = responseType,
+                responseWindowSeconds = windowSeconds,
+                winnerRule = winnerRule,
+                winnerN = winnerN,
+                outcomes = new List<EventOutcome>
+                {
+                    new EventOutcome { weight = 1, resultText = "Resolved!", rewards = rewards.ToList() }
+                }
+            };
+        }
+
+        // =========================== Selection ===========================
+
+        [Fact]
+        public void SelectByWeight_SkipsZeroWeightEntries()
+        {
+            var a = new RandomEvent { label = "a", weight = 0 };
+            var b = new RandomEvent { label = "b", weight = 5 };
+            var rng = new Random(1);
+
+            for (int i = 0; i < 50; i++)
+                Assert.Equal("b", RandomEventEngine.SelectByWeight(new List<RandomEvent> { a, b }, rng).label);
+        }
+
+        [Fact]
+        public void SelectByWeight_EmptyOrSingle()
+        {
+            Assert.Null(RandomEventEngine.SelectByWeight(new List<RandomEvent>(), new Random(1)));
+            Assert.Null(RandomEventEngine.SelectByWeight(null, new Random(1)));
+
+            var only = new RandomEvent { label = "only", weight = 0 };
+            Assert.Same(only, RandomEventEngine.SelectByWeight(new List<RandomEvent> { only }, new Random(1)));
+        }
+
+        [Fact]
+        public void SelectByWeight_AllZero_FallsBackToUniform()
+        {
+            var a = new RandomEvent { label = "a", weight = 0 };
+            var b = new RandomEvent { label = "b", weight = 0 };
+            Assert.NotNull(RandomEventEngine.SelectByWeight(new List<RandomEvent> { a, b }, new Random(1)));
+        }
+
+        // =========================== Response validation ===========================
+
+        [Fact]
+        public void Validation_Keyword_CaseInsensitive_RejectsOthers()
+        {
+            var engine = NewEngine();
+            var ae = engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeKeyword, RandomEventEngine.WinnerRuleFirstValid), DateTime.UtcNow);
+
+            Assert.True(engine.IsValidArg(ae, ae.Keyword.ToUpperInvariant()));
+            Assert.True(engine.IsValidArg(ae, ae.Keyword));
+            Assert.False(engine.IsValidArg(ae, "definitely-not-the-token"));
+        }
+
+        [Fact]
+        public void Validation_Challenge_AcceptsOnlyCorrectAnswer()
+        {
+            var engine = NewEngine();
+            var ae = engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeChallenge, RandomEventEngine.WinnerRuleFirstValid), DateTime.UtcNow);
+
+            Assert.True(engine.IsValidArg(ae, ae.ChallengeAnswer));
+            Assert.False(engine.IsValidArg(ae, "999999"));
+        }
+
+        [Fact]
+        public void Validation_None_AcceptsBareAndAnything()
+        {
+            var engine = NewEngine();
+            var ae = engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleFirstValid), DateTime.UtcNow);
+
+            Assert.True(engine.IsValidArg(ae, ""));
+            Assert.True(engine.IsValidArg(ae, "whatever"));
+        }
+
+        [Fact]
+        public void HandleRandom_NoActiveEvent_RepliesNoEvent()
+        {
+            var engine = NewEngine();
+            var result = engine.HandleRandom(Channel, "Alice", "", DateTime.UtcNow);
+            Assert.Equal(RandomEventEngine.NoEventMessage, result.ReplyToUser);
+        }
+
+        [Fact]
+        public void HandleRandom_WrongKeyword_DoesNotConsumeShot()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            var ae = engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeKeyword, RandomEventEngine.WinnerRuleFirstValid), DateTime.UtcNow);
+
+            var wrong = engine.HandleRandom(Channel, "Alice", "wrong-token", DateTime.UtcNow);
+            Assert.NotNull(wrong.ReplyToUser);
+            Assert.Null(wrong.ChannelAnnouncement);
+            Assert.Empty(ae.Responders);
+            Assert.True(engine.HasActiveEvent(Channel)); // still open — they can retry
+
+            var right = engine.HandleRandom(Channel, "Alice", ae.Keyword, DateTime.UtcNow);
+            Assert.NotNull(right.ChannelAnnouncement);
+        }
+
+        // =========================== Winner rules ===========================
+
+        [Fact]
+        public void Winner_FirstValid_ResolvesOnFirstResponder()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleFirstValid,
+                rewards: Reward("currency", "rosequartz", 5, 5)), DateTime.UtcNow);
+
+            var first = engine.HandleRandom(Channel, "Alice", "", DateTime.UtcNow);
+            Assert.Contains("[user]Alice[/user]", first.ChannelAnnouncement);
+            Assert.False(engine.HasActiveEvent(Channel));
+
+            // Bob is too late — event already resolved.
+            var late = engine.HandleRandom(Channel, "Bob", "", DateTime.UtcNow);
+            Assert.Equal(RandomEventEngine.NoEventMessage, late.ReplyToUser);
+        }
+
+        [Fact]
+        public void Winner_Nth_SelectsExactlyTheNthResponder()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            AddProfile("Carol");
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleNth, winnerN: 2,
+                rewards: Reward("currency", "rosequartz", 3, 3)), DateTime.UtcNow);
+
+            Assert.Null(engine.HandleRandom(Channel, "Alice", "", DateTime.UtcNow).ChannelAnnouncement); // pending
+            var second = engine.HandleRandom(Channel, "Bob", "", DateTime.UtcNow);
+
+            Assert.NotNull(second.ChannelAnnouncement);
+            Assert.Contains("[user]Bob[/user]", second.ChannelAnnouncement);
+            Assert.DoesNotContain("[user]Alice[/user]", second.ChannelAnnouncement);
+            Assert.False(engine.HasActiveEvent(Channel));
+        }
+
+        [Fact]
+        public void Winner_AllInWindow_GrantsEveryValidResponder_DuplicatesIgnored()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleAllInWindow,
+                windowSeconds: 60, rewards: Reward("currency", "rosequartz", 2, 2)), t0);
+
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Alice", "", t0); // duplicate ignored
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            // Window elapses → resolved by the scheduler tick.
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+            string announcement = string.Join("\n", output);
+
+            Assert.Contains("[user]Alice[/user]", announcement);
+            Assert.Contains("[user]Bob[/user]", announcement);
+            Assert.False(engine.HasActiveEvent(Channel));
+            Assert.Equal(2, _profiles["Alice"].currencies["rosequartz"]); // granted once despite the dup
+            Assert.Equal(2, _profiles["Bob"].currencies["rosequartz"]);
+        }
+
+        [Fact]
+        public void Winner_Random_PicksExactlyOneResponder()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleRandom,
+                windowSeconds: 60, rewards: Reward("currency", "rosequartz", 4, 4)), t0);
+
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+            string announcement = string.Join("\n", output);
+
+            int winners = (announcement.Contains("[user]Alice[/user]") ? 1 : 0) + (announcement.Contains("[user]Bob[/user]") ? 1 : 0);
+            Assert.Equal(1, winners);
+        }
+
+        // =========================== Reward application ===========================
+
+        [Fact]
+        public void Reward_Currency_AddsToWalletCreatingKey()
+        {
+            var p = new Profile { userName = "Alice" };
+            string frag = RandomEventEngine.ApplyEventReward(p, Reward("currency", "rosequartz", 5, 5), new Random(1));
+            Assert.Equal(5, p.currencies["rosequartz"]);
+            Assert.Contains("5 rosequartz", frag);
+
+            RandomEventEngine.ApplyEventReward(p, Reward("currency", "rosequartz", 3, 3), new Random(1));
+            Assert.Equal(8, p.currencies["rosequartz"]);
+        }
+
+        [Fact]
+        public void Reward_Title_AddedOnce_AsSystemTitle()
+        {
+            var p = new Profile { userName = "Alice" };
+            string frag = RandomEventEngine.ApplyEventReward(p, Reward("title", "Lucky", 0, 0), new Random(1));
+            Assert.Single(p.titles);
+            Assert.True(p.titles[0].IsSystemTitle);
+            Assert.Equal("Lucky", p.titles[0].titleText);
+            Assert.Contains("Lucky", frag);
+
+            // Idempotent: granting again does nothing and yields no fragment.
+            string again = RandomEventEngine.ApplyEventReward(p, Reward("title", "Lucky", 0, 0), new Random(1));
+            Assert.Single(p.titles);
+            Assert.Equal("", again);
+        }
+
+        [Fact]
+        public void Reward_Training_ClampedToHundred()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.trainings["magic"] = 95;
+            string frag = RandomEventEngine.ApplyEventReward(p, Reward("training", "magic", 10, 10), new Random(1));
+            Assert.Equal(TrainProcessor.LevelCap, p.trainings["magic"]); // 100, not 105
+            Assert.Contains("5", frag); // only +5 actually gained
+
+            // Already maxed → no gain, no fragment.
+            string maxed = RandomEventEngine.ApplyEventReward(p, Reward("training", "magic", 10, 10), new Random(1));
+            Assert.Equal("", maxed);
+        }
+
+        [Fact]
+        public void Reward_Corruption_DecreasesSignedAxis_PurityIncreases()
+        {
+            var p = new Profile { userName = "Alice" };
+            RandomEventEngine.ApplyEventReward(p, Reward("corruption", null, 5, 5), new Random(1));
+            Assert.Equal("-5", p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+
+            RandomEventEngine.ApplyEventReward(p, Reward("purity", null, 7, 7), new Random(1));
+            Assert.Equal("2", p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]); // -5 + 7
+        }
+
+        [Fact]
+        public void Reward_Curse_AddsKnownCurseOnce_RejectsUnknown()
+        {
+            var p = new Profile { userName = "Alice" };
+            string frag = RandomEventEngine.ApplyEventReward(p, Reward("curse", "poverty", 0, 0), new Random(1));
+            Assert.Single(CurseInstance.LoadAll(p));
+            Assert.Equal("poverty", CurseInstance.LoadAll(p)[0].Curse);
+            Assert.Contains("poverty", frag);
+
+            // Duplicate curse → no-op, no fragment.
+            Assert.Equal("", RandomEventEngine.ApplyEventReward(p, Reward("curse", "poverty", 0, 0), new Random(1)));
+
+            // Unknown curse id → nothing applied.
+            Assert.Equal("", RandomEventEngine.ApplyEventReward(p, Reward("curse", "not-a-real-curse", 0, 0), new Random(1)));
+            Assert.Single(CurseInstance.LoadAll(p));
+        }
+
+        [Fact]
+        public void Reward_None_NoWriteNoFragment()
+        {
+            var p = new Profile { userName = "Alice" };
+            string frag = RandomEventEngine.ApplyEventReward(p, Reward("none", null, 0, 0), new Random(1));
+            Assert.Equal("", frag);
+            Assert.Empty(p.currencies);
+            Assert.Empty(p.titles);
+        }
+
+        [Fact]
+        public void Resolution_SavesEachWinnerProfileOnce()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            _setProfileCalls = 0;
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleFirstValid,
+                rewards: Reward("currency", "rosequartz", 5, 5)), DateTime.UtcNow);
+
+            engine.HandleRandom(Channel, "Alice", "", DateTime.UtcNow);
+            Assert.Equal(1, _setProfileCalls);
+        }
+
+        [Fact]
+        public void Resolution_WinnersPlaceholder_CarriesMultiPersonFlavor_NoRewardLineWhenNoneGranted()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = new RandomEvent
+            {
+                label = "test", weight = 1, announceText = "An event happens.",
+                responseType = RandomEventEngine.ResponseTypeNone, responseWindowSeconds = 60,
+                winnerRule = RandomEventEngine.WinnerRuleAllInWindow,
+                outcomes = new List<EventOutcome>
+                {
+                    new EventOutcome
+                    {
+                        weight = 1,
+                        resultText = "{winners} are now glowing purple.",
+                        rewards = new List<EventReward> { Reward("none", null, 0, 0) }
+                    }
+                }
+            };
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal(new List<string> { "[user]Alice[/user] and [user]Bob[/user] are now glowing purple." }, output);
+        }
+
+        [Fact]
+        public void Resolution_GroupsIdenticalRewardsOntoOneLine_WithPluralVerb()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            AddProfile("Bob");
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = new RandomEvent
+            {
+                label = "test", weight = 1, announceText = "An event happens.",
+                responseType = RandomEventEngine.ResponseTypeNone, responseWindowSeconds = 60,
+                winnerRule = RandomEventEngine.WinnerRuleAllInWindow,
+                outcomes = new List<EventOutcome>
+                {
+                    new EventOutcome
+                    {
+                        weight = 1,
+                        resultText = "Cutie giggles with delight.",
+                        rewards = new List<EventReward> { Reward("currency", "rosequartz", 3, 3) }
+                    }
+                }
+            };
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal("Cutie giggles with delight.\n[user]Alice[/user] and [user]Bob[/user] receive [b]3 rosequartz[/b]!", output[0]);
+        }
+
+        // =========================== Scheduler ===========================
+
+        [Fact]
+        public void Scheduler_DueFireIntoActiveChannel_OpensEvent_ThenOneAtATime()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            var events = new List<RandomEvent> { EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleAllInWindow) };
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            // First tick seeds the next-fire (6-8h out): nothing fires yet.
+            Assert.Empty(engine.Tick(Channel, t0, () => events));
+            Assert.False(engine.HasActiveEvent(Channel));
+
+            // 9h later, with fresh activity, the due fire opens an event.
+            DateTime t1 = t0.AddHours(9);
+            engine.RecordActivity(Channel, t1);
+            var fired = engine.Tick(Channel, t1, () => events);
+            Assert.Single(fired);
+            Assert.True(engine.HasActiveEvent(Channel));
+
+            // One event at a time: an immediate second tick fires nothing more.
+            Assert.Empty(engine.Tick(Channel, t1, () => events));
+            Assert.True(engine.HasActiveEvent(Channel));
+        }
+
+        [Fact]
+        public void Scheduler_DueFireIntoQuietChannel_SkipsAndDoesNotPost()
+        {
+            var engine = NewEngine();
+            var events = new List<RandomEvent> { EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleAllInWindow) };
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            engine.Tick(Channel, t0, () => events); // seed
+            // 9h later with NO recent activity → due but quiet → skip, no post, no active event.
+            var output = engine.Tick(Channel, t0.AddHours(9), () => events);
+            Assert.Empty(output);
+            Assert.False(engine.HasActiveEvent(Channel));
+        }
+
+        [Fact]
+        public void Scheduler_WindowElapse_ResolvesNonFirstValid()
+        {
+            var engine = NewEngine();
+            AddProfile("Alice");
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleAllInWindow,
+                windowSeconds: 30, rewards: Reward("currency", "rosequartz", 1, 1)), t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(31), () => new List<RandomEvent>());
+            Assert.Single(output);
+            Assert.Contains("[user]Alice[/user]", output[0]);
+            Assert.False(engine.HasActiveEvent(Channel));
+        }
+
+        [Fact]
+        public void Scheduler_FirstValidWindowElapsesWithNoResponder_ClosesWithNoWinner()
+        {
+            var engine = NewEngine();
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            engine.ForceOpen(Channel, EventWith(RandomEventEngine.ResponseTypeNone, RandomEventEngine.WinnerRuleFirstValid, windowSeconds: 30), t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(31), () => new List<RandomEvent>());
+            Assert.Single(output);
+            Assert.False(engine.HasActiveEvent(Channel));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -80,6 +80,7 @@ namespace FChatDicebot.BotCommands
                 "!business",
                 "!joinchateau",
                 "!modmessage",
+                "!random",
                 "!feedback [sub]!suggestion[/sub]",
                 "!setmark",
                 "!help [sub]!commands[/sub]",
@@ -156,7 +157,7 @@ namespace FChatDicebot.BotCommands
                 "!odorize",
                 "!break"
             };
-            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 22nd 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
+            string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 29th 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
                     "[u]Does not require channel[/u]\n" +
                     Utils.sortedListDisplayText(generalCommands) + "\n" +
                     "[i]Recovery Commands:[/i] " + Utils.sortedListDisplayText(recoveryCommands) + "\n\n" +

--- a/FChatDicebot/BotCommands/ChateauRandom.cs
+++ b/FChatDicebot/BotCommands/ChateauRandom.cs
@@ -1,0 +1,63 @@
+using System;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// !random: join the ambient random event currently running in this channel (B12). The bot
+    /// occasionally fires an event into an opted-in channel; residents respond with !random
+    /// (plus an event-requested keyword or answer, when the event demands one to thwart snipers).
+    /// Not a consent interaction — it has no recipient, investment level, or reversal. All the
+    /// scheduling, validation, and reward logic lives in <see cref="RandomEventEngine"/>; this
+    /// command is just the thin channel-side entry point.
+    /// </summary>
+    public class ChateauRandom : ChatBotCommand
+    {
+        public ChateauRandom()
+        {
+            Name = "random";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Join the random event happening in this channel";
+            LongDescription = "Take part in the random event the bot is currently running in this channel. " +
+                "The bot fires an event into the channel every so often; respond with !random to join in. " +
+                "Some events ask you to include an extra word or answer (it'll say so) to keep things fair — " +
+                "for those, type it after the command, e.g. !random rose. Winners may earn currency, a title, " +
+                "training, a shift in corruption or purity, a curse, or just a bit of fun. There's no cooldown; " +
+                "participation is limited by the event's own response window.";
+            Usage = "!random\nor\n!random <keyword/answer>";
+            RelatedCommands = new string[] { "dossier", "help" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, MessageAddress address, UserGeneratedCommand command)
+        {
+            string characterName = address.character;
+            string channel = address.channel;
+
+            if (bot.RandomEventEngine == null)
+            {
+                bot.SendPrivateMessage(RandomEventEngine.NoEventMessage, characterName);
+                return;
+            }
+
+            // The original-case joined args are the event's requested keyword/answer (if any).
+            string arg = rawTerms != null && rawTerms.Length > 0 ? string.Join(" ", rawTerms).Trim() : "";
+
+            RandomResponseResult result = bot.RandomEventEngine.HandleRandom(channel, characterName, arg, DateTime.UtcNow);
+
+            if (!string.IsNullOrEmpty(result.ChannelAnnouncement))
+                bot.SendMessageInChannel(result.ChannelAnnouncement, channel);
+            if (!string.IsNullOrEmpty(result.ReplyToUser))
+                bot.SendPrivateMessage(result.ReplyToUser, characterName);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/Support/RandomEventEngine.cs
+++ b/FChatDicebot/BotCommands/Support/RandomEventEngine.cs
@@ -1,0 +1,639 @@
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// The whole engine behind the B12 ambient "random events" system. Holds the per-channel
+    /// in-memory scheduler state, fires a seeded <see cref="RandomEvent"/> into an opted-in
+    /// channel every several hours, validates <c>!random</c> responses (defeating snipers per
+    /// the event's anti-snipe rule), resolves the winner(s), and grants the rolled outcome's
+    /// rewards to existing profile stores (currency / title / training / corruption / purity /
+    /// curse).
+    ///
+    /// Deliberately lives outside <c>FChatDicebot.BotCommands</c> so the reflection-based command
+    /// loader in <c>BotCommandController</c> doesn't try to <c>Activator.CreateInstance</c> it.
+    ///
+    /// Profile reads/writes go through injected delegates (in production, MonDB; in tests, an
+    /// in-memory dictionary) so the entire fire → respond → resolve → grant path is unit-testable
+    /// away from BotMain and Mongo. All in-memory state (active events, per-channel next-fire and
+    /// last-activity timestamps, collected responders) is intentionally non-persistent and resets
+    /// on restart — only the event definitions and granted rewards are durable.
+    ///
+    /// Thread-safety: the F-Chat receive thread (<c>!random</c>, activity) and the heartbeat thread
+    /// (the scheduler tick) both touch this state, so every public entry point takes the single
+    /// instance lock.
+    /// </summary>
+    public class RandomEventEngine
+    {
+        // ---- Tuning (owner-review defaults; see Random-Events.md "Open items") ----
+        // Cadence: about one event per channel every 6-8 hours, with jitter.
+        public const double IntervalMinHours = 6.0;
+        public const double IntervalMaxHours = 8.0;
+        // Activity gate: only fire into a channel that saw a human message this recently.
+        public const int ActivityWindowMinutes = 15;
+        // Fallback response window when an event leaves responseWindowSeconds at 0.
+        public const int DefaultResponseWindowSeconds = 60;
+
+        public const string ResponseTypeNone = "none";
+        public const string ResponseTypeKeyword = "keyword";
+        public const string ResponseTypeChallenge = "challenge";
+
+        public const string WinnerRuleFirstValid = "firstValid";
+        public const string WinnerRuleAllInWindow = "allInWindow";
+        public const string WinnerRuleNth = "nth";
+        public const string WinnerRuleRandom = "random";
+
+        // Pool of simple tokens used to randomize the "keyword" anti-snipe arg per fire.
+        public static readonly string[] KeywordPool = new string[]
+        {
+            "rose", "velvet", "candle", "satin", "amber", "ivory", "ribbon", "lace",
+            "ember", "petal", "feather", "crimson", "violet", "honey", "pearl", "thorn",
+        };
+
+        private readonly object _lock = new object();
+        private readonly Random _rng;
+        private readonly Func<string, Profile> _getProfile;
+        private readonly Action<string, Profile> _setProfile;
+
+        // Per-channel state (keys are lowercased channel ids).
+        private readonly Dictionary<string, ActiveRandomEvent> _active = new Dictionary<string, ActiveRandomEvent>();
+        private readonly Dictionary<string, DateTime> _nextFire = new Dictionary<string, DateTime>();
+        private readonly Dictionary<string, DateTime> _lastActivity = new Dictionary<string, DateTime>();
+
+        public RandomEventEngine(Func<string, Profile> getProfile, Action<string, Profile> setProfile, Random rng = null)
+        {
+            _getProfile = getProfile;
+            _setProfile = setProfile;
+            _rng = rng ?? new Random();
+        }
+
+        // ============================ Public entry points ============================
+
+        /// <summary>Record that a human posted in a channel (drives the activity gate).</summary>
+        public void RecordActivity(string channel, DateTime utcNow)
+        {
+            if (string.IsNullOrEmpty(channel)) return;
+            lock (_lock)
+            {
+                _lastActivity[Key(channel)] = utcNow;
+            }
+        }
+
+        /// <summary>
+        /// Handle one <c>!random</c> from a resident. Returns what (if anything) to PM the
+        /// responder and what (if anything) to announce publicly. An invalid response is nudged
+        /// but does NOT consume the resident's shot (owner-chosen default) — the anti-snipe
+        /// protection lives entirely in needing the right keyword/answer; a genuinely fast,
+        /// correct response is never penalized just for being quick.
+        /// </summary>
+        public RandomResponseResult HandleRandom(string channel, string userName, string arg, DateTime utcNow)
+        {
+            lock (_lock)
+            {
+                string key = Key(channel);
+                ActiveRandomEvent ae;
+                if (!_active.TryGetValue(key, out ae) || ae.Resolved)
+                    return RandomResponseResult.Reply(NoEventMessage);
+
+                // keyword / challenge validation; a wrong arg is nudged without consuming the shot.
+                if (!IsValidArg(ae, arg))
+                    return RandomResponseResult.Reply(WrongArgMessage(ae));
+
+                // One shot per resident per event.
+                if (ae.Responders.Any(r => string.Equals(r, userName, StringComparison.OrdinalIgnoreCase)))
+                    return RandomResponseResult.Reply(AlreadyRespondedMessage);
+
+                ae.Responders.Add(userName);
+
+                // firstValid resolves immediately on the first valid responder.
+                if (IsRule(ae, WinnerRuleFirstValid))
+                    return RandomResponseResult.Announce(ResolveLocked(key, ae, new List<string> { userName }));
+
+                // nth resolves as soon as the N-th valid responder arrives.
+                if (IsRule(ae, WinnerRuleNth) && ae.Responders.Count >= NthTarget(ae))
+                    return RandomResponseResult.Announce(ResolveLocked(key, ae, null));
+
+                // allInWindow / random / nth-not-yet: accept and wait for the window to close.
+                return RandomResponseResult.Reply(AcceptedWaitMessage);
+            }
+        }
+
+        /// <summary>
+        /// One scheduler heartbeat for a single eligible channel. Seeds the first fire time,
+        /// resolves an active event whose window has elapsed, and fires a new event when one is
+        /// due and the channel is active. Returns the channel messages to post (0-2). The event
+        /// list is loaded lazily so Mongo is only hit when an event is actually about to fire.
+        /// </summary>
+        public List<string> Tick(string channel, DateTime utcNow, Func<List<RandomEvent>> getEvents)
+        {
+            var output = new List<string>();
+            lock (_lock)
+            {
+                string key = Key(channel);
+                EnsureScheduledLocked(key, utcNow);
+
+                // Resolve / time out any active event whose window has elapsed.
+                ActiveRandomEvent ae;
+                if (_active.TryGetValue(key, out ae) && !ae.Resolved && utcNow >= ae.WindowEndUtc)
+                {
+                    if (IsRule(ae, WinnerRuleFirstValid) && ae.Responders.Count == 0)
+                    {
+                        // firstValid that nobody won in time: close it out (next fire was already
+                        // scheduled when this event fired).
+                        _active.Remove(key);
+                        output.Add(NoWinnerMessage(ae));
+                    }
+                    else
+                    {
+                        output.Add(ResolveLocked(key, ae, null));
+                    }
+                }
+
+                // Fire a new event if one is due, none is active, and the room is awake. The next
+                // fire is scheduled at fire time, so events stay 6-8h apart regardless of how long
+                // resolution takes.
+                if (!_active.ContainsKey(key) && IsFireDueLocked(key, utcNow))
+                {
+                    if (IsChannelActiveLocked(key, utcNow))
+                    {
+                        List<RandomEvent> events = getEvents != null ? getEvents() : null;
+                        ActiveRandomEvent fired = OpenEventLocked(key, channel, events, utcNow);
+                        RescheduleLocked(key, utcNow);
+                        if (fired != null)
+                            output.Add(fired.AnnounceText);
+                    }
+                    else
+                    {
+                        // Due, but the room is quiet: skip and reschedule (don't spam a dead room).
+                        RescheduleLocked(key, utcNow);
+                    }
+                }
+            }
+            return output;
+        }
+
+        // ============================ Test / inspection helpers ============================
+
+        public bool HasActiveEvent(string channel)
+        {
+            lock (_lock) { return _active.ContainsKey(Key(channel)); }
+        }
+
+        public ActiveRandomEvent PeekActiveEvent(string channel)
+        {
+            lock (_lock)
+            {
+                ActiveRandomEvent ae;
+                return _active.TryGetValue(Key(channel), out ae) ? ae : null;
+            }
+        }
+
+        /// <summary>
+        /// Test seam: open a specific event immediately, bypassing the weighted scheduler so a
+        /// test can exercise validation / winner / resolution paths deterministically. Not used in
+        /// production (the scheduler fires events via <see cref="Tick"/>).
+        /// </summary>
+        public ActiveRandomEvent ForceOpen(string channel, RandomEvent ev, DateTime utcNow)
+        {
+            lock (_lock)
+            {
+                return OpenEventLocked(Key(channel), channel, new List<RandomEvent> { ev }, utcNow);
+            }
+        }
+
+        // ============================ Resolution ============================
+
+        // Assumes the instance lock is held. Marks the event resolved, removes it from the active
+        // map, grants the rolled outcome's rewards to each winner, and returns the public
+        // announcement. The next fire was already scheduled when this event fired.
+        //
+        // Multi-winner support: the outcome's own resultText is expected to carry whatever
+        // flavor applies to every winner together (via the {winners} placeholder — e.g. "{winners}
+        // are now glowing purple."), rather than the engine bolting on a generic "joins in" line.
+        // Reward grants are still per-winner (magnitudes are re-rolled per person), but winners
+        // who end up with identical reward fragments are combined onto one line so identical
+        // grants read as one clean sentence instead of a repeated line per person.
+        private string ResolveLocked(string key, ActiveRandomEvent ae, List<string> winnersOverride)
+        {
+            ae.Resolved = true;
+            _active.Remove(key);
+
+            List<string> winners = winnersOverride ?? ResolveWinners(ae.Event.winnerRule, NthTarget(ae), ae.Responders, _rng);
+            if (winners == null || winners.Count == 0)
+                return NoWinnerMessage(ae);
+
+            EventOutcome outcome = SelectOutcome(ae.Event, _rng);
+
+            // Apply rewards per winner (each profile saved once) and collect their fragments.
+            var fragmentsByWinner = new Dictionary<string, List<string>>();
+            foreach (string winner in winners)
+            {
+                Profile p = _getProfile != null ? _getProfile(winner) : null;
+                var fragments = new List<string>();
+                if (p != null && outcome != null && outcome.rewards != null)
+                {
+                    foreach (EventReward reward in outcome.rewards)
+                    {
+                        string frag = ApplyEventReward(p, reward, _rng);
+                        if (!string.IsNullOrEmpty(frag))
+                            fragments.Add(frag);
+                    }
+                    if (_setProfile != null)
+                        _setProfile(winner, p);
+                }
+                fragmentsByWinner[winner] = fragments;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            string header = outcome != null ? SubstituteWinners(outcome.resultText, winners) : null;
+            if (!string.IsNullOrEmpty(header))
+                sb.Append(header);
+
+            // Group winners with identical reward fragments (in first-seen order) into one line
+            // each. A winner with no reward at all gets no line — the header already covers the
+            // flavor for everyone via {winners}.
+            var groups = new List<WinnerGroup>();
+            foreach (string winner in winners)
+            {
+                List<string> fragments = fragmentsByWinner[winner];
+                if (fragments.Count == 0) continue;
+
+                WinnerGroup existing = groups.FirstOrDefault(g => g.Fragments.SequenceEqual(fragments));
+                if (existing != null)
+                    existing.Names.Add(winner);
+                else
+                    groups.Add(new WinnerGroup { Fragments = fragments, Names = new List<string> { winner } });
+            }
+
+            foreach (WinnerGroup group in groups)
+            {
+                List<string> tags = group.Names.Select(n => "[user]" + n + "[/user]").ToList();
+                string verb = tags.Count > 1 ? " receive " : " receives ";
+                if (sb.Length > 0) sb.Append("\n");
+                sb.Append(JoinWithAnd(tags) + verb + JoinWithAnd(group.Fragments) + "!");
+            }
+
+            return sb.ToString();
+        }
+
+        private class WinnerGroup
+        {
+            public List<string> Fragments;
+            public List<string> Names;
+        }
+
+        // ============================ Firing / materialization ============================
+
+        // Assumes the instance lock is held. Picks an event by weight, materializes the
+        // per-fire anti-snipe state, stores it active, and returns it (null if no events).
+        private ActiveRandomEvent OpenEventLocked(string key, string channel, List<RandomEvent> events, DateTime utcNow)
+        {
+            RandomEvent chosen = SelectByWeight(events, _rng);
+            if (chosen == null) return null;
+
+            int windowSeconds = chosen.responseWindowSeconds > 0 ? chosen.responseWindowSeconds : DefaultResponseWindowSeconds;
+            var ae = new ActiveRandomEvent
+            {
+                Event = chosen,
+                Channel = channel,
+                FiredAtUtc = utcNow,
+                WindowEndUtc = utcNow.AddSeconds(windowSeconds),
+            };
+
+            string announce = chosen.announceText ?? "";
+            string type = (chosen.responseType ?? ResponseTypeNone).ToLowerInvariant();
+            switch (type)
+            {
+                case ResponseTypeKeyword:
+                    ae.Keyword = KeywordPool[_rng.Next(KeywordPool.Length)];
+                    announce = Substitute(announce, ae.Keyword, "", windowSeconds);
+                    if (!announce.Contains(ae.Keyword))
+                        announce += "\n[sub]Quick, [b]!random " + ae.Keyword + "[/b] to take part![/sub]";
+                    break;
+                case ResponseTypeChallenge:
+                    string problem;
+                    GenerateChallenge(_rng, out problem, out string answer);
+                    ae.ChallengeAnswer = answer;
+                    announce = Substitute(announce, "", problem, windowSeconds);
+                    if (!announce.Contains(problem))
+                        announce += "\n[sub]Quick, [b]!random " + problem + " = ?[/b] to take part![/sub]";
+                    break;
+                default:
+                    announce = Substitute(announce, "", "", windowSeconds);
+                    break;
+            }
+
+            ae.AnnounceText = announce;
+            _active[key] = ae;
+            return ae;
+        }
+
+        // ============================ Scheduling (lock-held) ============================
+
+        private void EnsureScheduledLocked(string key, DateTime utcNow)
+        {
+            if (!_nextFire.ContainsKey(key))
+                _nextFire[key] = utcNow.Add(RandomInterval());
+        }
+
+        private void RescheduleLocked(string key, DateTime utcNow)
+        {
+            _nextFire[key] = utcNow.Add(RandomInterval());
+        }
+
+        private bool IsFireDueLocked(string key, DateTime utcNow)
+        {
+            DateTime when;
+            return _nextFire.TryGetValue(key, out when) && utcNow >= when;
+        }
+
+        private bool IsChannelActiveLocked(string key, DateTime utcNow)
+        {
+            DateTime when;
+            return _lastActivity.TryGetValue(key, out when)
+                && (utcNow - when) <= TimeSpan.FromMinutes(ActivityWindowMinutes);
+        }
+
+        private TimeSpan RandomInterval()
+        {
+            double hours = IntervalMinHours + _rng.NextDouble() * (IntervalMaxHours - IntervalMinHours);
+            return TimeSpan.FromHours(hours);
+        }
+
+        // ============================ Pure helpers (unit-tested directly) ============================
+
+        /// <summary>Weighted pick over candidate events; null if the list is empty.</summary>
+        public static RandomEvent SelectByWeight(List<RandomEvent> events, Random rng)
+        {
+            if (events == null || events.Count == 0) return null;
+            if (events.Count == 1) return events[0];
+
+            int total = events.Sum(e => Math.Max(0, e.weight));
+            if (total <= 0) return events[rng.Next(events.Count)]; // all weightless => uniform
+
+            int pick = rng.Next(0, total);
+            foreach (RandomEvent e in events)
+            {
+                pick -= Math.Max(0, e.weight);
+                if (pick < 0) return e;
+            }
+            return events[events.Count - 1];
+        }
+
+        /// <summary>Weighted pick over an event's outcomes; null if it has none.</summary>
+        public static EventOutcome SelectOutcome(RandomEvent ev, Random rng)
+        {
+            if (ev == null || ev.outcomes == null || ev.outcomes.Count == 0) return null;
+            if (ev.outcomes.Count == 1) return ev.outcomes[0];
+
+            int total = ev.outcomes.Sum(o => Math.Max(0, o.weight));
+            if (total <= 0) return ev.outcomes[rng.Next(ev.outcomes.Count)];
+
+            int pick = rng.Next(0, total);
+            foreach (EventOutcome o in ev.outcomes)
+            {
+                pick -= Math.Max(0, o.weight);
+                if (pick < 0) return o;
+            }
+            return ev.outcomes[ev.outcomes.Count - 1];
+        }
+
+        /// <summary>
+        /// Resolve the winner list from the collected (ordered, deduped) responders per the rule.
+        /// Pure — used by both the immediate firstValid path and the window-close path.
+        /// </summary>
+        public static List<string> ResolveWinners(string winnerRule, int nthTarget, List<string> responders, Random rng)
+        {
+            var empty = new List<string>();
+            if (responders == null || responders.Count == 0) return empty;
+
+            string rule = (winnerRule ?? WinnerRuleFirstValid).ToLowerInvariant();
+            switch (rule)
+            {
+                case "allinwindow":
+                    return new List<string>(responders);
+                case "nth":
+                    int n = Math.Max(1, nthTarget);
+                    return responders.Count >= n ? new List<string> { responders[n - 1] } : empty;
+                case "random":
+                    return new List<string> { responders[rng.Next(responders.Count)] };
+                case "firstvalid":
+                default:
+                    return new List<string> { responders[0] };
+            }
+        }
+
+        /// <summary>Inclusive roll in [min, max]; tolerant of an inverted or degenerate range.</summary>
+        public static int RollAmount(int min, int max, Random rng)
+        {
+            if (max < min) { int t = min; min = max; max = t; }
+            if (max == min) return min;
+            return rng.Next(min, max + 1); // +1: Random.Next upper bound is exclusive
+        }
+
+        /// <summary>
+        /// Apply one reward to a profile in place and return a short human fragment describing it
+        /// (or "" when nothing was granted — e.g. a maxed training, an unknown curse, or "none").
+        /// Each branch reuses the same store the corresponding interaction writes to; corruption
+        /// and curse are system-granted here, intentionally bypassing the consent flow (the player
+        /// opted in by responding). Pure save-free: the caller persists the profile once after all
+        /// rewards apply.
+        /// </summary>
+        public static string ApplyEventReward(Profile profile, EventReward reward, Random rng)
+        {
+            if (profile == null || reward == null) return "";
+            string type = (reward.type ?? ResponseTypeNone).ToLowerInvariant();
+            int amount = RollAmount(reward.min, reward.max, rng);
+
+            switch (type)
+            {
+                case "currency":
+                    if (string.IsNullOrEmpty(reward.key) || amount <= 0) return "";
+                    if (profile.currencies == null) profile.currencies = new Dictionary<string, int>();
+                    if (profile.currencies.ContainsKey(reward.key)) profile.currencies[reward.key] += amount;
+                    else profile.currencies[reward.key] = amount;
+                    return "[b]" + amount + " " + reward.key + "[/b]";
+
+                case "title":
+                    if (string.IsNullOrEmpty(reward.key)) return "";
+                    if (profile.titles == null) profile.titles = new List<Title>();
+                    bool alreadyHas = profile.titles.Any(t =>
+                        t.IsSystemTitle && string.Equals(t.titleText, reward.key, StringComparison.OrdinalIgnoreCase));
+                    if (alreadyHas) return "";
+                    profile.titles.Add(new Title { titleText = reward.key, givenBy = "Chateau", grantedTime = DateTime.UtcNow });
+                    return "the title ·" + reward.key + "·";
+
+                case "training":
+                    if (string.IsNullOrEmpty(reward.key) || amount <= 0) return "";
+                    if (profile.trainings == null) profile.trainings = new Dictionary<string, int>();
+                    int current = profile.trainings.ContainsKey(reward.key) ? profile.trainings[reward.key] : 0;
+                    int capped = Math.Min(TrainProcessor.LevelCap, Math.Max(0, current + amount));
+                    int gained = capped - current;
+                    profile.trainings[reward.key] = capped;
+                    if (gained <= 0) return "";
+                    return "[b]" + gained + "[/b] " + reward.key + " training";
+
+                case "corruption":
+                    // Negative on the signed axis = corruption (see CorruptionProcessor).
+                    if (amount <= 0) return "";
+                    WriteCorruption(profile, CorruptionProcessor.ReadCorruption(profile) - amount);
+                    return "[b]" + amount + "[/b] corruption";
+
+                case "purity":
+                    // Positive on the signed axis = purity.
+                    if (amount <= 0) return "";
+                    WriteCorruption(profile, CorruptionProcessor.ReadCorruption(profile) + amount);
+                    return "[b]" + amount + "[/b] purity";
+
+                case "curse":
+                    if (string.IsNullOrEmpty(reward.key) || !CurseProcessor.CatalogMap.ContainsKey(reward.key)) return "";
+                    List<CurseInstance> curses = CurseInstance.LoadAll(profile);
+                    if (curses.Any(c => string.Equals(c.Curse, reward.key, StringComparison.OrdinalIgnoreCase))) return "";
+                    curses.Add(new CurseInstance { Curse = reward.key, AppliedBy = "Chateau", AppliedAt = DateTime.UtcNow });
+                    CurseInstance.SaveAll(profile, curses);
+                    return "the [b]" + reward.key + "[/b] curse";
+
+                default: // "none" and anything unrecognized: flavor only, no write.
+                    return "";
+            }
+        }
+
+        public bool IsValidArg(ActiveRandomEvent ae, string arg)
+        {
+            if (ae == null) return false;
+            string type = (ae.Event.responseType ?? ResponseTypeNone).ToLowerInvariant();
+            string trimmed = (arg ?? "").Trim();
+            switch (type)
+            {
+                case ResponseTypeKeyword:
+                    return string.Equals(trimmed, ae.Keyword, StringComparison.OrdinalIgnoreCase);
+                case ResponseTypeChallenge:
+                    return string.Equals(trimmed, ae.ChallengeAnswer, StringComparison.OrdinalIgnoreCase);
+                default: // "none" ignores the arg entirely
+                    return true;
+            }
+        }
+
+        // ============================ Small private helpers ============================
+
+        private static void WriteCorruption(Profile profile, int value)
+        {
+            if (profile.characteristics == null) profile.characteristics = new Dictionary<string, string>();
+            profile.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = value.ToString();
+        }
+
+        private static void GenerateChallenge(Random rng, out string problem, out string answer)
+        {
+            int a = rng.Next(2, 10);
+            int b = rng.Next(2, 10);
+            problem = a + " + " + b;
+            answer = (a + b).ToString();
+        }
+
+        private static string Substitute(string template, string keyword, string challenge, int windowSeconds)
+        {
+            if (string.IsNullOrEmpty(template)) return template ?? "";
+            return template
+                .Replace("{keyword}", keyword ?? "")
+                .Replace("{challenge}", challenge ?? "")
+                .Replace("{window}", windowSeconds.ToString())
+                .Replace("{seconds}", windowSeconds.ToString());
+        }
+
+        private static string JoinWithAnd(List<string> parts)
+        {
+            if (parts == null || parts.Count == 0) return "";
+            if (parts.Count == 1) return parts[0];
+            if (parts.Count == 2) return parts[0] + " and " + parts[1];
+            return string.Join(", ", parts.Take(parts.Count - 1)) + " and " + parts[parts.Count - 1];
+        }
+
+        // Lets an outcome's resultText address every winner by name via a {winners} placeholder
+        // (e.g. "{winners} are now glowing purple.") so multi-person flavor is authored per-event
+        // rather than invented generically by the engine. A no-op when the placeholder is absent.
+        private static string SubstituteWinners(string template, List<string> winners)
+        {
+            if (string.IsNullOrEmpty(template)) return template ?? "";
+            if (!template.Contains("{winners}")) return template;
+            List<string> tags = winners.Select(w => "[user]" + w + "[/user]").ToList();
+            return template.Replace("{winners}", JoinWithAnd(tags));
+        }
+
+        private static bool IsRule(ActiveRandomEvent ae, string rule)
+        {
+            return string.Equals(ae.Event.winnerRule, rule, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int NthTarget(ActiveRandomEvent ae)
+        {
+            return Math.Max(1, ae.Event.winnerN);
+        }
+
+        private static string Key(string channel)
+        {
+            return (channel ?? "").ToLowerInvariant();
+        }
+
+        // ============================ Framework user-facing strings (owner review) ============================
+
+        public const string NoEventMessage =
+            "There's no random event for you to respond to right now. When there is, everyone will be explicitly prompted.";
+        public const string AlreadyRespondedMessage =
+            "You can't participate twice! Wait for next event.";
+        public const string AcceptedWaitMessage =
+            "You're in! We'll announce the results once everyone has had some time to join.";
+
+        public static string WrongArgMessage(ActiveRandomEvent ae)
+        {
+            string type = (ae?.Event?.responseType ?? "").ToLowerInvariant();
+            if (type == ResponseTypeChallenge)
+                return "That's not quite the answer this one's looking for. Give it another read and try again!";
+            return "That's not the word this one's looking for. Try again!";
+        }
+
+        public static string NoWinnerMessage(ActiveRandomEvent ae)
+        {
+            return "Time's up for now. Until next time~";
+        }
+    }
+
+    /// <summary>One in-flight event in a channel. In-memory only; never persisted.</summary>
+    public class ActiveRandomEvent
+    {
+        public RandomEvent Event;
+        public string Channel;
+        public DateTime FiredAtUtc;
+        public DateTime WindowEndUtc;
+        public string AnnounceText;          // fully materialized announce string (placeholders resolved)
+        public string Keyword;               // required token for the "keyword" type
+        public string ChallengeAnswer;       // expected answer for the "challenge" type
+        public List<string> Responders = new List<string>(); // valid responders, in order, deduped
+        public bool Resolved;
+    }
+
+    /// <summary>
+    /// The result of one <c>!random</c>: an optional private reply to the responder and an optional
+    /// public channel announcement. The command sends whichever are non-empty.
+    /// </summary>
+    public class RandomResponseResult
+    {
+        public string ReplyToUser;
+        public string ChannelAnnouncement;
+
+        public static RandomResponseResult Reply(string message)
+        {
+            return new RandomResponseResult { ReplyToUser = message };
+        }
+
+        public static RandomResponseResult Announce(string message)
+        {
+            return new RandomResponseResult { ChannelAnnouncement = message };
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/UpdateSetting.cs
+++ b/FChatDicebot/BotCommands/UpdateSetting.cs
@@ -91,6 +91,8 @@ namespace FChatDicebot.BotCommands
                     changed = SettingType.CommandPrefix;
                 if (terms.Contains("allowwork"))
                     changed = SettingType.AllowWork;
+                if (terms.Contains("allowrandomevents"))
+                    changed = SettingType.AllowRandomEvents;
                 if (terms.Contains("workmultiplier"))
                     changed = SettingType.WorkMultiplier;
                 if (terms.Contains("worktierrange"))
@@ -309,6 +311,9 @@ namespace FChatDicebot.BotCommands
                         }
                     }
                     break;
+                case SettingType.AllowRandomEvents:
+                    thisChannel.AllowRandomEvents = setValue;
+                    break;
                 case SettingType.WorkMultiplier:
                     if (setNumber < 0)
                         setNumber = 0;
@@ -518,6 +523,7 @@ namespace FChatDicebot.BotCommands
         SlotsMultiplierLimit,
         StartingChips,
         AllowWork,
+        AllowRandomEvents,
         WorkMultiplier,
         WorkTierRange,
         WorkBaseAmount,

--- a/FChatDicebot/BotCommands/ViewSettings.cs
+++ b/FChatDicebot/BotCommands/ViewSettings.cs
@@ -40,11 +40,11 @@ namespace FChatDicebot.BotCommands
                 thisChannel.AllowGames, thisChannel.AllowSettingChannelDescription, "", "", thisChannel.AllowChess, thisChannel.AllowChessEicons, thisChannel.CommandPrefix.ToString(), thisChannel.SinglePlayerGameCooldownSeconds,
                 thisChannel.CardPrintSetting != null && thisChannel.CardPrintSetting.FourColorPlayingCards, thisChannel.CardPrintSetting != null && thisChannel.CardPrintSetting.SortCards, thisChannel.CardPrintSetting != null && thisChannel.CardPrintSetting.TarotIcons, thisChannel.CardPrintSetting != null && thisChannel.CardPrintSetting.UsePlayingCardEmotes, thisChannel.UseDefaultPotions, thisChannel.PotionChipsCost, thisChannel.PotionCommandsAlias
                 );
-            string settingsPart1b = string.Format("[b]AllowWork:[/b] {0}, [b]WorkMultiplier:[/b] {1}, [b]WorkTierRange:[/b] {2}, [b]WorkBaseAmount:[/b] {3}, [b]WorkCommandAlias:[/b] {4}{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}{16}{17}{18}{19}\n" +
+            string settingsPart1b = string.Format("[b]AllowWork:[/b] {0}, [b]WorkMultiplier:[/b] {1}, [b]WorkTierRange:[/b] {2}, [b]WorkBaseAmount:[/b] {3}, [b]WorkCommandAlias:[/b] {4}, [b]AllowRandomEvents:[/b] {5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}{16}{17}{18}{19}\n" +
                 "[b]OnlyOpViewOthersChips:[/b] {20}, [b]SlotsCooldownSeconds:[/b] {21}, [b]WorkCooldownSeconds:[/b] {22}, [b]ShowSpoilerSlots:[/b] {23}, [b]SpoilerAllOutputs:[/b] {24}, [b]DungeonDelveCooldownSeconds:[/b] {25}{26}{27}{28}{29}\n" +
                 "[b]AllowNsfw:[/b] {30}, [b]AllowRpg:[/b] {31}, [b]ShowCommasInNumbers:[/b] {32}, [b]CurrencyName:[/b] {33}, [b]CurrencyNamePlural:[/b] {34}{35}{36}\n"
                 ,
-                thisChannel.AllowWork, thisChannel.WorkMultiplier, thisChannel.WorkTierRange, thisChannel.WorkBaseAmount, string.IsNullOrEmpty(thisChannel.WorkCommandAlias) ? "(null)" : thisChannel.WorkCommandAlias, "","", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                thisChannel.AllowWork, thisChannel.WorkMultiplier, thisChannel.WorkTierRange, thisChannel.WorkBaseAmount, string.IsNullOrEmpty(thisChannel.WorkCommandAlias) ? "(null)" : thisChannel.WorkCommandAlias, thisChannel.AllowRandomEvents,"", "", "", "", "", "", "", "", "", "", "", "", "", "",
                 thisChannel.OnlyOpViewOthersChips, thisChannel.SlotsCooldownSeconds, thisChannel.WorkCooldownSeconds, thisChannel.ShowSpoilerSlots, thisChannel.SpoilerAllOutputs, thisChannel.DungeonDelveCooldownSeconds, "","","","",
                 thisChannel.AllowNsfw, thisChannel.AllowRPG, thisChannel.ShowCommasInNumbers, thisChannel.CurrencyName, thisChannel.CurrencyNamePlural, "", ""
                 );

--- a/FChatDicebot/BotMain.cs
+++ b/FChatDicebot/BotMain.cs
@@ -87,6 +87,9 @@ namespace FChatDicebot
         public List<BotFutureMessage> FutureMessages;
         public BotCommandController BotCommandController;
         public DiceBot DiceBot;
+        // Ambient "random events" scheduler/resolver (B12). In-memory per-channel state; created
+        // in Run() once the database is initialized. Profile reads/writes go through MonDB.
+        public BotCommands.Support.RandomEventEngine RandomEventEngine;
         public AccountSettings AccountSettings;
         public List<SavedRollTable> SavedTables;
         public List<SavedSlotsSetting> SavedSlots;
@@ -137,6 +140,9 @@ namespace FChatDicebot
         public int ReconnectTimer = 0;
         public const double CheckinIntervalSeconds = 20;
         public const double ChannelOpsRefreshSeconds = 60 * 60;
+        // How often the random-events scheduler scans eligible channels (seconds). Events are
+        // hours apart, so a coarse scan is plenty and keeps the 200ms tick loop cheap.
+        public const double RandomEventScanIntervalSeconds = 10;
         public List<string> ChannelsJoined = new List<string>();
         public List<UserGeneratedCommand> WaitingChannelOpRequests = new List<UserGeneratedCommand>();
         public List<BuyCommand> WaitingBuyCommands = new List<BuyCommand>();
@@ -182,6 +188,7 @@ namespace FChatDicebot
             WebRequests = new BotWebRequests();
             _discordUsers = new List<SocketUser>();
             DiceBot = new DiceFunctions.DiceBot(this);
+            RandomEventEngine = new BotCommands.Support.RandomEventEngine(MonDB.getProfile, MonDB.setProfile);
             VelvetcuffConnection = new FChatDicebot.VelvetcuffConnection(WebRequests, AccountSettings);
 
             if(RunMode == RunMode.FListOnly || RunMode == RunMode.FlistPlusDiscord)
@@ -644,6 +651,7 @@ namespace FChatDicebot
                         }
                     }
                     HandleFutureMessagesTick(TickTimeMiliseconds);
+                    HandleRandomEventsTick(TickTimeMiliseconds);
 
                     Thread.Sleep(TickTimeMiliseconds);
                 }
@@ -993,6 +1001,46 @@ namespace FChatDicebot
             }
         }
 
+        // Heartbeat for the ambient random-events scheduler (B12), sibling to
+        // HandleFutureMessagesTick. The per-channel scan is throttled to RandomEventScanIntervalSeconds
+        // so we don't hammer the loop or Mongo: most ticks do nothing, and the event list is only
+        // loaded when an event is actually about to fire. Only opted-in, currently-joined channels
+        // are eligible. Wrapped per-channel so one bad channel can't abort the others.
+        private double _lastRandomEventScanSeconds = 0;
+        private void HandleRandomEventsTick(int tickMs)
+        {
+            if (RandomEventEngine == null || SavedChannelSettings == null)
+                return;
+
+            double nowSeconds = DoubleTime.GetCurrentTimestampSeconds();
+            if (nowSeconds - _lastRandomEventScanSeconds < RandomEventScanIntervalSeconds)
+                return;
+            _lastRandomEventScanSeconds = nowSeconds;
+
+            DateTime utcNow = DateTime.UtcNow;
+            List<ChannelSettings> eligible = SavedChannelSettings
+                .Where(cs => cs != null && cs.AllowRandomEvents && ChannelsJoined != null && ChannelsJoined.Contains(cs.Name))
+                .ToList();
+
+            foreach (ChannelSettings cs in eligible)
+            {
+                try
+                {
+                    List<string> messages = RandomEventEngine.Tick(cs.Name, utcNow, () => MonDB.getRandomEvents());
+                    foreach (string m in messages)
+                    {
+                        if (!string.IsNullOrEmpty(m))
+                            SendMessageInChannel(m, cs.Name);
+                    }
+                }
+                catch (Exception exc)
+                {
+                    Console.WriteLine("Exception in HandleRandomEventsTick for " + cs.Name + ": " + exc.ToString());
+                    Utils.AddToLog("Exception in HandleRandomEventsTick for " + cs.Name + ": " + exc.ToString(), null);
+                }
+            }
+        }
+
         private void PerformStartupClientCommands(WebSocket sock, BotMessage firstIdnRequest, bool reconnect)
         {
             if (firstIdnRequest == null)
@@ -1293,6 +1341,16 @@ namespace FChatDicebot
                 prefixChar = channelSettings.CommandPrefix.ToString();
             }
             string[] channelOps = channelSettings != null ? channelSettings.GetChannelOps() : null;
+
+            // Activity gate for ambient random events (B12): any human message in a channel keeps
+            // it "awake" so the scheduler only fires into rooms with live chatter. The bot's own
+            // posts are excluded so they can't keep a dead room artificially alive.
+            if (RandomEventEngine != null
+                && BotCommandController.MessageCameFromChannel(newAddress)
+                && (AccountSettings == null || !string.Equals(messageContent.character, AccountSettings.CharacterName, StringComparison.OrdinalIgnoreCase)))
+            {
+                RandomEventEngine.RecordActivity(messageContent.channel, DateTime.UtcNow);
+            }
 
             if (string.IsNullOrEmpty(messageContent.message))
             {

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -593,6 +593,24 @@ namespace FChatDicebot.Database
             collection.DeleteOne(filter);
         }
 
+        // Random Event Operations (read-only in-bot; seeded externally like Duties)
+        public List<RandomEvent> GetRandomEvents()
+        {
+            var collection = Database.GetCollection<BsonDocument>("RandomEvents");
+            var documents = collection.Find(Builders<BsonDocument>.Filter.Empty).ToList();
+
+            return documents.Select(doc => BsonSerializer.Deserialize<RandomEvent>(doc)).ToList();
+        }
+
+        public List<RandomEvent> GetRandomEventsByCategory(string category)
+        {
+            var collection = Database.GetCollection<BsonDocument>("RandomEvents");
+            var filter = Builders<BsonDocument>.Filter.AnyEq("categories", category);
+            var documents = collection.Find(filter).ToList();
+
+            return documents.Select(doc => BsonSerializer.Deserialize<RandomEvent>(doc)).ToList();
+        }
+
         // Command Operations
         public Command GetCommand(string commandName)
         {

--- a/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/Database/Ichateaudatabase.cs
@@ -67,6 +67,10 @@ namespace FChatDicebot.Database
         void SetPendingDuty(PendingDuty updatedDuty);
         void DeletePendingDuty(ObjectId dutyId);
 
+        // Random Event Operations (read-only in-bot; seeded externally like Duties)
+        List<RandomEvent> GetRandomEvents();
+        List<RandomEvent> GetRandomEventsByCategory(string category);
+
         // Command Operations
         Command GetCommand(string commandName);
         List<Command> GetAllCommands();

--- a/FChatDicebot/FChatDicebot.csproj
+++ b/FChatDicebot/FChatDicebot.csproj
@@ -233,6 +233,8 @@
     <Compile Include="BotCommands\ChateauEconomics.cs" />
     <Compile Include="BotCommands\Support\ChateauStatisticsSupport.cs" />
     <Compile Include="BotCommands\Support\BondTreeSupport.cs" />
+    <Compile Include="BotCommands\Support\RandomEventEngine.cs" />
+    <Compile Include="BotCommands\ChateauRandom.cs" />
     <Compile Include="BotCommands\Support\CasualGroupCommandSupport.cs" />
     <Compile Include="BotCommands\ChateauBondtree.cs" />
     <Compile Include="BotCommands\ChateauFamilytree.cs" />

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -277,6 +277,50 @@ namespace FChatDicebot.Model
         public int value { get; set; }
     }
 
+    /// <summary>
+    /// A seeded, data-authored ambient channel event (the B12 "random events" system). Lives in
+    /// the read-only <c>RandomEvents</c> collection and mirrors the <see cref="Duty"/> /
+    /// <see cref="DutyResult"/> / <see cref="Reward"/> authoring shape so new events ship without
+    /// a deploy. The bot fires one of these into an opted-in channel every several hours; residents
+    /// join with <c>!random</c>; after the response window resolves, the bot announces the chosen
+    /// outcome and grants its rewards to the winner(s). See
+    /// <c>BotCommands.Support.RandomEventEngine</c> for selection/validation/resolution.
+    /// </summary>
+    public class RandomEvent
+    {
+        [BsonId]
+        [BsonRepresentation(BsonType.ObjectId)]
+        public ObjectId Id { get; set; }
+        public string label { get; set; }
+        public string[] categories { get; set; }
+        public int weight { get; set; }                // selection weight among eligible events
+        public string announceText { get; set; }       // posted to the channel when the event fires
+        public string responseType { get; set; }       // "none" | "keyword" | "challenge"
+        public int responseWindowSeconds { get; set; } // how long !random is accepted (0 => engine default)
+        public string winnerRule { get; set; }         // "firstValid" | "allInWindow" | "nth" | "random"
+        public int winnerN { get; set; }               // for "nth": which valid responder wins (1-based)
+        public List<EventOutcome> outcomes { get; set; } = new List<EventOutcome>(); // weighted roll on resolve
+    }
+
+    public class EventOutcome
+    {
+        public int weight { get; set; }        // weighted pick among the event's outcomes
+        // Announced when this outcome is granted. May include a {winners} placeholder (e.g.
+        // "{winners} are now glowing purple.") substituted with every winner's [user] tag —
+        // lets a multi-winner outcome (allInWindow/etc.) carry its own combined flavor instead
+        // of a generic engine-authored line.
+        public string resultText { get; set; }
+        public List<EventReward> rewards { get; set; } = new List<EventReward>(); // applied to winner(s)
+    }
+
+    public class EventReward
+    {
+        public string type { get; set; } // "currency" | "title" | "training" | "corruption" | "purity" | "curse" | "none"
+        public string key { get; set; }  // currency name / title text / training skill / curse id (unused for corruption/purity/none)
+        public int min { get; set; }     // magnitude/amount low  (currency, training, corruption, purity)
+        public int max { get; set; }     // magnitude/amount high
+    }
+
     public class Pledge
     {
         [BsonId]

--- a/FChatDicebot/MonDB.cs
+++ b/FChatDicebot/MonDB.cs
@@ -140,6 +140,16 @@ namespace FChatDicebot
             return GetDatabase().GetDutiesByCategory(category);
         }
 
+        internal static List<RandomEvent> getRandomEvents()
+        {
+            return GetDatabase().GetRandomEvents();
+        }
+
+        internal static List<RandomEvent> getRandomEventsByCategory(string category)
+        {
+            return GetDatabase().GetRandomEventsByCategory(category);
+        }
+
         internal static List<Identifier> getIdentifiers(string category)
         {
             return GetDatabase().GetIdentifiersByCategory(category);

--- a/FChatDicebot/SavedData/ChannelSettings.cs
+++ b/FChatDicebot/SavedData/ChannelSettings.cs
@@ -38,6 +38,9 @@ namespace FChatDicebot.SavedData
         public bool UseVcAccountForChips;
         public bool StartupChannel;
         public bool AllowWork;
+        // Opt-in for ambient random events (B12). Default false; the scheduler only fires into
+        // joined channels that have this enabled.
+        public bool AllowRandomEvents;
         public int WorkMultiplier;
         public int WorkTierRange;
         public int WorkBaseAmount;

--- a/wiki-docs/Feature-Requests.md
+++ b/wiki-docs/Feature-Requests.md
@@ -7,6 +7,6 @@ Features and changes, big and small, that have been proposed but not thoroughly 
 * !cancel and !decline (initiator and recipient geared 'remove pending interaction' commands) on top of existing time out parameters.
 * additional casual commands. lapsit, boobhat, lick, possibly more. Will it take up too much dossier space? Do they have reasonable titles to accrue?
 * Some way to resurface chips, poker, other games from the underlying dicebot functionality (currently, Chateau Work has overwritten the dicebot work). Save this for after original dice bot developer pushes their most recent dicebot changes to Git, for ease of merging
-* Random events, to encourage spontaneous chat activity. Responding to a random event would always start !random but might also require an additional argument, to slow down campers/snipers
 * Audit existing commands for sensible new aliases (and check for collisions before adding any). Surfaced while speccing !refuse/!withdraw, whose short aliases !r and !w need a collision check against the live command table.
+* Author more !random events (see `wiki-docs/specs/Future-Social/Random-Events.md`). The engine/scheduler shipped 2026-06-29 but only one starter event ("Cutie says {word}") exists in the `RandomEvents` collection so far — needs a real pool (varied response types, winner rules, and reward types) so the ambient events don't feel repetitive.
 

--- a/wiki-docs/specs/Future-Social/Random-Events.md
+++ b/wiki-docs/specs/Future-Social/Random-Events.md
@@ -1,7 +1,9 @@
 # Random Events — ambient channel events + `!random`
 
-**Status:** Proposed (design-complete, owner-reviewed 2026-06-21).
+**Status:** ✅ SHIPPED 2026-06-29, wording pass + design tweak 2026-07-01 (owner review). Per-event `announceText` / `resultText` and reward magnitudes are authored data in the seeded `RandomEvents` collection; a single starter event ("Cutie says {word}") has been authored — see *Seed data* below.
 **Feature-Requests source:** "Random events, to encourage spontaneous chat activity. Responding to a random event would always start !random but might also require an additional argument, to slow down campers/snipers" (B12).
+
+> **Note on paths:** this spec was written before the latest Dice Bot integration flattened `FChatDicebot/FChatDicebot/…` to `FChatDicebot/…`. The links below predate that move; the as-built files are: model in [Model/ChateauDB.cs](../../../FChatDicebot/Model/ChateauDB.cs), engine in [BotCommands/Support/RandomEventEngine.cs](../../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs), command in [BotCommands/ChateauRandom.cs](../../../FChatDicebot/BotCommands/ChateauRandom.cs), scheduler in [BotMain.cs](../../../FChatDicebot/BotMain.cs) (`HandleRandomEventsTick`), DB in [Database/Chateaudatabase.cs](../../../FChatDicebot/Database/Chateaudatabase.cs), tests in `FChatDicebot.Tests/Unit/Randomeventenginetests.cs`. Discord is intentionally excluded — the tick is wired into `RunLoopFList` only (the deployment is F-Chat / Chateau-only).
 
 > This is the largest of the Social/events specs. It has three buildable chunks that can land incrementally: **(1)** the event data model + seeded collection, **(2)** the `!random` participation command + active-event lifecycle, **(3)** the tick-driven scheduler. The bulk of the work is wiring the **six reward types** to existing grant mechanisms (below).
 
@@ -31,7 +33,7 @@ public class RandomEvent
     public string[] categories { get; set; }
     public int weight { get; set; }              // selection weight among eligible events
     public string announceText { get; set; }      // posted to the channel when the event fires
-    public string responseType { get; set; }      // "none" | "keyword" | "challenge" | "delay"
+    public string responseType { get; set; }      // "none" | "keyword" | "challenge"
     public int responseWindowSeconds { get; set; } // how long !random is accepted (e.g. 60)
     public string winnerRule { get; set; }         // "firstValid" | "allInWindow" | "nth" | "random"
     public int winnerN { get; set; }               // for "nth": which responder wins (e.g. 4)
@@ -41,7 +43,7 @@ public class RandomEvent
 public class EventOutcome
 {
     public int weight { get; set; }       // weighted pick among the event's outcomes
-    public string resultText { get; set; } // announced when this outcome is granted
+    public string resultText { get; set; } // announced when this outcome is granted; may use {winners}
     public List<EventReward> rewards { get; set; } = new List<EventReward>(); // applied to winner(s)
 }
 
@@ -57,8 +59,11 @@ public class EventReward
 **Response types (B12.3 — "depends on the event, could be any of the three"):**
 - `none` — `!random` with no arg participates.
 - `keyword` — `announceText` instructs the user to include a token; only `!random <token>` (matched case-insensitively) counts. The token is chosen per-fire (so it can be randomized) and held in the active-event state. Defeats pre-typed snipes.
-- `challenge` — a tiny generated problem (e.g. a small sum or a die to "roll"); the user submits the answer as the arg. Generated per-fire; expected answer held in active-event state.
-- `delay` — `!random` with no arg, but responses are only accepted after a randomized minimum delay from the fire (held in active-event state); earlier `!random`s are ignored (silently or with a "too eager" nudge), slowing campers.
+- `challenge` — a tiny generated problem (e.g. a small sum); the user submits the answer as the arg. Generated per-fire; expected answer held in active-event state.
+
+> **As-built design change (owner, 2026-07-01): the third response type ("delay" — reject responses before a randomized minimum time after the fire) was dropped.** The anti-snipe protection is entirely the keyword/challenge itself — you can't pre-type an answer you don't yet know. A pure time-gate would instead penalize residents who genuinely react fast and correctly, which isn't the goal. So `responseType` is now exactly `none` | `keyword` | `challenge`, and an invalid response is always just nudged (never time-gated) with no attempt consumed.
+
+> **As-built authoring note — `announceText` placeholders.** Because the keyword/challenge are randomized per-fire, the engine substitutes them into `announceText` at fire time: `{keyword}` → the chosen token, `{challenge}` → the generated problem (e.g. `3 + 7`), `{window}`/`{seconds}` → the response-window length. So a `keyword` event authors `"…shout the word {keyword} to be counted!"`. If a `keyword`/`challenge` event's `announceText` omits the placeholder, the engine appends a generated `[sub]Quick, !random {token}…[/sub]` instruction line so it's never unanswerable. `none` events ignore these placeholders.
 
 **Winner rules (B12.4 — "depends on the event"):**
 - `firstValid` — first valid responder wins; resolve immediately on that response.
@@ -102,11 +107,11 @@ New `ChatBotCommand` [ChateauRandom.cs](../../../FChatDicebot/BotCommands/Chatea
 | `CooldownDuration` | `null` (participation is gated by the event/window, not a timer) |
 
 **Behavior:**
-1. No active event in this channel → short reply, e.g. *(owner review)* `"There's nothing happening right now. Stick around — something might."`
-2. Active event → validate per `responseType` (token/answer match; delay elapsed); on invalid, a brief nudge (wrong/early) without consuming their one shot, or consume it — owner's call (see open items).
-3. Record the responder once (ignore duplicate `!random` from the same user in the same event).
-4. Resolve per `winnerRule`: `firstValid` resolves immediately; the others accumulate and resolve when the window closes (handled by the scheduler tick).
-5. On resolution, post the chosen outcome's `resultText` + a generated reward summary to the channel, and grant rewards to the winner(s).
+1. No active event in this channel → short reply (PM'd): `"There's no random event for you to respond to right now. When there is, everyone will be explicitly prompted."`
+2. Active event → validate per `responseType` (token/answer match); on invalid, a brief nudge, PM'd, **without consuming their one shot** — the resident can just try again.
+3. Record the responder once (ignore duplicate `!random` from the same user in the same event; PM'd "can't participate twice" nudge).
+4. Resolve per `winnerRule`: `firstValid` resolves immediately; the others accumulate (each accepted attempt gets a PM'd "you're in, results once everyone's had a chance to join") and resolve when the window closes (handled by the scheduler tick).
+5. On resolution, post the chosen outcome's `resultText` to the channel — substituting `{winners}` with every winner's `[user]` tag if present, so multi-winner outcomes can carry their own combined flavor (e.g. `"{winners} are now glowing purple."`) instead of a generic engine-authored line — followed by one combined reward line per distinct reward grant (winners who received identical rewards are grouped onto a single "X and Y receive Z!" line rather than repeated per person), and grants the rewards to the winner(s).
 
 ---
 
@@ -117,7 +122,7 @@ Per-channel opt-in + a tick handler parallel to `HandleFutureMessagesTick`:
 - **Opt-in:** new `ChannelSettings.AllowRandomEvents` flag (default `false`), matching the existing per-channel toggles (`AllowWork`, `AllowGames`, …) in [ChannelSettings.cs](../../../FChatDicebot/SavedData/ChannelSettings.cs). Only opted-in joined channels are eligible.
 - **Cadence:** about **one event per 6–8 hours per channel**, with jitter. Track a per-channel `nextFireUtc`; when reached, attempt a fire, then schedule the next at `now + random(6h, 8h)`.
 - **Activity gate:** to "encourage spontaneous chat activity" rather than spam dead rooms, only fire if the channel saw a human message within the last ~15 minutes. Record a per-channel `lastActivityUtc` in `HandleMessage` (where channel messages are already processed). If a fire is due but the channel is quiet, **skip and reschedule** (don't fire into an empty room).
-- **Fire:** pick a `RandomEvent` by `weight` (optionally filtered by category), materialize per-fire state (token/challenge/delay), post `announceText` to the channel, and open the active event with `windowEnd = now + responseWindowSeconds`.
+- **Fire:** pick a `RandomEvent` by `weight` (optionally filtered by category), materialize per-fire state (token/challenge), post `announceText` to the channel, and open the active event with `windowEnd = now + responseWindowSeconds`.
 - **Resolve:** each tick, close any active events whose window has elapsed (for non-`firstValid` rules) and emit the outcome.
 - **One at a time (B12.6):** at most one active event per channel; if one is active, a due fire is skipped (events are far enough apart that this is rare anyway).
 
@@ -154,9 +159,10 @@ Per-channel opt-in + a tick handler parallel to `HandleFutureMessagesTick`:
 ## Tests
 
 - **Selection:** weighted event pick is deterministic under a seeded RNG; category filter respected.
-- **Response validation:** `keyword` accepts only the matching token (case-insensitive) and rejects others; `challenge` accepts only the correct answer; `delay` rejects responses before the min delay and accepts after; `none` accepts a bare `!random`.
+- **Response validation:** `keyword` accepts only the matching token (case-insensitive) and rejects others; `challenge` accepts only the correct answer; `none` accepts a bare `!random`.
 - **Winner rules:** `firstValid` resolves on the first valid response; `nth` selects exactly the N-th; `allInWindow` grants every valid responder; `random` picks among valid responders (seeded); duplicate responses from one user ignored.
 - **Reward application:** each `type` mutates the right store by the rolled amount (currency add; training clamp 0–100; title added once; corruption up / purity down; curse added; `none` no write); profile saved once.
+- **Multi-winner resolution:** an outcome's `{winners}` placeholder substitutes every winner's tag with no reward line appended when nothing was granted; winners who receive identical reward fragments are combined onto one grouped line with the correct singular/plural verb.
 - **Scheduler:** a due fire into an active channel opens an event and reschedules; a due fire into a quiet channel skips + reschedules without posting; only one active event per channel; window elapse resolves non-`firstValid` events.
 
 ---
@@ -165,18 +171,34 @@ Per-channel opt-in + a tick handler parallel to `HandleFutureMessagesTick`:
 
 - **B12.1** `!random` is a **new command**; payoffs span **currency, title, training, corruption/purity, curse, or flavor**. The bot occasionally fires an event; users join with `!random {optional event-requested arg}`; the bot announces the outcome.
 - **B12.2** Per-channel timer into opted-in channels, **activity-gated**, ~**once per 6–8 hours** with jitter, open response window.
-- **B12.3** Anti-snipe arg is **per-event** — `keyword`, `challenge`, or `delay`.
+- **B12.3** Anti-snipe arg is **per-event** — `keyword` or `challenge` (a bare-`!random` "none" is also available for events that don't need one). A third `delay` type — gating on elapsed time rather than a code — was considered and dropped 2026-07-01 (owner): it would penalize a genuinely fast, correct response, and the keyword/challenge already supplies all the anti-snipe value.
 - **B12.4** Winner selection is **per-event** — first-come, all-in-window, exact Nth responder, or random.
 - **B12.5** Events authored in a **seeded collection**.
 - **B12.6** **One event at a time** per channel.
 
-## Open items
+## As-built defaults (owner-reviewed 2026-07-01)
 
-- All **framework** user-facing strings (no-event reply, too-early/wrong-answer nudge, window-closed/no-winner, generic win confirmation, reward-summary phrasing) pending owner wording approval. Per-event `announceText` / `resultText` are authored data, not code.
-- Exact tuning numbers: jitter bounds within 6–8h, activity-gate window (~15 min?), default `responseWindowSeconds`, per-reward magnitude ranges — owner to set when authoring events.
-- Whether an invalid/early `!random` **consumes** the user's one attempt or not.
-- Category-based event selection (seasonal/themed pools) — schema supports it; wire if wanted.
-- Whether to persist `nextFireUtc` across restarts (spec keeps it in-memory for simplicity).
+All framework strings live as `const`s on `RandomEventEngine` (search `// Framework user-facing strings`); tuning numbers are `const`s near the top of the same class.
+
+- **Framework user-facing strings** — final wording:
+  - *No active event* (`NoEventMessage`): "There's no random event for you to respond to right now. When there is, everyone will be explicitly prompted."
+  - *Wrong keyword* (`WrongArgMessage`, keyword type): "That's not the word this one's looking for. Try again!"
+  - *Wrong answer* (`WrongArgMessage`, challenge type): "That's not quite the answer this one's looking for. Give it another read and try again!"
+  - *Already responded* (`AlreadyRespondedMessage`): "You can't participate twice! Wait for next event."
+  - *Accepted, waiting* (`AcceptedWaitMessage`, PM'd, non-firstValid): "You're in! We'll announce the results once everyone has had some time to join."
+  - *No winner / window closed* (`NoWinnerMessage`): "Time's up for now. Until next time~"
+  - *Auto-appended anti-snipe hint* (when `announceText` omits the `{keyword}`/`{challenge}` placeholder): `[sub]Quick, [b]!random rose[/b] to take part![/sub]`
+  - *Win line*: `[user]Name[/user] receives [b]5 rosequartz[/b] and the title ·Lucky·!` for a single winner. Beyond this, all other resolution text is event-authored — see *Multi-winner resolution* below.
+- **Tuning numbers** (all `const` on `RandomEventEngine`): jitter `IntervalMinHours=6`/`IntervalMaxHours=8`; `ActivityWindowMinutes=15`; `DefaultResponseWindowSeconds=60` (used only when an event leaves `responseWindowSeconds` at 0). Per-reward magnitude ranges are authored per-event (engine just rolls `min..max` inclusive). Scheduler scan throttle `BotMain.RandomEventScanIntervalSeconds=10`.
+- **Invalid `!random` does NOT consume the attempt** — a wrong keyword/answer gets a PM nudge and the resident can retry immediately. There is no time-based rejection (see the dropped `delay` type above): the anti-snipe value is entirely in needing the right token/answer, so a genuinely quick, correct response should never be filtered out.
+- **Pending accepts are PM'd, not announced** — only the fire announcement and the resolution are public; accept/nudge/no-event replies go to the responder privately, keeping the channel clean (still TOS-safe since `!random` is user-invoked).
+- **Multi-winner resolution.** One outcome is rolled per event; its `resultText` is the header, with an optional `{winners}` placeholder substituted with every winner's `[user]` tag (joined "A, B and C") — this is how an author gives a multi-winner outcome its own combined flavor (e.g. `"{winners} are now glowing purple."`) instead of the engine inventing a generic per-person line. Each reward is then re-rolled and applied per winner (so `allInWindow` winners can receive varying amounts); winners who ended up with byte-identical reward fragments are grouped onto one line each (`"[user]Alice[/user] and [user]Bob[/user] receive [b]3 rosequartz[/b]!"`, singular "receives" for one winner); a winner granted nothing (a `none` reward, an already-maxed stat, a duplicate title, etc.) gets no reward line — the `{winners}` header is expected to already cover them.
+- **Category-based selection: NOT wired into the scheduler** — it weights across *all* events. `GetRandomEventsByCategory` exists (mirrors `GetDutiesByCategory`) for future seasonal/themed pools.
+- **`nextFireUtc` stays in-memory** — resets on restart; each eligible channel re-seeds its first fire at `now + random(6–8h)` on the first tick, so events don't all fire at once after a restart.
+
+## Seed data
+
+One starter event, **"Cutie says {word}"**, has been authored (owner inserted the document directly into the `RandomEvents` collection; it isn't tracked in this repo since events are pure Mongo data, not code). It's a `keyword`/`allInWindow` event: every resident who repeats Cutie's randomly-chosen word back within the window is granted the `Cutie` title, using the `{winners}` placeholder to greet everyone who caught it in one line. Authoring more events is tracked as a to-do (see `wiki-docs/Feature-Requests.md`) — write additional `RandomEvent` documents in the same shape; the scheduler picks among all of them by `weight` automatically, no code change needed.
 
 ## Assumptions
 


### PR DESCRIPTION
## Summary

Ships B12 from the Feature-Requests backlog: an ambient "random events" system that fires an in-character prompt into an opted-in channel every ~6-8 hours, lets residents respond with `!random`, and grants a reward to the winner(s) — currency, a title, training, a shift in corruption/purity, a curse, or just flavor. Events are pure Mongo data (a new seeded `RandomEvents` collection), so authoring more doesn't require a code change.

- **Model + DB**: `RandomEvent` / `EventOutcome` / `EventReward` (mirrors the existing `Duty`/`DutyResult`/`Reward` shape); `GetRandomEvents`/`GetRandomEventsByCategory` added through the DB layer.
- **Engine** (`RandomEventEngine`): in-memory per-channel scheduler state, weighted event/outcome selection, response validation (`none`/`keyword`/`challenge`), all four winner rules (`firstValid`/`allInWindow`/`nth`/`random`), and reward application wired to the **existing** grant mechanisms (currencies, titles, trainings, corruption/purity, curses) — no new player-facing subsystem.
- **Command + scheduler**: `!random` command; `HandleRandomEventsTick` beside the existing `HandleFutureMessagesTick` in the F-Chat run loop; per-channel activity tracking gates firing so dead rooms don't get spammed; new `ChannelSettings.AllowRandomEvents` opt-in flag wired through `!updatesetting`/`!viewsettings`/`!help`.
- **Multi-winner resolution**: an outcome's `resultText` can use a `{winners}` placeholder so multi-winner events author their own combined flavor (e.g. `"{winners} are now glowing purple."`) instead of a generic engine-authored line; winners who receive identical rewards are grouped onto one line with correct singular/plural verb.
- **Design note**: a third "delay" anti-snipe response type (reject responses before a randomized minimum time after firing) was considered and dropped per owner review — the keyword/challenge itself is the anti-snipe gate, and a pure time-gate would unfairly penalize a genuinely fast, correct response.
- Seeds a single starter event ("Cutie says {word}") directly into Mongo (not tracked in-repo, since events are data); authoring more is tracked as a Feature-Requests to-do.
- Discord is intentionally untouched — the scheduler is wired into the F-Chat run loop only.

## Test plan

- [x] `FChatDicebot` (main project) builds clean
- [x] Full test suite passes: **1380/1380** (1355 pre-existing + 25 new in `Randomeventenginetests.cs` covering selection, response validation, all winner rules, all six reward types, multi-winner grouping, and the scheduler)
- [ ] Live F-Chat verification (opt a test channel in via `!updatesetting allowrandomevents true`, wait for a fire or lower the interval consts locally, confirm `!random` responds and grants correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)