### PR TITLE
Consume bodyparts, birth/whatis gestation info, pooled slots jackpots

### DIFF
--- a/FChatDicebot.Tests/Unit/Wagerbanktests.cs
+++ b/FChatDicebot.Tests/Unit/Wagerbanktests.cs
@@ -209,17 +209,20 @@ namespace FChatDicebot.Tests.Unit
         }
 
         [Fact]
-        public void SlotsJackpot_PersistsPerKey_DefaultsToMinusOne()
+        public void SlotsJackpot_PersistsPerMachine_AsPerCurrencyAmounts()
         {
-            Assert.Equal(-1, _database.GetSlotsJackpot("Fancy|copper")); // unset
+            Assert.Empty(_database.GetSlotsJackpotAmounts("Fancy")); // unset
 
-            _database.SetSlotsJackpot("Fancy|copper", 500);
-            Assert.Equal(500, _database.GetSlotsJackpot("Fancy|copper"));
+            _database.SetSlotsJackpotAmounts("Fancy", new System.Collections.Generic.Dictionary<string, int> { { "copper", 500 } });
+            Assert.Equal(500, _database.GetSlotsJackpotAmounts("Fancy")["copper"]);
 
-            _database.SetSlotsJackpot("Fancy|copper", 750); // updates in place
-            Assert.Equal(750, _database.GetSlotsJackpot("Fancy|copper"));
+            // Updates in place, and other currencies on the same machine coexist in one document.
+            _database.SetSlotsJackpotAmounts("Fancy", new System.Collections.Generic.Dictionary<string, int> { { "copper", 750 }, { "gold", 30 } });
+            var amounts = _database.GetSlotsJackpotAmounts("Fancy");
+            Assert.Equal(750, amounts["copper"]);
+            Assert.Equal(30, amounts["gold"]);
 
-            Assert.Equal(-1, _database.GetSlotsJackpot("Fancy|gold")); // other currency isolated
+            Assert.Empty(_database.GetSlotsJackpotAmounts("OtherMachine")); // other machine isolated
         }
 
         public void Dispose()

--- a/FChatDicebot/BotCommands/ChateauBirth.cs
+++ b/FChatDicebot/BotCommands/ChateauBirth.cs
@@ -16,7 +16,7 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Commitment Interaction";
             ShortDescription = "Birth a pregnancy that has finished gestating";
-            LongDescription = "Birth your young once they have finished gestating. If multiple pregnancies are ready to be born, you will be messaged a numbered list of the pregnancies, and can choose which pregnancy to birth, or '!birth all' to birth every pregnancy you are able to.";
+            LongDescription = "Birth your young once they have finished gestating. If multiple pregnancies are ready to be born, you will be messaged a numbered list of the pregnancies, and can choose which pregnancy to birth, or '!birth all' to birth every pregnancy you are able to. Message this command privately to check on your pregnancies' remaining gestation time without birthing anything — actually giving birth requires running !birth in a channel.";
             Usage = "!birth\nor\n!birth {index}\n";
             RelatedCommands = new string[] { "breed", "dossier" };
             CooldownDuration = null;
@@ -24,7 +24,7 @@ namespace FChatDicebot.BotCommands
             IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
-            RequireChannel = true;
+            RequireChannel = false;
             LockCategory = CommandLockCategory.NONE;
         }
 
@@ -32,6 +32,13 @@ namespace FChatDicebot.BotCommands
         {
             string characterName = address.character;
             string channel = address.channel;
+
+            if (!commandController.MessageCameFromChannel(address))
+            {
+                bot.SendPrivateMessage(BuildGestationStatusMessage(MonDB.GetDatabase(), characterName), characterName);
+                return;
+            }
+
             BirthResult result = ExecuteBirth(MonDB.GetDatabase(), characterName, rawTerms);
             if (!string.IsNullOrEmpty(result.PrivateMessage))
             {
@@ -41,6 +48,38 @@ namespace FChatDicebot.BotCommands
             {
                 bot.SendMessageInChannel(result.ChannelMessage, channel);
             }
+        }
+
+        /// <summary>
+        /// DM-only status readout: lists every pregnancy with its remaining gestation time
+        /// (or "Ready now!"), without birthing anything. Actually giving birth requires
+        /// running !birth in a channel, since the completion message is posted publicly.
+        /// </summary>
+        public static string BuildGestationStatusMessage(IChateauDatabase database, string characterName)
+        {
+            Profile carrier = database.GetProfile(characterName);
+            if (carrier == null)
+            {
+                return ChateauInteractionHandler.notFoundText(characterName);
+            }
+
+            List<Pregnancy> pregnancies = carrier.pregnancies ?? new List<Pregnancy>();
+            if (pregnancies.Count == 0)
+            {
+                return "You aren't pregnant! Ask someone to !breed you first.";
+            }
+
+            DateTime now = DateTime.UtcNow;
+            string msg = "Here's the status of your pregnancies. Once one is ready, use !birth in a channel to actually give birth:";
+            foreach (var pregnancy in pregnancies.OrderBy(p => p.ReadyAt))
+            {
+                string status = pregnancy.ReadyAt <= now
+                    ? "Ready now!"
+                    : "ready in " + Utils.GetTimeSpanPrint(pregnancy.ReadyAt - now);
+                string broodPart = pregnancy.BroodSize > 1 ? " (brood of " + pregnancy.BroodSize + ")" : "";
+                msg += "\n[b]" + pregnancy.MonsterType + "[/b] sired by [user]" + pregnancy.Initiator + "[/user]" + broodPart + ": " + status;
+            }
+            return msg;
         }
 
         public class BirthResult

--- a/FChatDicebot/BotCommands/ChateauConsume.cs
+++ b/FChatDicebot/BotCommands/ChateauConsume.cs
@@ -20,12 +20,12 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Commitment Interaction";
             ShortDescription = "Consume/devour another resident";
-            LongDescription = "Consume or devour someone in whole or in part, whether that's their soul, their body, or their mind. The recipient must !consent before surrendering to their fate. It's up to you whether this is a permanent fate or something that can be recovered from.";
-            Usage = "!consume [noparse][user]NameInUserTag[/user][/noparse]";
+            LongDescription = "Consume or devour someone in whole or in part, whether that's their soul, their body, or their mind. Specify which of your own bodyparts is doing the consuming. The recipient must !consent before surrendering to their fate. It's up to you whether this is a permanent fate or something that can be recovered from.";
+            Usage = "!consume [noparse][user]NameInUserTag[/user][/noparse] {bodypart}";
             RelatedCommands = new string[] { "mark", "bond"};
             CooldownDuration = "1 Day";
             CooldownAppliesTo = "recipient";
-            IdentifierCategory = null;
+            IdentifierCategory = "bodypart";
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;
@@ -37,7 +37,9 @@ namespace FChatDicebot.BotCommands
             string characterName = address.character;
             string channel = address.channel;
             string timerString = "consume";
+            string identifierType = "bodypart";
             string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            string bodypart = commandController.GetIdentifierFromCommandTerms(rawTerms, identifierType);
             Profile recipientProfile = MonDB.getProfile(recipient);
             Profile initiatorProfile = MonDB.getProfile(characterName);
             Boolean valid = true;
@@ -45,8 +47,19 @@ namespace FChatDicebot.BotCommands
             {
                 bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
                 valid = false;
-            } 
-            else if (recipientProfile.timers.ContainsKey(timerString)) { 
+            }
+            else if (bodypart == null)
+            {
+                string message = ChateauInteractionHandler.typeNotFoundText(identifierType);
+                List<Identifier> bodypartIdentifiers = MonDB.getIdentifiers(identifierType);
+                if (bodypartIdentifiers != null && bodypartIdentifiers.Count > 0)
+                {
+                    message += "\n\nAvailable bodyparts: " + Utils.sortedListDisplayText(bodypartIdentifiers.Select(i => i.type).ToList());
+                }
+                bot.SendPrivateMessage(message, characterName);
+                valid = false;
+            }
+            else if (recipientProfile.timers.ContainsKey(timerString)) {
 
                 if (recipientProfile.timers[timerString].timerEnd.CompareTo(DateTime.UtcNow) > 0) //recipient was plantified too recently
                 {
@@ -60,11 +73,12 @@ namespace FChatDicebot.BotCommands
             {
                 // Delegate consent wording to the processor so it stays in one place.
                 var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("consume");
-                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, null);
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, bodypart);
 
                 Interaction objectifyInteraction = new Interaction();
                 objectifyInteraction.initiator = characterName;
                 objectifyInteraction.recipient = recipient;
+                objectifyInteraction.identifier = bodypart;
                 objectifyInteraction.type = timerString;
                 objectifyInteraction.investmentLevel = "commitment";
                 objectifyInteraction.interactionTime = DateTime.UtcNow;

--- a/FChatDicebot/BotCommands/ChateauIdentifier.cs
+++ b/FChatDicebot/BotCommands/ChateauIdentifier.cs
@@ -7,6 +7,7 @@ using FChatDicebot.BotCommands.Base;
 using FChatDicebot.SavedData;
 using Newtonsoft.Json;
 using FChatDicebot.DiceFunctions;
+using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
 using SharpCompress;
 
@@ -46,6 +47,14 @@ namespace FChatDicebot.BotCommands
                 if (identifier != null)
                 {
                     returnText = "[b]" + identifier.type + "[/b]\n" + identifier.description;
+
+                    if (identifier.categories != null && identifier.categories.Contains("monster", StringComparer.OrdinalIgnoreCase))
+                    {
+                        BreedProcessor.ResolveGestationAndBroodRange(identifier, out int gestationDays, out int broodSizeMin, out int broodSizeMax);
+                        string broodText = broodSizeMin == broodSizeMax ? broodSizeMin.ToString() : broodSizeMin + "-" + broodSizeMax;
+                        string dayWord = gestationDays == 1 ? "day" : "days";
+                        returnText += "\n[i]Gestation: " + gestationDays + " " + dayWord + ". Brood size: " + broodText + ".[/i]";
+                    }
                 }
                 else
                 {

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -802,21 +802,21 @@ namespace FChatDicebot.Database
             collection.UpdateOne(filter, update, options);
         }
 
-        public int GetSlotsJackpot(string key)
+        public Dictionary<string, int> GetSlotsJackpotAmounts(string machineKey)
         {
-            if (string.IsNullOrEmpty(key)) return -1;
+            if (string.IsNullOrEmpty(machineKey)) return new Dictionary<string, int>();
             var collection = Database.GetCollection<SlotsJackpot>("SlotsJackpots");
-            var filter = Builders<SlotsJackpot>.Filter.Eq(s => s.Id, key);
+            var filter = Builders<SlotsJackpot>.Filter.Eq(s => s.Id, machineKey);
             var doc = collection.Find(filter).FirstOrDefault();
-            return doc == null ? -1 : doc.Amount;
+            return doc?.Amounts ?? new Dictionary<string, int>();
         }
 
-        public void SetSlotsJackpot(string key, int amount)
+        public void SetSlotsJackpotAmounts(string machineKey, Dictionary<string, int> amounts)
         {
-            if (string.IsNullOrEmpty(key)) return;
+            if (string.IsNullOrEmpty(machineKey)) return;
             var collection = Database.GetCollection<SlotsJackpot>("SlotsJackpots");
-            var filter = Builders<SlotsJackpot>.Filter.Eq(s => s.Id, key);
-            var update = Builders<SlotsJackpot>.Update.Set(s => s.Amount, amount);
+            var filter = Builders<SlotsJackpot>.Filter.Eq(s => s.Id, machineKey);
+            var update = Builders<SlotsJackpot>.Update.Set(s => s.Amounts, amounts ?? new Dictionary<string, int>());
             collection.UpdateOne(filter, update, new UpdateOptions { IsUpsert = true });
         }
 

--- a/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/Database/Ichateaudatabase.cs
@@ -103,9 +103,10 @@ namespace FChatDicebot.Database
         List<MonsterStats> GetAllMonsterStats();
         void IncrementMonsterStats(string key, int pregnancyDelta, int offspringDelta);
 
-        // Slots jackpot persistence (per "{machine}|{currency}"); -1 when unset.
-        int GetSlotsJackpot(string key);
-        void SetSlotsJackpot(string key, int amount);
+        // Slots jackpot persistence, keyed per machine. Amounts maps currency -> running total;
+        // an unset machine (or unset currency within it) returns/starts empty.
+        Dictionary<string, int> GetSlotsJackpotAmounts(string machineKey);
+        void SetSlotsJackpotAmounts(string machineKey, Dictionary<string, int> amounts);
 
         // Mod Message Operations
         string GetModMessage(string messageLabel);

--- a/FChatDicebot/DiceFunctions/DiceBot.cs
+++ b/FChatDicebot/DiceFunctions/DiceBot.cs
@@ -794,26 +794,53 @@ namespace FChatDicebot.DiceFunctions
             if (held < betAmount)
                 return "Error: " + TextFormat.GetCharacterUserTags(address.character) + " does not have enough " + currency + " (" + betAmount + " needed, " + held + " held).";
 
-            // Load this machine's running jackpot for this currency (floored at the starting amount).
-            string jackpotKey = slotsSetting.Name + "|" + currency;
-            int storedJackpot = MonDB.GetDatabase().GetSlotsJackpot(jackpotKey);
+            // Load this machine's running jackpot. Every currency played on this machine grows
+            // its own column independently (never converted), but a jackpot win sweeps every
+            // other currency's column into the payout as a bonus bag — see below.
+            string jackpotKey = slotsSetting.Name;
+            Dictionary<string, int> jackpotAmounts = MonDB.GetDatabase().GetSlotsJackpotAmounts(jackpotKey);
+            int storedJackpot = jackpotAmounts.TryGetValue(currency, out int storedForCurrency) ? storedForCurrency : 0;
             int jackpot = storedJackpot >= slotsSetting.StartingJackpotAmount ? storedJackpot : slotsSetting.StartingJackpotAmount;
 
             var result = slotsSetting.GetSpinResult(random, betAmount, rewardMultiplier, jackpot, testCommand);
-
-            // Persist the jackpot's new running total (grows from losses, resets on a jackpot win).
-            MonDB.GetDatabase().SetSlotsJackpot(jackpotKey, result.NewJackpotAmount);
 
             // Stake to the house, winnings minted back — both in the bet currency.
             WagerBank.Burn(address.character, currency, betAmount);
             if (result.Winnings > 0)
                 WagerBank.PayWinner(address.character, currency, result.Winnings);
 
+            string bagText = "";
+            if (result.WonJackpot)
+            {
+                // Sweep every other currency's accumulated total on this machine into the win as
+                // a bonus bag, paid out in each of those currencies as-is (no conversion), then
+                // clear the whole machine's jackpot — every currency floors back to the starting
+                // amount on its next spin.
+                var bonusBag = new Dictionary<string, int>();
+                foreach (var entry in jackpotAmounts)
+                {
+                    if (entry.Key == currency || entry.Value <= 0) continue;
+                    bonusBag[entry.Key] = entry.Value;
+                }
+                foreach (var entry in bonusBag)
+                    WagerBank.PayWinner(address.character, entry.Key, entry.Value);
+                if (bonusBag.Count > 0)
+                    bagText = " Plus " + Wager.WagerGameSupport.DisplayBag(bonusBag) + " spills out of the machine!";
+
+                MonDB.GetDatabase().SetSlotsJackpotAmounts(jackpotKey, new Dictionary<string, int>());
+            }
+            else
+            {
+                // Persist this currency's new running total (grows from losses).
+                jackpotAmounts[currency] = result.NewJackpotAmount;
+                MonDB.GetDatabase().SetSlotsJackpotAmounts(jackpotKey, jackpotAmounts);
+            }
+
             int net = result.Winnings - betAmount;
             string betBonusString = betMultiplier > 1 ? "(x" + betMultiplier + ")" : "";
             string netString = "\n[sub]Net " + (net >= 0 ? "+" : "") + net + " " + currency + ".[/sub]";
-            string slotsSpinText = TextFormat.Emoji("dbslots1") + TextFormat.Emoji("dbslots2") + " " + TextFormat.GetCharacterIconTags(address.character) + " is spinning the [b]" + slotsSetting.Name + "[/b] slot machine! " + betBonusString + "\n[sub]Putting in " + betAmount + " " + currency + " and pulling the lever...[/sub] " + result.GetJackpotString();
-            return slotsSpinText + "\n" + result.ToString() + netString;
+            string slotsSpinText = TextFormat.Emoji("dbslots1") + TextFormat.Emoji("dbslots2") + " " + TextFormat.GetCharacterIconTags(address.character) + " is spinning the [b]" + slotsSetting.Name + "[/b] slot machine! " + betBonusString + "\n[sub]Putting in " + betAmount + " " + currency + " and pulling the lever...[/sub] " + result.GetJackpotString(currency);
+            return slotsSpinText + "\n" + result.ToString() + bagText + netString;
         }
 
         public string SpinSlots(SlotsSetting slotsSetting, MessageAddress address, int betMultiplier, FChatDicebot.BotCommands.SlotsTestCommand testCommand)
@@ -848,7 +875,7 @@ namespace FChatDicebot.DiceFunctions
 
             string newChips = DisplayChipPile(address, characterChips);
             string betBonusString = betMultiplier > 1 ? "(x" + betMultiplier + ")" : "";
-            string slotsSpinText = TextFormat.Emoji("dbslots1") + TextFormat.Emoji("dbslots2") + " " + TextFormat.GetCharacterIconTags(address.character) + " is spinning the [b]" + slotsSetting.Name + "[/b] slot machine! " + betBonusString + "\n[sub]Putting in " + betAmount + " " + BotMain.CurrencyPlaceholder + "s and pulling the lever...[/sub] " + result.GetJackpotString();
+            string slotsSpinText = TextFormat.Emoji("dbslots1") + TextFormat.Emoji("dbslots2") + " " + TextFormat.GetCharacterIconTags(address.character) + " is spinning the [b]" + slotsSetting.Name + "[/b] slot machine! " + betBonusString + "\n[sub]Putting in " + betAmount + " " + BotMain.CurrencyPlaceholder + "s and pulling the lever...[/sub] " + result.GetJackpotString(BotMain.CurrencyPlaceholder + "s");
             return slotsSpinText + "\n" + result.ToString();
         }
 

--- a/FChatDicebot/DiceFunctions/SlotsSetting.cs
+++ b/FChatDicebot/DiceFunctions/SlotsSetting.cs
@@ -488,12 +488,12 @@ namespace FChatDicebot.DiceFunctions
             return RawSpin + " " + winString + rewardString;
         }
 
-        public string GetJackpotString()
+        public string GetJackpotString(string currency)
         {
             if (WonJackpot || NewJackpotAmount == 0)
                 return "";
             else
-                return "[sub]The jackpot ticks up to $" + NewJackpotAmount + ".[/sub]";
+                return "[sub]The jackpot ticks up to " + NewJackpotAmount + " " + currency + ".[/sub]";
         }
     }
 }

--- a/FChatDicebot/DiceFunctions/Wager/WagerGameSupport.cs
+++ b/FChatDicebot/DiceFunctions/Wager/WagerGameSupport.cs
@@ -405,7 +405,7 @@ namespace FChatDicebot.DiceFunctions.Wager
             return TextFormat.GetCharacterUserTags(player) + " can't cover a stake of " + stake.Display() + ".";
         }
 
-        private static string DisplayBag(Dictionary<string, int> totals)
+        internal static string DisplayBag(Dictionary<string, int> totals)
         {
             var parts = totals.OrderBy(kv => kv.Key)
                 .Select(kv => kv.Value + " " + kv.Key)

--- a/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
@@ -308,6 +308,18 @@ namespace FChatDicebot.InteractionProcessors.Commitment
         /// </summary>
         internal static void ResolveGestationAndBrood(Identifier monsterIdentifier, Random random, out int gestationDays, out int broodSize, out bool isRareTwins)
         {
+            ResolveGestationAndBroodRange(monsterIdentifier, out gestationDays, out int broodMin, out int broodMax);
+            broodSize = RollBroodSize(broodMin, broodMax, random, out isRareTwins);
+        }
+
+        /// <summary>
+        /// Pure (no RNG) resolution of a monster's gestation days and brood size range —
+        /// the same category-default-then-override precedence as
+        /// <see cref="ResolveGestationAndBrood"/>, minus the brood-size roll. Used by
+        /// !whatis to display gestation info without actually rolling a pregnancy.
+        /// </summary>
+        internal static void ResolveGestationAndBroodRange(Identifier monsterIdentifier, out int gestationDays, out int broodSizeMin, out int broodSizeMax)
+        {
             CategoryDefault? categoryDefault = ResolveCategoryDefault(monsterIdentifier);
 
             int resolvedGestation = DefaultGestationDays;
@@ -338,7 +350,8 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             }
 
             gestationDays = ClampGestation(resolvedGestation);
-            broodSize = RollBroodSize(resolvedBroodMin, resolvedBroodMax, random, out isRareTwins);
+            broodSizeMin = resolvedBroodMin > 0 ? resolvedBroodMin : DefaultBroodSize;
+            broodSizeMax = resolvedBroodMax >= broodSizeMin ? resolvedBroodMax : broodSizeMin;
         }
 
         internal static CategoryDefault? ResolveCategoryDefault(Identifier monsterIdentifier)

--- a/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
@@ -20,6 +20,22 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         {
         }
 
+        public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)
+        {
+            var baseValidation = base.ValidateInteraction(initiator, recipient, identifier);
+            if (!baseValidation.IsValid)
+            {
+                return baseValidation;
+            }
+
+            if (string.IsNullOrEmpty(identifier))
+            {
+                return ValidationResult.Failure(ChateauInteractionHandler.typeNotFoundText("bodypart"));
+            }
+
+            return ValidationResult.Success();
+        }
+
         public override string ProcessInteraction(PendingCommand command)
         {
             string recipient = command.pendingInteraction.recipient;
@@ -46,7 +62,8 @@ namespace FChatDicebot.InteractionProcessors.Consequence
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            return initiatorProfile.displayName + " consumes " + recipientProfile.displayName + ", and they were never heard from again... or at least, it will be quite some time before they manage to escape, reform, or otherwise recover their strength.";
+            string bodypartText = Utils.BodypartToText(identifier);
+            return initiatorProfile.displayName + " consumes " + recipientProfile.displayName + " with their " + bodypartText + ", and they were never heard from again... or at least, it will be quite some time before they manage to escape, reform, or otherwise recover their strength.";
         }
 
         public override CooldownSpec CooldownRule => Cooldown;
@@ -60,10 +77,11 @@ namespace FChatDicebot.InteractionProcessors.Consequence
 
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
+            string bodypartText = Utils.BodypartToText(identifier);
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("consumed", Cooldown.PeriodDays));
 
-            return initiatorProfile.displayName + " is going to consume " + recipientProfile.displayName + "! " + seriousness
+            return initiatorProfile.displayName + " is going to consume " + recipientProfile.displayName + " with their " + bodypartText + "! " + seriousness
                 + " Do you !consent to being consumed, devoured, or otherwise feasted upon?";
         }
     }

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -112,15 +112,19 @@ namespace FChatDicebot.Model
     }
 
     /// <summary>
-    /// Persistent per-(machine, currency) slots jackpot. Grows by each spin's contribution and
-    /// resets to the machine's StartingJackpotAmount when won. Stored outside Profile so it never
-    /// counts as resident wealth in !economics / !populations. Id is "{machineName}|{currency}".
+    /// Persistent per-machine slots jackpot. Amounts is a per-currency running total (never
+    /// converted between currencies) — each currency grows independently from spins made in
+    /// that currency, but a jackpot win sweeps every currency's total in this machine into the
+    /// payout (see DiceBot.SpinSlotsCurrency), then the whole dictionary resets so every
+    /// currency floors back to the machine's StartingJackpotAmount on its next spin. Stored
+    /// outside Profile so it never counts as resident wealth in !economics / !populations.
+    /// Id is the machine name.
     /// </summary>
     public class SlotsJackpot
     {
         [BsonId]
         public string Id { get; set; }
-        public int Amount { get; set; }
+        public Dictionary<string, int> Amounts { get; set; } = new Dictionary<string, int>();
     }
 
     public class Title

--- a/wiki-docs/specs/Breed-and-Birth.md
+++ b/wiki-docs/specs/Breed-and-Birth.md
@@ -69,6 +69,14 @@ If no NPC system is installed (graceful degradation), `name=` and `description=`
 
 `!birth` is **not** a consent-flow interaction — it's a self-action. No `PendingCommand` involved.
 
+### DM status readout
+
+`!birth` no longer hard-requires a channel. Messaged privately, it doesn't birth anything — it lists every one of the caller's pregnancies with a status line ("Ready now!" or "ready in {time remaining}"), then reminds them that actually giving birth requires running `!birth` in a channel (the completion message is posted publicly). See `ChateauBirth.BuildGestationStatusMessage`.
+
+## `!whatis` gestation display
+
+`!identifier` / `!whatis` appends a `Gestation: {N} days. Brood size: {min}-{max}.` line for any identifier in the `monster` category, resolved via `BreedProcessor.ResolveGestationAndBroodRange` (the same category-default-then-override precedence as the real roll, minus the brood-size RNG — pure and side-effect-free so looking it up doesn't consume anything).
+
 ## Persistence
 
 On `Profile`:


### PR DESCRIPTION
## Summary
- `!consume` now requires the initiator's bodypart as an identifier (mirroring `!mark`'s pattern), with the available bodypart list surfaced when it's omitted.
- `!whatis`/`!identifier` now shows gestation days and brood size range for monster-category identifiers.
- DMing `!birth` no longer just rejects with "requires a channel" — it lists every pregnancy's status (ready or remaining time) and prompts the user to run `!birth` in a channel to actually give birth.
- Slots jackpots now pool across every currency played on a machine: each currency grows its own running total, but a jackpot win sweeps every other currency's accumulated total into the payout as a bonus bag (paid in those currencies, no conversion), then the whole machine's jackpot resets.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 1433/1433 passing (against a real local MongoDB), including a rewritten `SlotsJackpot` persistence test for the new per-machine, per-currency dictionary storage
- [x] Updated `wiki-docs/specs/Breed-and-Birth.md` for the new `!whatis` gestation display and DM `!birth` status readout

🤖 Generated with [Claude Code](https://claude.com/claude-code)