### PR TITLE
Share one eicon slot for !climax/!climaxfor and render the climaxer's

### DIFF
--- a/FChatDicebot.Tests/Unit/Interactioneicontests.cs
+++ b/FChatDicebot.Tests/Unit/Interactioneicontests.cs
@@ -3,6 +3,7 @@ using FChatDicebot.Database;
 using FChatDicebot.InteractionProcessors;
 using FChatDicebot.InteractionProcessors.Casual;
 using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.Involved;
 using FChatDicebot.Model;
 using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
@@ -88,6 +89,34 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         {
             Assert.True(InteractionEiconSupport.IsSelfRendered("mark"));
             Assert.False(InteractionEiconSupport.IsSelfRendered("kiss"));
+        }
+
+        // ---- climax / climaxfor share one stored slot ----
+
+        [Fact]
+        public void ClimaxAndClimaxfor_ShareOneStoredSlot()
+        {
+            var p = new ProfileBuilder().Build();
+
+            // Set under one verb, read back under both — they resolve to the same slot.
+            InteractionEiconSupport.SetInteractionEicon(p, "climaxfor", "[eicon]spray[/eicon]");
+            Assert.Equal("[eicon]spray[/eicon]", InteractionEiconSupport.GetInteractionEicon(p, "climax"));
+            Assert.Equal("[eicon]spray[/eicon]", InteractionEiconSupport.GetInteractionEicon(p, "climaxfor"));
+
+            // Overwriting from the other direction updates the same shared icon.
+            InteractionEiconSupport.SetInteractionEicon(p, "climax", "[eicon]drip[/eicon]");
+            Assert.Equal("[eicon]drip[/eicon]", InteractionEiconSupport.GetInteractionEicon(p, "climaxfor"));
+
+            // Clearing from either direction clears the shared icon.
+            InteractionEiconSupport.ClearInteractionEicon(p, "climaxfor");
+            Assert.Equal(string.Empty, InteractionEiconSupport.GetInteractionEicon(p, "climax"));
+        }
+
+        [Fact]
+        public void TryResolveTokenToVerbKeys_ClimaxforFoldsToClimax()
+        {
+            Assert.True(InteractionEiconSupport.TryResolveTokenToVerbKeys("climaxfor", out var keys));
+            Assert.Equal(new[] { "climax" }, keys);
         }
 
         // ---- Directionality of the completion suffix ----
@@ -185,6 +214,49 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             Assert.Contains("[eicon]aa[/eicon]", message);
             Assert.Contains("[eicon]bb[/eicon]", message);
+        }
+
+        // ---- Climax: the climaxer's eicon shows, whichever direction was typed ----
+
+        [Fact]
+        public void Climaxfor_ShowsInitiatorEicon_TheClimaxer()
+        {
+            // !climaxfor: the initiator is the one climaxing, so their icon shows.
+            var initiator = new ProfileBuilder()
+                .WithUserName("Alice").WithDisplayName("Alice")
+                .WithCharacteristic("eicon_climax", "[eicon]alicecum[/eicon]")
+                .BuildAndSave(_database);
+            var recipient = new ProfileBuilder()
+                .WithUserName("Bob").WithDisplayName("Bob")
+                .WithCharacteristic("eicon_climax", "[eicon]bobcum[/eicon]")
+                .BuildAndSave(_database);
+
+            string message = new ClimaxforProcessor(_database).GetCompletionMessageWithStatusEffects(
+                initiator, recipient, ClimaxforProcessor.ComposeIdentifier("climaxfor", 1), "climaxfor");
+
+            Assert.Contains("[eicon]alicecum[/eicon]", message);
+            Assert.DoesNotContain("[eicon]bobcum[/eicon]", message);
+        }
+
+        [Fact]
+        public void Climax_ShowsRecipientEicon_TheClimaxer()
+        {
+            // !climax: the recipient is the one made to climax, so THEIR icon shows —
+            // not the initiator's, even though the initiator typed the command.
+            var initiator = new ProfileBuilder()
+                .WithUserName("Alice").WithDisplayName("Alice")
+                .WithCharacteristic("eicon_climax", "[eicon]alicecum[/eicon]")
+                .BuildAndSave(_database);
+            var recipient = new ProfileBuilder()
+                .WithUserName("Bob").WithDisplayName("Bob")
+                .WithCharacteristic("eicon_climax", "[eicon]bobcum[/eicon]")
+                .BuildAndSave(_database);
+
+            string message = new ClimaxforProcessor(_database).GetCompletionMessageWithStatusEffects(
+                initiator, recipient, ClimaxforProcessor.ComposeIdentifier("climax", 1), "climax");
+
+            Assert.Contains("[eicon]bobcum[/eicon]", message);
+            Assert.DoesNotContain("[eicon]alicecum[/eicon]", message);
         }
 
         // ---- Birth special-case ----

--- a/FChatDicebot/BotCommands/ChateauSeteicon.cs
+++ b/FChatDicebot/BotCommands/ChateauSeteicon.cs
@@ -21,11 +21,10 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "General";
             ShortDescription = "Set your personal eicon for an interaction";
-            LongDescription = "Pin one of your own eicons to an interaction, the way Chateau Contract has its own little easter-egg icons. Once set, whenever you perform that interaction the onlookers will see your eicon alongside the result.\n\n"
-                + "Works for almost every interaction across the Casual, Involved, Commitment, and Consequence categories — for example !cuddle, !kiss, !spank, !mark, !corrupt, !pay, and more (but not system, recovery, or dicebot commands). For mutual interactions like !kiss, !cuddle, !handhold and !bond, both people's eicons show; for one-sided ones, only yours (the one performing it) does.\n\n"
+            LongDescription = "Set a special eicon to show for your interactions of the specified type. Once set, whenever you perform that interaction the onlookers will see your eicon alongside the result. For mutual interactions (!kiss, !cuddle, !handhold and !bond) and group interactions, all participants' eicons will show. For !climax and !climaxfor, the eicon for the one climaxing will show. For all other interactions, the initiator's eicon will show.\n\n"
                 + "Set one with !seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]. Leave the eicon off to clear it. Message !seteicon on its own to see everything you've set.";
             Usage = "!seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]\nor\n!seteicon {interaction}   (to clear it)\nor\n!seteicon   (to list what you've set)";
-            RelatedCommands = new string[] { "setmark", "dossier" };
+            RelatedCommands = new string[] { "dossier" };
             CooldownDuration = null;
             CooldownAppliesTo = null;
             IdentifierCategory = null;

--- a/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
@@ -12,9 +12,12 @@ namespace FChatDicebot.InteractionProcessors
     ///
     /// Eicons are stored on <see cref="Profile.characteristics"/>, keyed by the interaction
     /// <b>verb</b> that gets stamped on <see cref="Interaction.type"/> at completion time. That
-    /// keeps the storage key and the completion-time lookup in agreement, and lets
-    /// shared-processor pairs (corrupt/purify, climax/climaxfor, lap/sit) carry distinct icons
-    /// even though one processor backs both verbs.
+    /// keeps the storage key and the completion-time lookup in agreement, and lets most
+    /// shared-processor pairs (corrupt/purify, lap/sit) carry distinct icons even though one
+    /// processor backs both verbs. The one exception is <c>climax</c>/<c>climaxfor</c>: those
+    /// two verbs are the same act typed from opposite directions, so they deliberately share a
+    /// single stored slot (see <see cref="StorageKey"/>) — a resident sets their climax eicon
+    /// once and it renders whichever direction they use.
     ///
     /// The <c>mark</c> eicon predates this system: it lives in <c>characteristics["mark"]</c>,
     /// is surfaced in the dossier and by <c>MarkProcessor</c>'s own reveal, and is therefore
@@ -30,10 +33,18 @@ namespace FChatDicebot.InteractionProcessors
         /// <summary>The verb whose eicon is stored/rendered specially (see class summary).</summary>
         public const string MarkVerbKey = "mark";
 
+        /// <summary>
+        /// The two directional climax verbs. They fold onto <see cref="ClimaxVerbKey"/> for
+        /// storage so <c>!seteicon climax</c> and <c>!seteicon climaxfor</c> share one icon.
+        /// </summary>
+        public const string ClimaxVerbKey = "climax";
+        public const string ClimaxforVerbKey = "climaxfor";
+
         // User-typed command token -> the interaction verb key(s) it reads/writes. Aliases fold
-        // onto their canonical verb (hug->cuddle, dress->dressup, hire->employ); !pay covers both
-        // payment directions. Every value here is a verb that appears on Interaction.type at
-        // completion time, so this map and the completion suffix stay in lockstep.
+        // onto their canonical verb (hug->cuddle, dress->dressup, hire->employ, climaxfor->climax);
+        // !pay covers both payment directions. Every value here is a verb that appears on
+        // Interaction.type at completion time, so this map and the completion suffix stay in
+        // lockstep (climaxfor's completion read folds back via StorageKey normalization).
         private static readonly Dictionary<string, string[]> TokenToVerbKeys =
             new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
         {
@@ -50,7 +61,7 @@ namespace FChatDicebot.InteractionProcessors
             { "spank", new[] { "spank" } },
             // Involved
             { "climax", new[] { "climax" } },
-            { "climaxfor", new[] { "climaxfor" } },
+            { "climaxfor", new[] { "climax" } },
             { "dressup", new[] { "dressup" } },
             { "dress", new[] { "dressup" } },
             { "feed", new[] { "feed" } },
@@ -89,7 +100,7 @@ namespace FChatDicebot.InteractionProcessors
         public static readonly string[] CanonicalTokensInOrder = new[]
         {
             "boobhat", "bully", "cuddle", "handhold", "kiss", "lap", "sit", "lick", "spank",
-            "climax", "climaxfor", "dressup", "feed", "golden", "milk", "pay",
+            "climax", "dressup", "feed", "golden", "milk", "pay",
             "birth", "bond", "breed", "consume", "corrupt", "purify", "employ", "entitle",
             "mark", "objectify", "petrify", "plant", "train",
             "break", "curse", "dose", "infest", "monsterize", "odorize", "rename",
@@ -144,12 +155,23 @@ namespace FChatDicebot.InteractionProcessors
         }
 
         // Mark keeps its historical characteristics["mark"] slot so the dossier + existing marks
-        // keep working unchanged; every other verb namespaces under "eicon_".
+        // keep working unchanged; every other verb namespaces under "eicon_". climaxfor folds to
+        // climax first so both directions resolve to the same slot on every set/read/clear —
+        // this normalization is the single seam that keeps the two verbs sharing one icon,
+        // whether the verb arrives typed by the user or read raw off Interaction.type.
         private static string StorageKey(string verbKey)
         {
-            return string.Equals(verbKey, MarkVerbKey, StringComparison.OrdinalIgnoreCase)
+            string normalized = NormalizeVerbKey(verbKey);
+            return string.Equals(normalized, MarkVerbKey, StringComparison.OrdinalIgnoreCase)
                 ? MarkVerbKey
-                : "eicon_" + verbKey;
+                : "eicon_" + normalized;
+        }
+
+        private static string NormalizeVerbKey(string verbKey)
+        {
+            return string.Equals(verbKey, ClimaxforVerbKey, StringComparison.OrdinalIgnoreCase)
+                ? ClimaxVerbKey
+                : verbKey;
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -194,9 +194,22 @@ namespace FChatDicebot.InteractionProcessors
         public virtual bool EiconAppliesToBothParties => false;
 
         /// <summary>
-        /// 1:1 custom-eicon flourish: the initiator's eicon for the typed verb, plus the
-        /// recipient's when <see cref="EiconAppliesToBothParties"/> and they're a different
-        /// person. Empty when nobody involved has one set, or for self-rendered verbs (mark).
+        /// The party whose custom interaction eicon leads the 1:1 completion suffix — the one
+        /// who "performs" the interaction. Default: the initiator. Override when the acting
+        /// party is someone else (e.g. climax, where the climaxer — the recipient on
+        /// <c>!climax</c> — is the one whose eicon should show). Mirrors
+        /// <see cref="GetStatusEffectSubject"/>, which redirects status fragments the same way.
+        /// </summary>
+        protected virtual Profile GetEiconSubject(string interactionVerb, Profile initiatorProfile, Profile recipientProfile)
+        {
+            return initiatorProfile;
+        }
+
+        /// <summary>
+        /// 1:1 custom-eicon flourish: the acting party's eicon for the typed verb (see
+        /// <see cref="GetEiconSubject"/>), plus the other party's when
+        /// <see cref="EiconAppliesToBothParties"/> and they're a different person. Empty when
+        /// nobody involved has one set, or for self-rendered verbs (mark).
         /// </summary>
         private string BuildOneToOneEiconSuffix(string interactionVerb, Profile initiatorProfile, Profile recipientProfile)
         {
@@ -204,10 +217,12 @@ namespace FChatDicebot.InteractionProcessors
             if (InteractionEiconSupport.IsSelfRendered(verb)) return string.Empty;
 
             var eicons = new List<string>();
-            AddInteractionEicon(eicons, initiatorProfile, verb);
+            Profile primary = GetEiconSubject(verb, initiatorProfile, recipientProfile);
+            AddInteractionEicon(eicons, primary, verb);
             if (EiconAppliesToBothParties && !IsSameProfile(initiatorProfile, recipientProfile))
             {
-                AddInteractionEicon(eicons, recipientProfile, verb);
+                Profile other = IsSameProfile(primary, initiatorProfile) ? recipientProfile : initiatorProfile;
+                AddInteractionEicon(eicons, other, verb);
             }
             return JoinEiconSuffix(eicons);
         }

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -419,6 +419,26 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 : recipientProfile;
         }
 
+        /// <summary>
+        /// The custom <c>!seteicon</c> eicon on a climax belongs to the person who actually
+        /// climaxed — the initiator on <c>!climaxfor</c>, the recipient on <c>!climax</c> (the
+        /// inverted reskin). Self-targets resolve to the initiator either way. This is the same
+        /// redirection <see cref="GetStatusEffectSubject"/> makes for status fragments; the two
+        /// climax verbs also share a single stored eicon slot (see
+        /// <see cref="InteractionEiconSupport"/>), so the icon renders whichever direction the
+        /// climaxer set it from.
+        /// </summary>
+        protected override Profile GetEiconSubject(string interactionVerb, Profile initiatorProfile, Profile recipientProfile)
+        {
+            if (initiatorProfile == null || recipientProfile == null) return initiatorProfile;
+            return string.Equals(
+                ResolveClimaxer(interactionVerb, initiatorProfile.userName, recipientProfile.userName),
+                initiatorProfile.userName,
+                StringComparison.Ordinal)
+                ? initiatorProfile
+                : recipientProfile;
+        }
+
         public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             // Consent warnings are only emitted for non-self-target paths, so we can


### PR DESCRIPTION
## What

Two related fixes to the `!seteicon` custom-eicon feature for climax:

1. **`!seteicon climax` and `!seteicon climaxfor` now share one stored icon.** They are the same act typed from opposite directions, so a resident sets their climax eicon once and it renders whichever direction they use. The seam is storage-key normalization (`climaxfor` folds to `climax`), which keeps the set path (`!seteicon`) and the completion read (which uses the raw verb off `Interaction.type`) resolving to the same slot. `climaxfor` becomes a token alias of `climax` and drops from the canonical list so the `!seteicon` readout shows no duplicate row.

2. **The eicon that renders is the climaxer's, not the command-typer's.** A new `GetEiconSubject` hook on the base processor (default: the initiator, so no existing interaction changes) is overridden in `ClimaxforProcessor` to return the person actually climaxing via the existing `ResolveClimaxer` — the initiator on `!climaxfor`, the recipient on `!climax`. This mirrors how `GetStatusEffectSubject` already redirects status fragments.

## Also
- Refreshed the `!seteicon` help text to spell out the mutual / group / climax / default rules.
- Dropped the deprecated `!setmark` from `!seteicon`'s related commands.

## Tests
Added coverage in `Interactioneicontests.cs`: the shared-slot round-trip (set/overwrite/clear from either direction), the `climaxfor -> climax` alias resolution, and both completion directions (`!climaxfor` shows the initiator's eicon, `!climax` shows the recipient's). Full suite: 1461 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)