### PR TITLE
Add global !seteicon custom-interaction-eicon system

### DIFF
--- a/FChatDicebot.Tests/Unit/Cuddleprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Cuddleprocessortests.cs
@@ -322,9 +322,11 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void GetCompletionMessage_QueenContract_AddsEicon()
+        public void GetCompletionMessage_QueenContractSolo_NoLongerHardcodesEicon()
         {
-            // Arrange
+            // The single-party Queen Contract cuddle icon (qchug) now comes from her own
+            // !seteicon cuddle instead of a hardcoded branch, so a QC-without-Rin cuddle no
+            // longer appends it here. (The QC+Rin combined icon is still hardcoded — below.)
             var queenContract = new ProfileBuilder()
                 .WithUserName("Queen Contract")
                 .WithDisplayName("Queen Contract")
@@ -339,7 +341,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             string message = _processor.GetCompletionMessage(queenContract, recipient, "");
 
             // Assert
-            Assert.Contains("[eicon]qchug[/eicon]", message);
+            Assert.DoesNotContain("[eicon]qchug[/eicon]", message);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Interactioneicontests.cs
+++ b/FChatDicebot.Tests/Unit/Interactioneicontests.cs
@@ -1,0 +1,224 @@
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Casual;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Tests for the global custom-eicon feature (!seteicon): storage/mapping in
+    /// InteractionEiconSupport, the directional-vs-symmetric completion suffix, the lapsit
+    /// per-position rule, and the birth special-case.
+    /// </summary>
+    [Collection("Database")]
+    public class InteractionEiconTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public InteractionEiconTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        // ---- InteractionEiconSupport storage / mapping ----
+
+        [Fact]
+        public void SetInteractionEicon_ThenGet_Roundtrips()
+        {
+            var p = new ProfileBuilder().Build();
+            InteractionEiconSupport.SetInteractionEicon(p, "kiss", "[eicon]lips[/eicon]");
+            Assert.Equal("[eicon]lips[/eicon]", InteractionEiconSupport.GetInteractionEicon(p, "kiss"));
+        }
+
+        [Fact]
+        public void SetInteractionEicon_Mark_UsesLegacyCharacteristicSlot()
+        {
+            var p = new ProfileBuilder().Build();
+            InteractionEiconSupport.SetInteractionEicon(p, InteractionEiconSupport.MarkVerbKey, "[eicon]qcmark[/eicon]");
+
+            // Mark keeps its historical slot so the dossier + existing marks keep working.
+            Assert.Equal("[eicon]qcmark[/eicon]", p.characteristics["mark"]);
+            Assert.False(p.characteristics.ContainsKey("eicon_mark"));
+        }
+
+        [Fact]
+        public void ClearInteractionEicon_RemovesIt()
+        {
+            var p = new ProfileBuilder().Build();
+            InteractionEiconSupport.SetInteractionEicon(p, "spank", "[eicon]hand[/eicon]");
+            InteractionEiconSupport.ClearInteractionEicon(p, "spank");
+            Assert.Equal(string.Empty, InteractionEiconSupport.GetInteractionEicon(p, "spank"));
+        }
+
+        [Theory]
+        [InlineData("hug", new[] { "cuddle" })]
+        [InlineData("dress", new[] { "dressup" })]
+        [InlineData("hire", new[] { "employ" })]
+        [InlineData("purify", new[] { "purify" })]
+        [InlineData("sit", new[] { "sit" })]
+        [InlineData("pay", new[] { "paymentGive", "paymentReceive" })]
+        public void TryResolveTokenToVerbKeys_MapsTokens(string token, string[] expected)
+        {
+            Assert.True(InteractionEiconSupport.TryResolveTokenToVerbKeys(token, out var keys));
+            Assert.Equal(expected, keys);
+        }
+
+        [Theory]
+        [InlineData("rest")]
+        [InlineData("roll")]
+        [InlineData("")]
+        [InlineData("notacommand")]
+        public void TryResolveTokenToVerbKeys_RejectsUnsupported(string token)
+        {
+            Assert.False(InteractionEiconSupport.TryResolveTokenToVerbKeys(token, out _));
+        }
+
+        [Fact]
+        public void IsSelfRendered_OnlyMark()
+        {
+            Assert.True(InteractionEiconSupport.IsSelfRendered("mark"));
+            Assert.False(InteractionEiconSupport.IsSelfRendered("kiss"));
+        }
+
+        // ---- Directionality of the completion suffix ----
+
+        [Fact]
+        public void GroupEiconSuffix_Directional_InitiatorOnly()
+        {
+            var initiator = new ProfileBuilder().WithCharacteristic("eicon_spank", "[eicon]ihand[/eicon]").Build();
+            var recipient = new ProfileBuilder().WithCharacteristic("eicon_spank", "[eicon]rbutt[/eicon]").Build();
+            var processor = new SpankProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("spank", initiator, new List<Profile> { recipient });
+
+            Assert.Contains("[eicon]ihand[/eicon]", suffix);
+            Assert.DoesNotContain("[eicon]rbutt[/eicon]", suffix);
+        }
+
+        [Fact]
+        public void GroupEiconSuffix_Symmetric_AllParticipants_NoDedup()
+        {
+            var initiator = new ProfileBuilder().WithCharacteristic("eicon_kiss", "[eicon]lips[/eicon]").Build();
+            var c1 = new ProfileBuilder().WithCharacteristic("eicon_kiss", "[eicon]heart[/eicon]").Build();
+            var c2 = new ProfileBuilder().WithCharacteristic("eicon_kiss", "[eicon]lips[/eicon]").Build(); // same icon as initiator
+            var processor = new KissProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("kiss", initiator, new List<Profile> { c1, c2 });
+
+            // No de-dup: the duplicate "lips" shows once per participant that set it.
+            Assert.Equal(" [eicon]lips[/eicon] [eicon]heart[/eicon] [eicon]lips[/eicon]", suffix);
+        }
+
+        [Fact]
+        public void GroupEiconSuffix_Mark_IsSelfRendered_ReturnsEmpty()
+        {
+            var initiator = new ProfileBuilder().Build();
+            InteractionEiconSupport.SetInteractionEicon(initiator, "mark", "[eicon]qcmark[/eicon]");
+            var recipient = new ProfileBuilder().Build();
+            var processor = new MarkProcessor(_database);
+
+            // Mark renders its own reveal inline; the generic suffix must not double it.
+            Assert.Equal(string.Empty, processor.GetGroupEiconSuffix("mark", initiator, new List<Profile> { recipient }));
+        }
+
+        // ---- Lapsit per-position rule (bottom shows lap, riders show sit) ----
+
+        [Fact]
+        public void LapsitGroupEiconSuffix_Lap_BottomShowsLap_RidersShowSit()
+        {
+            // !lap: the initiator is the bottom, consenters stack above in order.
+            var initiator = new ProfileBuilder()
+                .WithCharacteristic("eicon_lap", "[eicon]LAP[/eicon]")
+                .WithCharacteristic("eicon_sit", "[eicon]ISIT[/eicon]")
+                .Build();
+            var c1 = new ProfileBuilder().WithCharacteristic("eicon_sit", "[eicon]C1SIT[/eicon]").Build();
+            var c2 = new ProfileBuilder().WithCharacteristic("eicon_sit", "[eicon]C2SIT[/eicon]").Build();
+            var processor = new LapsitProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("lap", initiator, new List<Profile> { c1, c2 });
+
+            // Bottom (initiator) uses their lap eicon; riders use their sit eicon.
+            Assert.Equal(" [eicon]LAP[/eicon] [eicon]C1SIT[/eicon] [eicon]C2SIT[/eicon]", suffix);
+        }
+
+        [Fact]
+        public void LapsitGroupEiconSuffix_Sit_FirstConsenterIsBottom()
+        {
+            // !sit: the first consenter claims the bottom, the initiator sits at position 1.
+            var initiator = new ProfileBuilder().WithCharacteristic("eicon_sit", "[eicon]ISIT[/eicon]").Build();
+            var c1 = new ProfileBuilder().WithCharacteristic("eicon_lap", "[eicon]C1LAP[/eicon]").Build();
+            var c2 = new ProfileBuilder().WithCharacteristic("eicon_sit", "[eicon]C2SIT[/eicon]").Build();
+            var processor = new LapsitProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("sit", initiator, new List<Profile> { c1, c2 });
+
+            // Bottom is c1 (their lap eicon); initiator + c2 ride (their sit eicons).
+            Assert.Equal(" [eicon]C1LAP[/eicon] [eicon]ISIT[/eicon] [eicon]C2SIT[/eicon]", suffix);
+        }
+
+        // ---- 1:1 completion path actually appends the eicon (symmetric shows both) ----
+
+        [Fact]
+        public void CompletionWithStatusEffects_Symmetric_AppendsBothEicons()
+        {
+            var initiator = new ProfileBuilder()
+                .WithUserName("Alice").WithDisplayName("Alice")
+                .WithCharacteristic("eicon_kiss", "[eicon]aa[/eicon]")
+                .BuildAndSave(_database);
+            var recipient = new ProfileBuilder()
+                .WithUserName("Bob").WithDisplayName("Bob")
+                .WithCharacteristic("eicon_kiss", "[eicon]bb[/eicon]")
+                .BuildAndSave(_database);
+            var processor = new KissProcessor(_database);
+
+            string message = processor.GetCompletionMessageWithStatusEffects(initiator, recipient, "", "kiss");
+
+            Assert.Contains("[eicon]aa[/eicon]", message);
+            Assert.Contains("[eicon]bb[/eicon]", message);
+        }
+
+        // ---- Birth special-case ----
+
+        [Fact]
+        public void Birth_AppendsCarrierBirthEicon()
+        {
+            var carrier = new ProfileBuilder()
+                .WithUserName("Carrier")
+                .WithDisplayName("Carrier")
+                .WithCharacteristic("eicon_birth", "[eicon]stork[/eicon]")
+                .BuildAndSave(_database);
+
+            carrier.pregnancies = new List<Pregnancy>
+            {
+                new Pregnancy
+                {
+                    Initiator = "Sire",
+                    MonsterType = "slime",
+                    ConceivedAt = DateTime.UtcNow.AddDays(-2),
+                    ReadyAt = DateTime.UtcNow.AddDays(-1),
+                    BroodSize = 1,
+                    Categories = new List<string>(),
+                }
+            };
+            _database.SetProfile("Carrier", carrier);
+
+            var result = ChateauBirth.ExecuteBirth(_database, "Carrier", new string[] { });
+
+            Assert.Contains("[eicon]stork[/eicon]", result.ChannelMessage);
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Kissprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Kissprocessortests.cs
@@ -325,9 +325,10 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         }
 
         [Fact]
-        public void GetCompletionMessage_QueenContract_AddsEicon()
+        public void GetCompletionMessage_QueenContract_NoLongerHardcodesEicon()
         {
-            // Arrange
+            // Queen Contract's kiss icon (qckiss) now comes from her own !seteicon kiss
+            // instead of a hardcoded branch, so it's no longer appended here.
             var queenContract = new ProfileBuilder()
                 .WithUserName("Queen Contract")
                 .WithDisplayName("Queen Contract")
@@ -342,8 +343,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             string message = _processor.GetCompletionMessage(queenContract, recipient, "");
 
             // Assert
-            Assert.Contains("[eicon]qckiss[/eicon]", message);
-            Assert.DoesNotContain("usingOldInteractionMessage", message);
+            Assert.DoesNotContain("[eicon]qckiss[/eicon]", message);
         }
 
         [Fact]

--- a/FChatDicebot/BotCommands/ChateauBirth.cs
+++ b/FChatDicebot/BotCommands/ChateauBirth.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using FChatDicebot.BotCommands.Base;
 using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
 using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
 
@@ -210,12 +211,17 @@ namespace FChatDicebot.BotCommands
 
         private static string BuildCompletionMessage(Profile carrier, Pregnancy pregnancy)
         {
+            // Birth is a solo resolution (no consent pipeline), so it appends the carrier's
+            // own custom !seteicon birth eicon here rather than through the shared completion hook.
+            string birthEicon = InteractionEiconSupport.GetInteractionEicon(carrier, "birth");
+            string eiconSuffix = string.IsNullOrEmpty(birthEicon) ? string.Empty : " " + birthEicon;
+
             // Rare-twins flavor: the resolved brood range was [1,1] and the 1% roll fired.
             if (pregnancy.IsRareTwins)
             {
                 return carrier.displayName + " has miraculously given birth to a pair of " + pregnancy.MonsterType
                     + " twins — a rare blessing for a species that normally bears just one! (Sired by "
-                    + pregnancy.Initiator + ".)";
+                    + pregnancy.Initiator + ".)" + eiconSuffix;
             }
 
             string broodPhrase = pregnancy.BroodSize > 1
@@ -223,7 +229,7 @@ namespace FChatDicebot.BotCommands
                 : Utils.AnOrA(pregnancy.MonsterType) + " " + pregnancy.MonsterType;
 
             return carrier.displayName + " has given birth to " + broodPhrase
-                + "! (Sired by " + pregnancy.Initiator + ".)";
+                + "! (Sired by " + pregnancy.Initiator + ".)" + eiconSuffix;
         }
 
         private static string BuildReadyList(List<Pregnancy> ready)

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -224,7 +224,7 @@ namespace FChatDicebot.BotCommands
 
                 Profile initProfile = MonDB.getProfile(toConsent.pendingInteraction.initiator);
                 Profile recipProfile = MonDB.getProfile(toConsent.pendingInteraction.recipient);
-                channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier);
+                channelMessage += processor.GetCompletionMessageWithStatusEffects(initProfile, recipProfile, toConsent.pendingInteraction.identifier, toConsent.pendingInteraction.type);
                 channelMessage += processor.GetAndClearRateLimitMessage();
             }
             else

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -82,7 +82,7 @@ namespace FChatDicebot.BotCommands
                 "!modmessage",
                 "!random",
                 "!feedback [sub]!suggestion[/sub]",
-                "!setmark",
+                "!seteicon",
                 "!help [sub]!commands[/sub]",
                 "!botinfo",
                 "!uptime"

--- a/FChatDicebot/BotCommands/ChateauSeteicon.cs
+++ b/FChatDicebot/BotCommands/ChateauSeteicon.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// <c>!seteicon {interaction} [eicon]YourEicon[/eicon]</c> — pin one of your own eicons to an
+    /// interaction, so it shows up on that interaction's completion message (the way Chateau
+    /// Contract has its own easter-egg icons). Global replacement for the old <c>!setmark</c>,
+    /// which now delegates to the same storage. See <see cref="InteractionEiconSupport"/>.
+    /// </summary>
+    public class ChateauSeteicon : ChatBotCommand
+    {
+        public ChateauSeteicon()
+        {
+            Name = "seteicon";
+            Aliases = new string[] { };
+            Category = "General";
+            ShortDescription = "Set your personal eicon for an interaction";
+            LongDescription = "Pin one of your own eicons to an interaction, the way Chateau Contract has its own little easter-egg icons. Once set, whenever you perform that interaction the onlookers will see your eicon alongside the result.\n\n"
+                + "Works for almost every interaction across the Casual, Involved, Commitment, and Consequence categories — for example !cuddle, !kiss, !spank, !mark, !corrupt, !pay, and more (but not system, recovery, or dicebot commands). For mutual interactions like !kiss, !cuddle, !handhold and !bond, both people's eicons show; for one-sided ones, only yours (the one performing it) does.\n\n"
+                + "Set one with !seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]. Leave the eicon off to clear it. Message !seteicon on its own to see everything you've set.";
+            Usage = "!seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]\nor\n!seteicon {interaction}   (to clear it)\nor\n!seteicon   (to list what you've set)";
+            RelatedCommands = new string[] { "setmark", "dossier" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, MessageAddress address, UserGeneratedCommand command)
+        {
+            string characterName = address.character;
+            Profile profile = MonDB.getProfile(characterName);
+            if (profile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(characterName), characterName);
+                return;
+            }
+
+            string token = terms != null && terms.Length > 0 ? terms[0] : null;
+
+            // Bare "!seteicon" -> list everything the resident has set.
+            if (string.IsNullOrEmpty(token))
+            {
+                bot.SendPrivateMessage(BuildListMessage(profile), characterName);
+                return;
+            }
+
+            if (!InteractionEiconSupport.TryResolveTokenToVerbKeys(token, out string[] verbKeys))
+            {
+                bot.SendPrivateMessage(
+                    "'" + token + "' isn't an interaction you can pin an eicon to. Try one like !cuddle, !kiss, or !spank. See !help seteicon for the full list.",
+                    characterName);
+                return;
+            }
+
+            // GetEIconFromCommandTerms returns null when no [eicon]...[/eicon] token is present.
+            string eicon = commandController.GetEIconFromCommandTerms(rawTerms);
+
+            // No eicon supplied -> clear it.
+            if (string.IsNullOrEmpty(eicon))
+            {
+                foreach (string verbKey in verbKeys)
+                {
+                    InteractionEiconSupport.ClearInteractionEicon(profile, verbKey);
+                }
+                MonDB.setProfile(characterName, profile);
+                bot.SendPrivateMessage(
+                    "Cleared, your " + token + " interactions won't show a personal eicon anymore.",
+                    characterName);
+                return;
+            }
+
+            if (eicon.Length > InteractionEiconSupport.MaxEiconLength)
+            {
+                bot.SendPrivateMessage("That icon name is way too long! Are you sure it's a real eicon?", characterName);
+                return;
+            }
+
+            foreach (string verbKey in verbKeys)
+            {
+                InteractionEiconSupport.SetInteractionEicon(profile, verbKey, eicon);
+            }
+            MonDB.setProfile(characterName, profile);
+
+            bot.SendPrivateMessage(
+                "Done! From now on, whenever you " + token + " someone, the onlookers will see " + eicon + ".",
+                characterName);
+        }
+
+        /// <summary>
+        /// DM readout of every interaction the resident has an eicon set for. Iterates the
+        /// canonical (alias-free) token list so aliases don't produce duplicate rows.
+        /// </summary>
+        private string BuildListMessage(Profile profile)
+        {
+            var lines = new List<string>();
+            foreach (string token in InteractionEiconSupport.CanonicalTokensInOrder)
+            {
+                if (!InteractionEiconSupport.TryResolveTokenToVerbKeys(token, out string[] verbKeys)) continue;
+                string eicon = verbKeys
+                    .Select(k => InteractionEiconSupport.GetInteractionEicon(profile, k))
+                    .FirstOrDefault(e => !string.IsNullOrEmpty(e));
+                if (string.IsNullOrEmpty(eicon)) continue;
+                lines.Add("[b]!" + token + "[/b]: " + eicon);
+            }
+
+            if (lines.Count == 0)
+            {
+                return "You haven't set any interaction eicons yet. Try something like !seteicon kiss [noparse][eicon]YourEicon[/eicon][/noparse]. See !help seteicon for the full list.";
+            }
+            return "Here are the interaction eicons you've set:\n" + string.Join("\n", lines);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauSetmark.cs
+++ b/FChatDicebot/BotCommands/ChateauSetmark.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FChatDicebot.BotCommands.Base;
+using FChatDicebot.InteractionProcessors;
 using FChatDicebot.SavedData;
 using Newtonsoft.Json;
 using FChatDicebot.DiceFunctions;
@@ -19,10 +20,10 @@ namespace FChatDicebot.BotCommands
             Name = "setmark";
             Aliases = new string[] { };
             Category = "General";
-            ShortDescription = "Set your personal mark eicon";
-            LongDescription = "Set or change your personal mark that will appear on those you have !mark'd. Marks must be a valid F-List eicon name. Once set, anyone you mark will display this icon in their dossier.";
-            Usage = "!setmark [noparse][eicon]YourMarkName[/eicon][/noparse]";
-            RelatedCommands = new string[] { "mark", "dossier" };
+            ShortDescription = "Set your personal mark eicon [sub](Legacy command, identical to !seteicon mark)[/sub]";
+            LongDescription = "[sub](Legacy command, identical to !seteicon mark, which now works for every other interaction too.)[/sub]\n\nSet or change your personal mark that will appear on those you have !mark'd. Marks must be a valid F-List eicon name. Once set, anyone you mark will display this icon in their dossier.";
+            Usage = "!setmark [noparse][eicon]YourMarkName[/eicon][/noparse]\n(or the newer !seteicon mark [noparse][eicon]YourMarkName[/eicon][/noparse])";
+            RelatedCommands = new string[] { "seteicon", "mark", "dossier" };
             CooldownDuration = null;
             CooldownAppliesTo = null;
             IdentifierCategory = null;
@@ -37,26 +38,26 @@ namespace FChatDicebot.BotCommands
             string characterName = address.character;
             string channel = address.channel;
             string mark = commandController.GetEIconFromCommandTerms(rawTerms);
-            Profile initiatorProfile = MonDB.getProfile(characterName);
-            Boolean valid = true;
-            if (mark.Length > 47)
+            Profile markProfile = MonDB.getProfile(characterName);
+            if (markProfile == null)
             {
-                string textTooLong = "That icon name is way too long! Are you sure it's a real EIcon?";
-                bot.SendPrivateMessage(textTooLong, characterName);
-                valid = false;
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(characterName), characterName);
+                return;
             }
-            if (valid)
+            if (mark != null && mark.Length > InteractionEiconSupport.MaxEiconLength)
             {
-                string message = "Mark successfully changed! From now on, anyone who has been marked by " + initiatorProfile.displayName + " will display " + mark + " as their mark in our records.";
-
-                
-                Profile markProfile = MonDB.getProfile(characterName);
-                markProfile.characteristics["mark"] = mark;
-                MonDB.setProfile(characterName, markProfile);
-                
-
-                bot.SendPrivateMessage(message, characterName);
+                bot.SendPrivateMessage("That icon name is way too long! Are you sure it's a real eicon?", characterName);
+                return;
             }
+
+            // Route through the shared !seteicon storage (writes characteristics["mark"], the
+            // slot the dossier + MarkProcessor already read) so both commands stay in sync.
+            InteractionEiconSupport.SetInteractionEicon(markProfile, InteractionEiconSupport.MarkVerbKey, mark);
+            MonDB.setProfile(characterName, markProfile);
+
+            string message = "Mark successfully changed! From now on, anyone who has been marked by " + markProfile.displayName + " will display " + mark + " as their mark in our records."
+                + "\n[sub]Heads up: !setmark still works, but !seteicon lets you set eicons for every interaction now, including mark![/sub]";
+            bot.SendPrivateMessage(message, characterName);
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
@@ -80,17 +80,13 @@ namespace FChatDicebot.InteractionProcessors.Casual
 
             string message = $"{initiatorProfile.displayName} and {recipientProfile.displayName} cuddle up together. {GetRandomDescriptor(cuddleDescriptors)}";
 
-            // Special handling for Queen Contract and The Corrupted Rin
-            if (initiatorProfile.userName == "Queen Contract" || recipientProfile.userName == "Queen Contract")
+            // Only the Queen Contract + Corrupted Rin combined icon stays hardcoded; the
+            // single-party Queen Contract cuddle icon now comes from her own !seteicon cuddle.
+            bool queenInvolved = initiatorProfile.userName == "Queen Contract" || recipientProfile.userName == "Queen Contract";
+            bool rinInvolved = initiatorProfile.userName == "The Corrupted Rin" || recipientProfile.userName == "The Corrupted Rin";
+            if (queenInvolved && rinInvolved)
             {
-                if (initiatorProfile.userName == "The Corrupted Rin" || recipientProfile.userName == "The Corrupted Rin")
-                {
-                    message += " [eicon]rin_lap[/eicon]";
-                }
-                else
-                {
-                    message += " [eicon]qchug[/eicon]";
-                }
+                message += " [eicon]rin_lap[/eicon]";
             }
 
             return message;
@@ -122,9 +118,11 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 || consentersInOrder.Any(p => p.userName == "Queen Contract");
             bool anyRin = initiatorProfile.userName == "The Corrupted Rin"
                 || consentersInOrder.Any(p => p.userName == "The Corrupted Rin");
-            if (anyQueen)
+            // Only the Queen Contract + Corrupted Rin combined icon stays hardcoded; the
+            // single-party Queen Contract cuddle icon now comes from her own !seteicon cuddle.
+            if (anyQueen && anyRin)
             {
-                message += anyRin ? " [eicon]rin_lap[/eicon]" : " [eicon]qchug[/eicon]";
+                message += " [eicon]rin_lap[/eicon]";
             }
 
             return message;

--- a/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
@@ -19,6 +19,9 @@ namespace FChatDicebot.InteractionProcessors.Casual
         // Symmetric group model: every participant gets +(M-1) "cuddle".
         public override GroupSpec GroupSpec => GroupSpec.Symmetric("cuddle");
 
+        // Mutual interaction: both cuddlers' custom !seteicon eicons show on the completion.
+        public override bool EiconAppliesToBothParties => true;
+
         /// <summary>
         /// Constructor for dependency injection (for testing)
         /// </summary>

--- a/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
@@ -16,6 +16,9 @@ namespace FChatDicebot.InteractionProcessors.Casual
         // Symmetric group model: every participant gets +(M-1) "handhold".
         public override GroupSpec GroupSpec => GroupSpec.Symmetric("handhold");
 
+        // Mutual interaction: both parties' custom !seteicon eicons show on the completion.
+        public override bool EiconAppliesToBothParties => true;
+
         private static readonly List<string> HandholdDescriptors = new List<string>
         {
             "Cute.",

--- a/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
@@ -20,6 +20,9 @@ namespace FChatDicebot.InteractionProcessors.Casual
         // Symmetric group model: every participant gets +(M-1) "kiss".
         public override GroupSpec GroupSpec => GroupSpec.Symmetric("kiss");
 
+        // Mutual interaction: both kissers' custom !seteicon eicons show on the completion.
+        public override bool EiconAppliesToBothParties => true;
+
         private static readonly List<string> KissDescriptors = new List<string>
         {
             "cute.",

--- a/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
@@ -68,11 +68,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
         {
             string message = $"Mwah! {initiatorProfile.displayName} and {recipientProfile.displayName} share a kiss, {GetRandomDescriptor(KissDescriptors)}";
 
-            // Special handling for Queen Contract (keeping your existing special case)
-            if (initiatorProfile.userName == "Queen Contract")
-            {
-                message += "[eicon]qckiss[/eicon]";
-            }
+            // (Queen Contract's kiss icon now comes from her own !seteicon kiss.)
 
             return message;
         }
@@ -86,10 +82,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             names.AddRange(consentersInOrder.Select(p => p.displayName));
             string message = $"Mwah! {JoinNamesSerial(names)} share a flurry of kisses, {GetRandomDescriptor(KissDescriptors)}";
 
-            if (initiatorProfile.userName == "Queen Contract")
-            {
-                message += "[eicon]qckiss[/eicon]";
-            }
+            // (Queen Contract's kiss icon now comes from her own !seteicon kiss.)
 
             return message;
         }

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -260,6 +260,27 @@ namespace FChatDicebot.InteractionProcessors.Casual
         }
 
         /// <summary>
+        /// Per-position custom eicons for a resolved lap stack. The bottom (position 0) is a
+        /// pure lap, so it shows their <c>!lap</c> eicon; everyone stacked above (middle riders
+        /// and the top) shows their <c>!sit</c> eicon — a mid-stack rider is doing both, and
+        /// the owner prefers the sit icon there. Rendered bottom -> top so the icons read in
+        /// stack order.
+        /// </summary>
+        public override string GetGroupEiconSuffix(string interactionVerb, Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder)
+        {
+            string verb = string.IsNullOrEmpty(interactionVerb) ? InteractionType : interactionVerb;
+            var stack = BuildStack(verb, initiatorProfile, consentersInOrder); // bottom -> top
+
+            var eicons = new List<string>();
+            for (int position = 0; position < stack.Count; position++)
+            {
+                string roleVerb = position == 0 ? LapType : SitType;
+                AddInteractionEicon(eicons, stack[position], roleVerb);
+            }
+            return JoinEiconSuffix(eicons);
+        }
+
+        /// <summary>
         /// Assemble the lap stack bottom -> top from the typed verb and the consenters in
         /// consent order. <c>!lap</c>: initiator is the bottom, consenters stack above in
         /// order. <c>!sit</c>: the first consenter claims the open bottom, the initiator sits

--- a/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
@@ -72,10 +72,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 .Replace("{lickgiver}", initiatorProfile.displayName)
                 .Replace("{licktaker}", recipientProfile.displayName);
 
-            if (initiatorProfile.userName == "Queen Contract")
-            {
-                descriptor += "[eicon]qctongue[/eicon]";
-            }
+            // (Queen Contract's lick icon now comes from her own !seteicon lick.)
 
             return $"{initiatorProfile.displayName} gives {recipientProfile.displayName} a slow lick. {descriptor}";
         }
@@ -91,10 +88,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
                 .Replace("{lickgiver}", initiatorProfile.displayName)
                 .Replace("{licktaker}", consentersInOrder[0].displayName);
 
-            if (initiatorProfile.userName == "Queen Contract")
-            {
-                descriptor += "[eicon]qctongue[/eicon]";
-            }
+            // (Queen Contract's lick icon now comes from her own !seteicon lick.)
 
             // Spec's directional example: "Alice licks Bob, Carol, and Dave. {descriptor}".
             string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());

--- a/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
@@ -13,6 +13,9 @@ namespace FChatDicebot.InteractionProcessors.Consequence
         public override string InteractionType => "bond";
         public override string InvestmentLevel => "commitment";
 
+        // Mutual interaction: both partners' custom !seteicon eicons show on the completion.
+        public override bool EiconAppliesToBothParties => true;
+
         public override CooldownSpec CooldownRule => Cooldown;
 
         public static readonly CooldownSpec Cooldown = new CooldownSpec

--- a/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
+++ b/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
@@ -149,6 +149,8 @@ namespace FChatDicebot.InteractionProcessors
             Profile initiatorProfile = database.GetProfile(initiator);
             var consenterProfiles = consenterNames.Select(database.GetProfile).ToList();
             string message = processor.GetGroupCompletionMessage(initiatorProfile, consenterProfiles, identifier);
+            // Custom !seteicon flourish (keyed to the typed verb), before the rate-limit sub-note.
+            message += processor.GetGroupEiconSuffix(type, initiatorProfile, consenterProfiles);
             if (!string.IsNullOrEmpty(rateLimitNote))
             {
                 message += rateLimitNote;

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -67,11 +67,24 @@ namespace FChatDicebot.InteractionProcessors
 
         /// <summary>
         /// Channel-bound entry point: returns <see cref="GetCompletionMessage"/> with any
-        /// active status-effect completion fragments appended. The consent pipeline calls
-        /// this so every interaction surfaces e.g. corruption auras / scent layers
-        /// uniformly without each processor having to wire it in itself.
+        /// active status-effect completion fragments appended, plus the initiator's (and, for
+        /// symmetric interactions, the recipient's) custom <c>!seteicon</c> flourish. The
+        /// consent pipeline calls this so every interaction surfaces e.g. corruption auras /
+        /// scent layers uniformly without each processor having to wire it in itself.
+        ///
+        /// <paramref name="interactionVerb"/> is the verb actually stamped on the pending
+        /// (e.g. "purify" vs "corrupt", "sit" vs "lap"), used to look up the right custom
+        /// eicon for shared-processor pairs. Null falls back to <see cref="InteractionType"/>.
         /// </summary>
-        string GetCompletionMessageWithStatusEffects(Profile initiatorProfile, Profile recipientProfile, string identifier);
+        string GetCompletionMessageWithStatusEffects(Profile initiatorProfile, Profile recipientProfile, string identifier, string interactionVerb = null);
+
+        /// <summary>
+        /// Custom <c>!seteicon</c> flourish for a resolved group moment, over the consenting
+        /// recipients in consent order. Default: the initiator's eicon (plus every consenter's
+        /// for symmetric interactions); lapsit overrides for its per-position rule. Returns a
+        /// leading-space-prefixed string, or empty when nobody involved has one set.
+        /// </summary>
+        string GetGroupEiconSuffix(string interactionVerb, Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder);
 
         /// <summary>
         /// Drain any out-of-band private note the processor wants delivered to the

--- a/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
@@ -1,0 +1,155 @@
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Single source of truth for the per-interaction custom eicon feature (<c>!seteicon</c>).
+    /// Residents pin one of their own eicons to an interaction — the way Chateau Contract has
+    /// its own little easter-egg icons — and it surfaces on that interaction's completion
+    /// message.
+    ///
+    /// Eicons are stored on <see cref="Profile.characteristics"/>, keyed by the interaction
+    /// <b>verb</b> that gets stamped on <see cref="Interaction.type"/> at completion time. That
+    /// keeps the storage key and the completion-time lookup in agreement, and lets
+    /// shared-processor pairs (corrupt/purify, climax/climaxfor, lap/sit) carry distinct icons
+    /// even though one processor backs both verbs.
+    ///
+    /// The <c>mark</c> eicon predates this system: it lives in <c>characteristics["mark"]</c>,
+    /// is surfaced in the dossier and by <c>MarkProcessor</c>'s own reveal, and is therefore
+    /// excluded from the generic completion suffix (see <see cref="IsSelfRendered"/>) so it is
+    /// never double-appended. <c>!seteicon mark</c> and the legacy <c>!setmark</c> both write
+    /// that same slot.
+    /// </summary>
+    public static class InteractionEiconSupport
+    {
+        /// <summary>Longest eicon token we accept, mirroring the legacy <c>!setmark</c> guard.</summary>
+        public const int MaxEiconLength = 47;
+
+        /// <summary>The verb whose eicon is stored/rendered specially (see class summary).</summary>
+        public const string MarkVerbKey = "mark";
+
+        // User-typed command token -> the interaction verb key(s) it reads/writes. Aliases fold
+        // onto their canonical verb (hug->cuddle, dress->dressup, hire->employ); !pay covers both
+        // payment directions. Every value here is a verb that appears on Interaction.type at
+        // completion time, so this map and the completion suffix stay in lockstep.
+        private static readonly Dictionary<string, string[]> TokenToVerbKeys =
+            new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Casual
+            { "boobhat", new[] { "boobhat" } },
+            { "bully", new[] { "bully" } },
+            { "cuddle", new[] { "cuddle" } },
+            { "hug", new[] { "cuddle" } },
+            { "handhold", new[] { "handhold" } },
+            { "kiss", new[] { "kiss" } },
+            { "lap", new[] { "lap" } },
+            { "sit", new[] { "sit" } },
+            { "lick", new[] { "lick" } },
+            { "spank", new[] { "spank" } },
+            // Involved
+            { "climax", new[] { "climax" } },
+            { "climaxfor", new[] { "climaxfor" } },
+            { "dressup", new[] { "dressup" } },
+            { "dress", new[] { "dressup" } },
+            { "feed", new[] { "feed" } },
+            { "golden", new[] { "golden" } },
+            { "milk", new[] { "milk" } },
+            { "pay", new[] { "paymentGive", "paymentReceive" } },
+            // Commitment
+            { "birth", new[] { "birth" } },
+            { "bond", new[] { "bond" } },
+            { "breed", new[] { "breed" } },
+            { "consume", new[] { "consume" } },
+            { "corrupt", new[] { "corrupt" } },
+            { "purify", new[] { "purify" } },
+            { "employ", new[] { "employ" } },
+            { "hire", new[] { "employ" } },
+            { "entitle", new[] { "entitle" } },
+            { "mark", new[] { "mark" } },
+            { "objectify", new[] { "objectify" } },
+            { "petrify", new[] { "petrify" } },
+            { "plant", new[] { "plant" } },
+            { "train", new[] { "train" } },
+            // Consequence
+            { "break", new[] { "break" } },
+            { "curse", new[] { "curse" } },
+            { "dose", new[] { "dose" } },
+            { "infest", new[] { "infest" } },
+            { "monsterize", new[] { "monsterize" } },
+            { "odorize", new[] { "odorize" } },
+            { "rename", new[] { "rename" } },
+        };
+
+        /// <summary>
+        /// Canonical, alias-free tokens in display order — used when listing what a resident has
+        /// set so aliases (hug/dress/hire) don't produce duplicate rows.
+        /// </summary>
+        public static readonly string[] CanonicalTokensInOrder = new[]
+        {
+            "boobhat", "bully", "cuddle", "handhold", "kiss", "lap", "sit", "lick", "spank",
+            "climax", "climaxfor", "dressup", "feed", "golden", "milk", "pay",
+            "birth", "bond", "breed", "consume", "corrupt", "purify", "employ", "entitle",
+            "mark", "objectify", "petrify", "plant", "train",
+            "break", "curse", "dose", "infest", "monsterize", "odorize", "rename",
+        };
+
+        /// <summary>
+        /// Resolve a user-typed command token (interaction name or alias) to the verb key(s) its
+        /// eicon is stored under. Returns false for anything not in the supported interaction set
+        /// (system / recovery / dice commands).
+        /// </summary>
+        public static bool TryResolveTokenToVerbKeys(string token, out string[] verbKeys)
+        {
+            if (!string.IsNullOrEmpty(token) && TokenToVerbKeys.TryGetValue(token.Trim(), out var keys))
+            {
+                verbKeys = keys;
+                return true;
+            }
+            verbKeys = null;
+            return false;
+        }
+
+        /// <summary>
+        /// True when this verb renders its own eicon and so must be skipped by the generic
+        /// completion suffix. Only <c>mark</c> qualifies (its reveal is woven into
+        /// <c>MarkProcessor</c>'s completion sentence and shown in the dossier).
+        /// </summary>
+        public static bool IsSelfRendered(string verbKey)
+        {
+            return string.Equals(verbKey, MarkVerbKey, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>Get a resident's stored eicon for the given verb, or empty string if unset.</summary>
+        public static string GetInteractionEicon(Profile profile, string verbKey)
+        {
+            if (profile?.characteristics == null || string.IsNullOrEmpty(verbKey)) return string.Empty;
+            return profile.characteristics.TryGetValue(StorageKey(verbKey), out var eicon) ? eicon : string.Empty;
+        }
+
+        /// <summary>Store a resident's eicon for the given verb (does not persist — caller saves).</summary>
+        public static void SetInteractionEicon(Profile profile, string verbKey, string eicon)
+        {
+            if (profile == null || string.IsNullOrEmpty(verbKey)) return;
+            if (profile.characteristics == null) profile.characteristics = new Dictionary<string, string>();
+            profile.characteristics[StorageKey(verbKey)] = eicon;
+        }
+
+        /// <summary>Remove a resident's eicon for the given verb (does not persist — caller saves).</summary>
+        public static void ClearInteractionEicon(Profile profile, string verbKey)
+        {
+            if (profile?.characteristics == null || string.IsNullOrEmpty(verbKey)) return;
+            profile.characteristics.Remove(StorageKey(verbKey));
+        }
+
+        // Mark keeps its historical characteristics["mark"] slot so the dossier + existing marks
+        // keep working unchanged; every other verb namespaces under "eicon_".
+        private static string StorageKey(string verbKey)
+        {
+            return string.Equals(verbKey, MarkVerbKey, StringComparison.OrdinalIgnoreCase)
+                ? MarkVerbKey
+                : "eicon_" + verbKey;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -160,7 +160,7 @@ namespace FChatDicebot.InteractionProcessors
         /// sentence to attach to.
         /// </summary>
         public string GetCompletionMessageWithStatusEffects(
-            Profile initiatorProfile, Profile recipientProfile, string identifier)
+            Profile initiatorProfile, Profile recipientProfile, string identifier, string interactionVerb = null)
         {
             string baseMessage = GetCompletionMessage(initiatorProfile, recipientProfile, identifier);
             if (string.IsNullOrEmpty(baseMessage)) return baseMessage;
@@ -172,7 +172,90 @@ namespace FChatDicebot.InteractionProcessors
                 initiatorProfile, recipientProfile, identifier);
 
             string withStatusFragments = AppendStatusFragments(baseMessage, effects.CompletionAppendix);
-            return AppendStatusFragments(withStatusFragments, postEffectFragments);
+            string withPostEffects = AppendStatusFragments(withStatusFragments, postEffectFragments);
+
+            // Custom per-interaction eicon (!seteicon), keyed to the verb actually typed so
+            // shared-processor pairs keep distinct icons. Appended last, as a trailing flourish.
+            return withPostEffects + BuildOneToOneEiconSuffix(interactionVerb, initiatorProfile, recipientProfile);
+        }
+
+        // ====================================================================
+        // Custom interaction eicons (!seteicon). The initiator's chosen eicon
+        // (and, for symmetric interactions, the recipient's) is appended to the
+        // completion message. See InteractionEiconSupport.
+        // ====================================================================
+
+        /// <summary>
+        /// Whether both parties' custom interaction eicons surface on the completion message.
+        /// Directional interactions (the default) show only the initiator's; symmetric,
+        /// co-equal interactions (cuddle, kiss, handhold, bond) override this to true so each
+        /// participant's eicon shows.
+        /// </summary>
+        public virtual bool EiconAppliesToBothParties => false;
+
+        /// <summary>
+        /// 1:1 custom-eicon flourish: the initiator's eicon for the typed verb, plus the
+        /// recipient's when <see cref="EiconAppliesToBothParties"/> and they're a different
+        /// person. Empty when nobody involved has one set, or for self-rendered verbs (mark).
+        /// </summary>
+        private string BuildOneToOneEiconSuffix(string interactionVerb, Profile initiatorProfile, Profile recipientProfile)
+        {
+            string verb = string.IsNullOrEmpty(interactionVerb) ? InteractionType : interactionVerb;
+            if (InteractionEiconSupport.IsSelfRendered(verb)) return string.Empty;
+
+            var eicons = new List<string>();
+            AddInteractionEicon(eicons, initiatorProfile, verb);
+            if (EiconAppliesToBothParties && !IsSameProfile(initiatorProfile, recipientProfile))
+            {
+                AddInteractionEicon(eicons, recipientProfile, verb);
+            }
+            return JoinEiconSuffix(eicons);
+        }
+
+        /// <summary>
+        /// Group custom-eicon flourish over the consenting recipients in consent order.
+        /// Default: the initiator's eicon (plus every consenter's for symmetric interactions).
+        /// Lapsit overrides for its per-position rule.
+        /// </summary>
+        public virtual string GetGroupEiconSuffix(string interactionVerb, Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder)
+        {
+            string verb = string.IsNullOrEmpty(interactionVerb) ? InteractionType : interactionVerb;
+            if (InteractionEiconSupport.IsSelfRendered(verb)) return string.Empty;
+
+            var eicons = new List<string>();
+            AddInteractionEicon(eicons, initiatorProfile, verb);
+            if (EiconAppliesToBothParties && consentersInOrder != null)
+            {
+                foreach (var consenter in consentersInOrder)
+                {
+                    AddInteractionEicon(eicons, consenter, verb);
+                }
+            }
+            return JoinEiconSuffix(eicons);
+        }
+
+        /// <summary>
+        /// Append a participant's stored eicon for <paramref name="verb"/> to the running list,
+        /// if they have one. Deliberately does NOT de-duplicate: if several participants picked
+        /// the same eicon, it shows once per participant (e.g. three lipstick marks on a kiss).
+        /// </summary>
+        protected static void AddInteractionEicon(List<string> into, Profile profile, string verb)
+        {
+            string eicon = InteractionEiconSupport.GetInteractionEicon(profile, verb);
+            if (!string.IsNullOrEmpty(eicon)) into.Add(eicon);
+        }
+
+        /// <summary>Join collected eicons into a leading-space-prefixed suffix (empty if none).</summary>
+        protected static string JoinEiconSuffix(List<string> eicons)
+        {
+            if (eicons == null || eicons.Count == 0) return string.Empty;
+            return " " + string.Join(" ", eicons);
+        }
+
+        private static bool IsSameProfile(Profile a, Profile b)
+        {
+            if (a == null || b == null) return false;
+            return ReferenceEquals(a, b) || string.Equals(a.userName, b.userName, StringComparison.Ordinal);
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -193,7 +193,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             // Intensify-only — vices not already present on freshInitiator are not created.
             ApplyClimaxAutoDose(initiator, freshInitiator);
 
-            return GetCompletionMessageWithStatusEffects(freshInitiator, freshInitiator, interaction.identifier);
+            return GetCompletionMessageWithStatusEffects(freshInitiator, freshInitiator, interaction.identifier, typeKey);
         }
 
         public override ValidationResult ValidateInteraction(string initiator, string recipient, string identifier)

--- a/wiki-docs/specs/Custom-Interaction-Eicons.md
+++ b/wiki-docs/specs/Custom-Interaction-Eicons.md
@@ -64,6 +64,15 @@ The group path ([`GroupInteractionResolver`](../../FChatDicebot/InteractionProce
 
 The F-List profile documentation (maintained externally) should likewise treat `!setmark` as legacy.
 
+## Queen Contract hardcoded-eicon migration
+
+The single-party Queen Contract easter-egg icons were removed from the processors so they can be re-set through `!seteicon` without double-printing:
+
+- **Removed** (now set via `!seteicon`): cuddle `qchug`, kiss `qckiss`, lick `qctongue` (each in both the 1:1 and group paths).
+- **Kept** (can't be expressed as a single resident's eicon): the Queen Contract + Corrupted Rin combined `rin_lap` in both `CuddleProcessor` and `LapsitProcessor`.
+- **Kept** — spank `qcass` is recipient-side (fires when Queen Contract is *spanked*), which the initiator-keyed `!seteicon` can't reproduce, so it stays hardcoded.
+- **Left as-is** — `MarkProcessor` still writes `characteristics["queenMark"]` on the recipient; it's an orphaned value (never displayed) and not a double-print risk, so it was out of scope for this change.
+
 ## `!birth` special-case
 
 `!birth` is a solo resolution with no consent pipeline, so it does not flow through the shared completion hook. The carrier's `birth` eicon is appended directly in `ChateauBirth.BuildCompletionMessage`.

--- a/wiki-docs/specs/Custom-Interaction-Eicons.md
+++ b/wiki-docs/specs/Custom-Interaction-Eicons.md
@@ -1,0 +1,101 @@
+# `!seteicon` — Custom Interaction Eicons
+
+Let residents pin one of their own F-List eicons to an interaction, the way Chateau Contract itself has little "easter-egg" icons on some interactions. Once set, the eicon is appended to that interaction's completion message. Global replacement for the old single-purpose `!setmark`.
+
+**Status:** Implemented.
+**Investment level:** N/A — cross-cutting cosmetic feature over every consent-based interaction (plus solo `!birth`).
+**Reversal:** N/A — clear an eicon by running `!seteicon {interaction}` with no eicon.
+**Depends on:** the completion pipeline in `InteractionProcessorBase.GetCompletionMessageWithStatusEffects` and `GroupInteractionResolver` (Group-Interactions).
+
+## Command syntax
+
+```
+!seteicon {interaction} [eicon]YourEicon[/eicon]   → set
+!seteicon {interaction}                            → clear
+!seteicon                                          → DM a list of everything you've set
+```
+
+`{interaction}` accepts every interaction command name across the Casual, Involved, Commitment, and Consequence categories, plus their aliases (`hug`, `dress`, `hire`). It does **not** accept system, recovery, or dicebot commands — those return a "not an interaction you can pin an eicon to" reply.
+
+## Storage model
+
+Eicons live on `Profile.characteristics`, keyed by the interaction **verb actually stamped on `Interaction.type`** at completion time (`"eicon_" + verb`). Keying on the resolved verb rather than the processor's canonical `InteractionType` is what lets shared-processor pairs carry distinct icons:
+
+| Pair (one processor) | Distinct eicon keys |
+|----------------------|---------------------|
+| `!corrupt` / `!purify` | `corrupt` vs `purify` (follows the *effective* direction, so `!corrupt -3` shows the purify eicon) |
+| `!climax` / `!climaxfor` | `climax` vs `climaxfor` |
+| `!lap` / `!sit` | `lap` vs `sit` |
+
+Aliases fold onto their canonical verb (`hug`→`cuddle`, `dress`→`dressup`, `hire`→`employ`). `!pay` writes **both** payment directions (`paymentGive` + `paymentReceive`) so it shows whether the resident is paying or billing.
+
+`mark` is special: it keeps its historical `characteristics["mark"]` slot (read by the dossier and `MarkProcessor`'s own reveal), so it is **excluded from the generic suffix** (`InteractionEiconSupport.IsSelfRendered`) to avoid a double icon.
+
+All storage/mapping lives in one place: [`InteractionEiconSupport`](../../FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs).
+
+## Whose eicon shows (directionality)
+
+Driven by `InteractionProcessorBase.EiconAppliesToBothParties`:
+
+- **Directional (default):** only the initiator's eicon shows (e.g. `!spank`, `!mark`, `!feed`, `!corrupt`).
+- **Symmetric:** both parties' eicons show. Overridden to `true` on the mutual, co-equal interactions: **`cuddle`, `kiss`, `handhold`, `bond`**.
+
+Self-interactions (e.g. solo `!climax`) collapse to a single eicon.
+
+## Group behavior
+
+The group path ([`GroupInteractionResolver`](../../FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs)) appends `GetGroupEiconSuffix` after the combined completion message:
+
+- Symmetric group casuals (`cuddle`/`kiss`/`handhold`): every participant who set an eicon shows it.
+- Directional group casuals (`spank`/`bully`/`lick`/`boobhat`): only the initiator's.
+- **No de-duplication:** if several participants picked the same eicon it shows once per participant (e.g. three lipstick marks on a group kiss).
+
+### Lap-stack per-position rule
+
+`LapsitProcessor` overrides `GetGroupEiconSuffix`: the bottom of the stack (position 0, a pure lap) shows their `lap` eicon; everyone stacked above — middle riders and the top — shows their `sit` eicon (a mid-stack rider is doing both, and we prefer the sit icon there). Rendered bottom → top.
+
+## `!mark` / `!setmark` refactor
+
+`!setmark` still works but is now a thin wrapper over the shared storage (`InteractionEiconSupport.SetInteractionEicon(profile, "mark", …)`), and:
+
+- It is removed from the public `!help` command list (kept reachable via `!help setmark`, whose text marks it legacy and points to `!seteicon mark`).
+- Its success message appends a one-line nudge toward `!seteicon`.
+- `!seteicon mark` is the canonical way to set a mark eicon and writes the same slot.
+
+The F-List profile documentation (maintained externally) should likewise treat `!setmark` as legacy.
+
+## `!birth` special-case
+
+`!birth` is a solo resolution with no consent pipeline, so it does not flow through the shared completion hook. The carrier's `birth` eicon is appended directly in `ChateauBirth.BuildCompletionMessage`.
+
+## Files
+
+New:
+
+- [`FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs`](../../FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs) — storage, token→verb-key mapping, self-rendered check.
+- [`FChatDicebot/BotCommands/ChateauSeteicon.cs`](../../FChatDicebot/BotCommands/ChateauSeteicon.cs) — the `!seteicon` command (set / clear / list).
+- [`FChatDicebot.Tests/Unit/Interactioneicontests.cs`](../../FChatDicebot.Tests/Unit/Interactioneicontests.cs) — 21 tests.
+
+Modified:
+
+- `InteractionProcessorBase.cs` — `EiconAppliesToBothParties`, 1:1 suffix appended in `GetCompletionMessageWithStatusEffects` (new optional `interactionVerb` param), virtual `GetGroupEiconSuffix`, shared helpers.
+- `IInteractionProcessor.cs` — `interactionVerb` param + `GetGroupEiconSuffix` on the interface.
+- `KissProcessor.cs`, `CuddleProcessor.cs`, `HandholdProcessor.cs`, `BondProcessor.cs` — `EiconAppliesToBothParties => true`.
+- `LapsitProcessor.cs` — per-position `GetGroupEiconSuffix` override.
+- `ChateauConsent.cs` — threads `pendingInteraction.type` (the verb) into the 1:1 completion.
+- `GroupInteractionResolver.cs` — appends the group eicon suffix.
+- `Involved/ClimaxforProcessor.cs` — threads the verb through the self-climax completion.
+- `ChateauSetmark.cs` — delegates to shared storage, legacy help text + deprecation nudge, lowercased "eicon".
+- `ChateauBirth.cs` — appends the carrier's birth eicon.
+- `ChateauHelp.cs` — swaps `!setmark` for `!seteicon` in the public command list.
+
+## Tests
+
+`Interactioneicontests.cs` covers: storage round-trip; mark's legacy slot; clear; token/alias/`pay` resolution and rejection of unsupported tokens; `IsSelfRendered`; directional (initiator-only) vs symmetric (both) suffix; no de-duplication; mark excluded from the suffix; the lap-stack per-position rule for both `!lap` and `!sit`; the 1:1 completion actually appending both symmetric eicons; and the birth special-case.
+
+## Decisions
+
+- **No de-dup** in groups — deliberate (see Group behavior).
+- **Bond counts as symmetric** — both partners become each other's bond, so both eicons show.
+- **`!setmark` kept but undocumented** rather than removed, to preserve muscle memory and existing wiki/profile references.
+- **Shared-processor pairs are context-aware** — keyed on the resolved verb, so each direction can carry its own icon.

--- a/wiki-docs/specs/README.md
+++ b/wiki-docs/specs/README.md
@@ -50,6 +50,12 @@ Design + as-implemented documentation for the Chateau Contract interaction syste
 |------|------|
 | [Feedback](Feedback.md) | `!feedback` (+ `!suggestion` alias) to submit an idea or bug report into a new `Feedback` collection, plus admin-only `!feedbacklist` to read recent submissions. |
 
+### Customization
+
+| Spec | Adds |
+|------|------|
+| [Custom-Interaction-Eicons](Custom-Interaction-Eicons.md) | `!seteicon {interaction} [eicon]…[/eicon]` to pin your own eicon to any interaction (shown on its completion message). Verb-keyed storage (`InteractionEiconSupport`), `EiconAppliesToBothParties` directionality, group + lap-stack rules, `!birth` special-case. Subsumes `!setmark` (now a legacy alias). |
+
 ## Upcoming features
 
 See [`Future-Interactions/README.md`](Future-Interactions/README.md) for the design specs of features that haven't shipped yet, organized by tier and dependency.


### PR DESCRIPTION
## What

Adds `!seteicon {interaction} [eicon]YourEicon[/eicon]` — residents pin one of their own eicons to an interaction, shown on that interaction's completion message (the way Chateau Contract has its own easter-egg icons). Works for every Casual / Involved / Commitment / Consequence interaction plus solo `!birth`; not system, recovery, or dicebot commands. Global replacement for the old single-purpose `!setmark`.

```
!seteicon kiss [eicon]lipstick[/eicon]   → set
!seteicon kiss                           → clear
!seteicon                                → DM a list of what you've set
```

## Design decisions (as agreed)

- **Whose eicon shows:** directional interactions show the initiator's only; **symmetric** ones (`cuddle`, `kiss`, `handhold`, `bond`) show both parties'. Driven by `EiconAppliesToBothParties`.
- **Groups:** all participants who set one show it, with **no de-duplication** (three identical kiss icons = three lipstick marks). Lap-stack: the base shows its `lap` eicon, riders (middle + top) show their `sit` eicon.
- **Context-aware pairs:** eicons are keyed on the verb actually stamped on `Interaction.type`, so shared-processor pairs stay distinct — `corrupt`≠`purify` (follows effective direction), `climax`≠`climaxfor`, `lap`≠`sit`. `pay` covers both payment directions.
- **`!setmark`:** kept working but delegates to the shared storage and is now an undocumented legacy command (removed from public `!help`, still reachable via `!help setmark` with a nudge). Mark keeps its `characteristics["mark"]` slot and inline reveal, and is excluded from the generic suffix to avoid a double icon.
- **`!birth`:** solo, so its eicon is appended directly in `ChateauBirth`.

## Implementation

- One SSOT helper `InteractionEiconSupport` (storage + token/alias mapping).
- Reveal appended once in `GetCompletionMessageWithStatusEffects` (1:1) and `GroupInteractionResolver` (groups); `GetGroupEiconSuffix` is virtual so `LapsitProcessor` can do its per-position rule.
- New optional `interactionVerb` param threaded through the completion hook from `ChateauConsent` and the self-climax path.

## Tests

21 new tests in `Interactioneicontests.cs` (storage/mapping, directionality, no-dedup, lap-stack per-position, mark exclusion, birth). **Full suite: 1457 passing, 0 failures.**

## Docs

As-implemented spec at `wiki-docs/specs/Custom-Interaction-Eicons.md`, indexed in `specs/README.md`. Note: the external F-List profile command list should also mark `!setmark` legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)