### PR TITLE
Add !help support for currency-wagerable dicebot commands

### DIFF
--- a/FChatDicebot/BotCommands/CancelGame.cs
+++ b/FChatDicebot/BotCommands/CancelGame.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public CancelGame()
         {
             Name = "cancelgame";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Cancel the active game session";
+            LongDescription = "Cancels the game session for the given game type (or the only active session, if just one exists). Any committed currency stakes are refunded to their players.";
+            Usage = "!cancelgame\nor\n!cancelgame {game name}";
+            RelatedCommands = new string[] { "startgame", "joingame", "leavegame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -157,6 +157,29 @@ namespace FChatDicebot.BotCommands
                 "!odorize",
                 "!break"
             };
+
+            List<string> dicebotCommands = new List<string>()
+            {
+                "!joingame",
+                "!startgame",
+                "!leavegame",
+                "!cancelgame",
+                "!gamestatus",
+                "!gamecommand [sub]!gc, !g[/sub]",
+                "!showgames",
+                "!roll",
+                "!rolltable",
+                "!showlastroll",
+                "!coinflip",
+                "!fitd",
+                "!tipdie",
+                "!rock",
+                "!paper",
+                "!scissors",
+                "!lizard",
+                "!spock",
+                "!fen"
+            };
             string messageText = "These are all of the commands native to the [user]Chateau Contract[/user] bot, as of [b]June 29th 2026.[/b] For detailed description of their use, please see the [user]Chateau Contract[/user] profile or use !help [command] Commands in subtext are alternate names of the same command - all documentation will be for the first listed names.\n\n" +
                     "[u]Does not require channel[/u]\n" +
                     Utils.sortedListDisplayText(generalCommands) + "\n" +
@@ -167,11 +190,12 @@ namespace FChatDicebot.BotCommands
                     "[i]Involved Interactions:[/i] " + Utils.sortedListDisplayText(involvedCommands) + "\n" +
                     "[i]Commitment Interactions:[/i] " + Utils.sortedListDisplayText(commitmentCommands) + "\n" +
                     "[i]Consequence Interactions:[/i] " + Utils.sortedListDisplayText(consequenceCommands) + "\n" +
+                    "[i]Dice Bot Commands:[/i] " + Utils.sortedListDisplayText(dicebotCommands) + "\n" +
 
                     "\n[b]Channel Op only Commands:[/b]\n" +
                     "None yet :)\n" +
 
-                    "\nFor full information on dice commands, see the profile [user]Dice Bot[/user]. [color=yellow]The [user]Dice Bot[/user] profile is maintained for the core [user]Dice Bot[/user] and not all of the commands described may be present in the Chateau Contract bot.[/color]\n";
+                    "\nAny dicebot commands not listed here have yet to be fully migrated, or were intentionally cut. They might work, but use at your own risk!\n";
 
             if(Utils.IsCharacterAdmin(bot.AccountSettings.AdminCharacters, command.characterName))
             {
@@ -224,6 +248,9 @@ namespace FChatDicebot.BotCommands
                         break;
                     case "Recovery":
                         sb.AppendLine("[color=blue]Recovery[/color]");
+                        break;
+                    case "Dicebot":
+                        sb.AppendLine("[color=cyan]Dicebot[/color]");
                         break;
                     case "General":
                         sb.AppendLine("General");

--- a/FChatDicebot/BotCommands/CoinFlip.cs
+++ b/FChatDicebot/BotCommands/CoinFlip.cs
@@ -15,6 +15,15 @@ namespace FChatDicebot.BotCommands
         public CoinFlip()
         {
             Name = "coinflip";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Flip a coin";
+            LongDescription = "Flips a coin and reports heads or tails.";
+            Usage = "!coinflip";
+            RelatedCommands = new string[] { "roll" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/Fen.cs
+++ b/FChatDicebot/BotCommands/Fen.cs
@@ -20,6 +20,15 @@ namespace FChatDicebot.BotCommands
         public Fen()
         {
             Name = "fen";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Display a chess board from FEN notation";
+            LongDescription = "Renders a chess board position from FEN (Forsyth-Edwards Notation) text. 'starting' or 'default' shows the standard opening position. Add 'setdescription' to set this channel's description to the rendered board (requires the bot to be a channel admin, or you to be a bot admin).";
+            Usage = "!fen {FEN string}\nor\n!fen starting\nor\n!fen {FEN string} setdescription";
+            RelatedCommands = new string[] { "joingame", "gamecommand" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/FitD.cs
+++ b/FChatDicebot/BotCommands/FitD.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public FitD()
         {
             Name = "fitd";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Roll a Forged in the Dark style dice pool";
+            LongDescription = "Rolls the given number of six-sided dice and reports the highest result, Forged-in-the-Dark style (6 = success, 4-5 = partial success, 1-3 = failure, multiple 6s = critical).";
+            Usage = "!fitd {number of dice}";
+            RelatedCommands = new string[] { "roll" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/G.cs
+++ b/FChatDicebot/BotCommands/G.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public G()
         {
             Name = "g";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Alias for !gamecommand";
+            LongDescription = "Shorthand for !gamecommand. See !help gamecommand for full details.";
+            Usage = "!g {game name} {command}";
+            RelatedCommands = new string[] { "gamecommand" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/GC.cs
+++ b/FChatDicebot/BotCommands/GC.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public GC()
         {
             Name = "gc";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Alias for !gamecommand";
+            LongDescription = "Shorthand for !gamecommand. See !help gamecommand for full details.";
+            Usage = "!gc {game name} {command}";
+            RelatedCommands = new string[] { "gamecommand" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/GameCommand.cs
+++ b/FChatDicebot/BotCommands/GameCommand.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public GameCommand()
         {
             Name = "gamecommand";
+            Aliases = new string[] { "gc", "g" };
+            Category = "Dicebot";
+            ShortDescription = "Send a game-specific command to the active game session";
+            LongDescription = "Passes a command through to whichever game is currently active in this channel (for example, choosing a card or an action specific to that game). What's valid depends on the game in progress, see that game's own instructions.";
+            Usage = "!gamecommand {game name} {command}\nor\n!gc {game name} {command}\nor\n!g {game name} {command}";
+            RelatedCommands = new string[] { "joingame", "startgame", "gamestatus" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/GameStatus.cs
+++ b/FChatDicebot/BotCommands/GameStatus.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public GameStatus()
         {
             Name = "gamestatus";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Check the status of an active game session";
+            LongDescription = "Shows the current state of the named game's session in this channel. Includes players joined, whose turn it is, and any countdown remaining before it can start.";
+            Usage = "!gamestatus {game name}";
+            RelatedCommands = new string[] { "joingame", "startgame", "gamecommand" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/JoinGame.cs
+++ b/FChatDicebot/BotCommands/JoinGame.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public JoinGame()
         {
             Name = "joingame";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Join or start a dice game";
+            LongDescription = "Join the current game session for a game type, or start a new one if none exists. Optionally stake an amount of currency - the first player to name a stake opens it, later players either match it exactly or propose a different stake (which the opener must !accept). Joining with no stake at all makes it a friendly, no-money game.";
+            Usage = "!joingame {game name}\nor\n!joingame {game name} {amount} {currency}";
+            RelatedCommands = new string[] { "startgame", "leavegame", "gamestatus", "showgames", "cancelgame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/LeaveGame.cs
+++ b/FChatDicebot/BotCommands/LeaveGame.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public LeaveGame()
         {
             Name = "leavegame";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Leave a dice game session you've joined";
+            LongDescription = "Removes you from the named game's session in this channel. If you had a currency stake committed, it's refunded.";
+            Usage = "!leavegame {game name}";
+            RelatedCommands = new string[] { "joingame", "cancelgame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/Lizard.cs
+++ b/FChatDicebot/BotCommands/Lizard.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public Lizard()
         {
             Name = "lizard";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Play lizard in an active Rock-Paper-Scissors game";
+            LongDescription = "Submits lizard as your move in the Rock-Paper-Scissors session you've joined in this channel via !joingame. (Lizard and Spock only apply if the session was started as the five-way variant.)";
+            Usage = "!lizard";
+            RelatedCommands = new string[] { "rock", "paper", "scissors", "spock", "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/Paper.cs
+++ b/FChatDicebot/BotCommands/Paper.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public Paper()
         {
             Name = "paper";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Play paper in an active Rock-Paper-Scissors game";
+            LongDescription = "Submits paper as your move in the Rock-Paper-Scissors session you've joined in this channel via !joingame. (Lizard and Spock only apply if the session was started as the five-way variant.)";
+            Usage = "!paper";
+            RelatedCommands = new string[] { "rock", "scissors", "lizard", "spock", "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/Rock.cs
+++ b/FChatDicebot/BotCommands/Rock.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public Rock()
         {
             Name = "rock";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Play rock in an active Rock-Paper-Scissors game";
+            LongDescription = "Submits rock as your move in the Rock-Paper-Scissors session you've joined in this channel via !joingame. (Lizard and Spock only apply if the session was started as the five-way variant.)";
+            Usage = "!rock";
+            RelatedCommands = new string[] { "paper", "scissors", "lizard", "spock", "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/Roll.cs
+++ b/FChatDicebot/BotCommands/Roll.cs
@@ -13,6 +13,15 @@ namespace FChatDicebot.BotCommands
         public Roll()
         {
             Name = "roll";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Roll dice using standard dice notation";
+            LongDescription = "Rolls one or more dice and reports the result. Accepts standard notation such as '2d6', '1d20+5', or multiple dice groups at once.";
+            Usage = "!roll {dice notation}";
+            RelatedCommands = new string[] { "rolltable", "showlastroll", "tipdie" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/RollTable.cs
+++ b/FChatDicebot/BotCommands/RollTable.cs
@@ -15,6 +15,15 @@ namespace FChatDicebot.BotCommands
         public RollTable()
         {
             Name = "rolltable";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Roll on a saved random table";
+            LongDescription = "Rolls against a saved table (a weighted or listed set of possible results) and reports what came up. Some tables reference others and roll them automatically as a secondary result unless 'nosecondary' is given; 'nolabel' hides the table's name in the output.";
+            Usage = "!rolltable {table name}\nor\n!rolltable {table name} nolabel\nor\n!rolltable {table name} nosecondary";
+            RelatedCommands = new string[] { "roll", "showlastroll" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/Scissors.cs
+++ b/FChatDicebot/BotCommands/Scissors.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public Scissors()
         {
             Name = "scissors";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Play scissors in an active Rock-Paper-Scissors game";
+            LongDescription = "Submits scissors as your move in the Rock-Paper-Scissors session you've joined in this channel via !joingame. (Lizard and Spock only apply if the session was started as the five-way variant.)";
+            Usage = "!scissors";
+            RelatedCommands = new string[] { "rock", "paper", "lizard", "spock", "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/ShowGames.cs
+++ b/FChatDicebot/BotCommands/ShowGames.cs
@@ -15,8 +15,17 @@ namespace FChatDicebot.BotCommands
         public ShowGames()
         {
             Name = "showgames";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "List every game type available with !joingame";
+            LongDescription = "Shows the full list of dice games currently supported, by name, for use with !joingame.";
+            Usage = "!showgames";
+            RelatedCommands = new string[] { "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
-            RequireChannelAdmin = true;
+            RequireChannelAdmin = false;
             RequireChannel = false;
             LockCategory = CommandLockCategory.SavedTables;
         }

--- a/FChatDicebot/BotCommands/ShowLastRoll.cs
+++ b/FChatDicebot/BotCommands/ShowLastRoll.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public ShowLastRoll()
         {
             Name = "showlastroll";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Show the last dice roll made.";
+            LongDescription = "Redisplays the most recent dice roll recorded. Add 'sort' to show the individual dice sorted by value.";
+            Usage = "!showlastroll\nor\n!showlastroll sort";
+            RelatedCommands = new string[] { "roll", "tipdie" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/Spock.cs
+++ b/FChatDicebot/BotCommands/Spock.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public Spock()
         {
             Name = "spock";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Play spock in an active Rock-Paper-Scissors game";
+            LongDescription = "Submits spock as your move in the Rock-Paper-Scissors session you've joined in this channel via !joingame. (Lizard and Spock only apply if the session was started as the five-way variant.)";
+            Usage = "!spock";
+            RelatedCommands = new string[] { "rock", "paper", "scissors", "lizard", "joingame" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;

--- a/FChatDicebot/BotCommands/StartGame.cs
+++ b/FChatDicebot/BotCommands/StartGame.cs
@@ -16,6 +16,15 @@ namespace FChatDicebot.BotCommands
         public StartGame()
         {
             Name = "startgame";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Start the current game session once enough players have joined";
+            LongDescription = "Starts the game session for the given game type once the minimum player count has been met. Add 'keepsession' to keep the session open for another round after this one finishes, or 'endsession' to close it out.";
+            Usage = "!startgame {game name}\nor\n!startgame {game name} keepsession\nor\n!startgame {game name} endsession";
+            RelatedCommands = new string[] { "joingame", "gamestatus", "gamecommand" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = true;

--- a/FChatDicebot/BotCommands/TipDie.cs
+++ b/FChatDicebot/BotCommands/TipDie.cs
@@ -14,6 +14,15 @@ namespace FChatDicebot.BotCommands
         public TipDie()
         {
             Name = "tipdie";
+            Aliases = new string[] { };
+            Category = "Dicebot";
+            ShortDescription = "Adjust one die from the last roll";
+            LongDescription = "Changes one die's result from the most recent roll, useful for correcting or narratively 'tipping' a die after the fact. Without arguments, tips the lowest-value die up to the die's maximum face.";
+            Usage = "!tipdie\nor\n!tipdie {from}>{to}";
+            RelatedCommands = new string[] { "roll", "showlastroll" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
             RequireBotAdmin = false;
             RequireChannelAdmin = false;
             RequireChannel = false;


### PR DESCRIPTION
## Summary
- Adds full `!help` support (ShortDescription/LongDescription/Usage/RelatedCommands) to the 21 dicebot commands recently made currency-wagerable (`!joingame`, `!startgame`, `!leavegame`, `!cancelgame`, `!gamestatus`, `!gamecommand`/`!gc`/`!g`, `!showgames`, `!roll`, `!rolltable`, `!showlastroll`, `!coinflip`, `!fitd`, `!tipdie`, `!rock`/`!paper`/`!scissors`/`!lizard`/`!spock`, `!fen`), under a new `Category = "Dicebot"` rendered `[color=cyan]Dicebot[/color]` in `ChateauHelp`.
- `!gc`/`!g` get thin alias entries mirroring the existing `!c` → `!consent` pattern.
- `!showgames` is now public (`RequireChannelAdmin` flipped to `false`).
- General `!help` listing gained a `Dice Bot Commands:` line for these, replacing the old blanket pointer to the external Dice Bot profile with a note that anything not listed may not be fully migrated.
- `!bet`/`!claimpot` intentionally excluded — owner said these legacy chip/pot commands aren't fully supported yet.
- All new user-facing strings were drafted, reviewed, and revised with the repo owner before being applied.

## Test plan
- [x] `dotnet build FChatDicebot.sln` — 0 errors
- [x] `dotnet test FChatDicebot.Tests/FChatDicebot.Tests.csproj` — 1433/1433 passed
- [ ] Live F-Chat verification of `!help {command}` output for a few of the new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)