### PR TITLE
Render the group lap-stack eicons as a vertical totem pole

### DIFF
--- a/FChatDicebot.Tests/Unit/Interactioneicontests.cs
+++ b/FChatDicebot.Tests/Unit/Interactioneicontests.cs
@@ -176,8 +176,9 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string suffix = processor.GetGroupEiconSuffix("lap", initiator, new List<Profile> { c1, c2 });
 
-            // Bottom (initiator) uses their lap eicon; riders use their sit eicon.
-            Assert.Equal(" [eicon]LAP[/eicon] [eicon]C1SIT[/eicon] [eicon]C2SIT[/eicon]", suffix);
+            // Totem pole: one figure per line, topmost sitter (c2) first, bottom lap (initiator)
+            // last. Bottom uses their lap eicon; riders use their sit eicon.
+            Assert.Equal("\n[eicon]C2SIT[/eicon]\n[eicon]C1SIT[/eicon]\n[eicon]LAP[/eicon]", suffix);
         }
 
         [Fact]
@@ -191,8 +192,29 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string suffix = processor.GetGroupEiconSuffix("sit", initiator, new List<Profile> { c1, c2 });
 
-            // Bottom is c1 (their lap eicon); initiator + c2 ride (their sit eicons).
-            Assert.Equal(" [eicon]C1LAP[/eicon] [eicon]ISIT[/eicon] [eicon]C2SIT[/eicon]", suffix);
+            // Totem pole top -> bottom: topmost sitter c2, then initiator, then bottom lap c1
+            // (their lap eicon). One figure per line.
+            Assert.Equal("\n[eicon]C2SIT[/eicon]\n[eicon]ISIT[/eicon]\n[eicon]C1LAP[/eicon]", suffix);
+        }
+
+        [Fact]
+        public void LapsitGroupEiconSuffix_UnsetSlot_FallsBackToCharacterIcon()
+        {
+            // A participant with no eicon for their role still holds a slot in the pole via
+            // their character icon, so an unset middle rider can't collapse the stack.
+            var initiator = new ProfileBuilder()
+                .WithUserName("BottomChar")
+                .WithCharacteristic("eicon_lap", "[eicon]LAP[/eicon]")
+                .Build();
+            var c1 = new ProfileBuilder().WithUserName("MiddleChar").Build(); // no sit eicon set
+            var c2 = new ProfileBuilder().WithUserName("TopChar")
+                .WithCharacteristic("eicon_sit", "[eicon]C2SIT[/eicon]").Build();
+            var processor = new LapsitProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("lap", initiator, new List<Profile> { c1, c2 });
+
+            // Top -> bottom: c2's sit eicon, MiddleChar's fallback character icon, initiator's lap eicon.
+            Assert.Equal("\n[eicon]C2SIT[/eicon]\n[icon]MiddleChar[/icon]\n[eicon]LAP[/eicon]", suffix);
         }
 
         // ---- 1:1 completion path actually appends the eicon (symmetric shows both) ----

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -260,24 +260,47 @@ namespace FChatDicebot.InteractionProcessors.Casual
         }
 
         /// <summary>
-        /// Per-position custom eicons for a resolved lap stack. The bottom (position 0) is a
+        /// Per-position custom eicons for a resolved lap stack, rendered as a vertical "totem
+        /// pole" — one figure per line, topmost sitter first — so the icons read like the
+        /// physical stack (top of the pile sits on the top line). The bottom (position 0) is a
         /// pure lap, so it shows their <c>!lap</c> eicon; everyone stacked above (middle riders
-        /// and the top) shows their <c>!sit</c> eicon — a mid-stack rider is doing both, and
-        /// the owner prefers the sit icon there. Rendered bottom -> top so the icons read in
-        /// stack order.
+        /// and the top) shows their <c>!sit</c> eicon — a mid-stack rider is doing both, and the
+        /// owner prefers the sit icon there.
+        ///
+        /// Unlike every other group interaction, the lap stack fills empty slots: a participant
+        /// who hasn't set the relevant eicon falls back to their character icon
+        /// (<c>[icon]{userName}[/icon]</c>) so the pole always carries one figure per person and
+        /// the stack stays visually intact.
         /// </summary>
         public override string GetGroupEiconSuffix(string interactionVerb, Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder)
         {
             string verb = string.IsNullOrEmpty(interactionVerb) ? InteractionType : interactionVerb;
             var stack = BuildStack(verb, initiatorProfile, consentersInOrder); // bottom -> top
 
-            var eicons = new List<string>();
-            for (int position = 0; position < stack.Count; position++)
+            // Walk top -> bottom so the topmost sitter lands on the top line of the pole.
+            var figures = new List<string>();
+            for (int position = stack.Count - 1; position >= 0; position--)
             {
                 string roleVerb = position == 0 ? LapType : SitType;
-                AddInteractionEicon(eicons, stack[position], roleVerb);
+                figures.Add(GetStackFigure(stack[position], roleVerb));
             }
-            return JoinEiconSuffix(eicons);
+
+            if (figures.Count == 0) return string.Empty;
+            // One figure per line, stacked beneath the completion sentence.
+            return "\n" + string.Join("\n", figures);
+        }
+
+        /// <summary>
+        /// The totem figure for one stack member: their custom eicon for
+        /// <paramref name="roleVerb"/> if set, otherwise their F-List character icon so an unset
+        /// slot still holds the pole together. Mirrors <c>Utils.GetCharacterIconTags</c>; kept
+        /// inline to match this file's other literal tag flourishes (e.g. the rin_lap eicon).
+        /// </summary>
+        private static string GetStackFigure(Profile profile, string roleVerb)
+        {
+            string eicon = InteractionEiconSupport.GetInteractionEicon(profile, roleVerb);
+            if (!string.IsNullOrEmpty(eicon)) return eicon;
+            return "[icon]" + (profile?.userName ?? string.Empty) + "[/icon]";
         }
 
         /// <summary>

--- a/wiki-docs/specs/Custom-Interaction-Eicons.md
+++ b/wiki-docs/specs/Custom-Interaction-Eicons.md
@@ -50,9 +50,11 @@ The group path ([`GroupInteractionResolver`](../../FChatDicebot/InteractionProce
 - Directional group casuals (`spank`/`bully`/`lick`/`boobhat`): only the initiator's.
 - **No de-duplication:** if several participants picked the same eicon it shows once per participant (e.g. three lipstick marks on a group kiss).
 
-### Lap-stack per-position rule
+### Lap-stack per-position rule (totem pole)
 
-`LapsitProcessor` overrides `GetGroupEiconSuffix`: the bottom of the stack (position 0, a pure lap) shows their `lap` eicon; everyone stacked above — middle riders and the top — shows their `sit` eicon (a mid-stack rider is doing both, and we prefer the sit icon there). Rendered bottom → top.
+`LapsitProcessor` overrides `GetGroupEiconSuffix` and renders the stack as a vertical **totem pole** — one figure per line, topmost sitter first — so the icons read like the physical stack (top of the pile on the top line). The bottom of the stack (position 0, a pure lap) shows their `lap` eicon; everyone stacked above — middle riders and the top — shows their `sit` eicon (a mid-stack rider is doing both, and we prefer the sit icon there).
+
+Unlike every other group interaction, the lap stack **fills empty slots**: a participant who hasn't set the relevant eicon falls back to their character icon (`[icon]{userName}[/icon]`) so the pole always carries one figure per person and the stack stays visually intact. (This slot-filling is lap-stack-only; other group interactions still omit unset participants.)
 
 ## `!mark` / `!setmark` refactor
 
@@ -83,7 +85,7 @@ New:
 
 - [`FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs`](../../FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs) — storage, token→verb-key mapping, self-rendered check.
 - [`FChatDicebot/BotCommands/ChateauSeteicon.cs`](../../FChatDicebot/BotCommands/ChateauSeteicon.cs) — the `!seteicon` command (set / clear / list).
-- [`FChatDicebot.Tests/Unit/Interactioneicontests.cs`](../../FChatDicebot.Tests/Unit/Interactioneicontests.cs) — 21 tests.
+- [`FChatDicebot.Tests/Unit/Interactioneicontests.cs`](../../FChatDicebot.Tests/Unit/Interactioneicontests.cs) — 22 tests.
 
 Modified:
 
@@ -100,7 +102,7 @@ Modified:
 
 ## Tests
 
-`Interactioneicontests.cs` covers: storage round-trip; mark's legacy slot; clear; token/alias/`pay` resolution and rejection of unsupported tokens; `IsSelfRendered`; directional (initiator-only) vs symmetric (both) suffix; no de-duplication; mark excluded from the suffix; the lap-stack per-position rule for both `!lap` and `!sit`; the 1:1 completion actually appending both symmetric eicons; and the birth special-case.
+`Interactioneicontests.cs` covers: storage round-trip; mark's legacy slot; clear; token/alias/`pay` resolution and rejection of unsupported tokens; `IsSelfRendered`; directional (initiator-only) vs symmetric (both) suffix; no de-duplication; mark excluded from the suffix; the lap-stack per-position totem rule for both `!lap` and `!sit` (top → bottom, newline-separated) and its unset-slot character-icon fallback; the 1:1 completion actually appending both symmetric eicons; and the birth special-case.
 
 ## Decisions
 


### PR DESCRIPTION
## What

Builds on the recently shipped custom-interaction eicons (`!seteicon`, PR #52). Group `!lap` / `!sit` now render each participant's eicon as a vertical **totem pole** — one figure per line, topmost sitter first — so the icons read like the physical stack instead of a space-separated inline run.

## Details

- **Totem layout:** `LapsitProcessor.GetGroupEiconSuffix` now emits `\n`-separated figures, top → bottom (topmost sitter on the top line, bottom lap anchoring the base).
- **Unset-slot fallback:** a participant who hasn't set the relevant eicon falls back to their F-List character icon (`[icon]{userName}[/icon]`) so every position holds a figure and the stack can't visually collapse. This slot-filling is lap-stack-only.
- **Unchanged:** the per-position rule (bottom shows their `lap` eicon, riders show their `sit` eicon) and the count/title math.

## Scope

Only the multi-person group path (3+). A 2-person `!lap`/`!sit` uses the 1:1 completion path and stays inline.

## Example

Group `!lap` — Alice is the lap (lap eicon set), Bob rides (no sit eicon), Carol rides (sit eicon set):

```
Alice pulls Bob onto their lap. Then Carol takes a seat, forming a lap stack 3 people tall! Lap! Lap! Lap!
[eicon]carolsit[/eicon]
[icon]Bob[/icon]
[eicon]alicelap[/eicon]
```

## Tests

Updated the two lap-stack suffix tests to the new totem format and added `LapsitGroupEiconSuffix_UnsetSlot_FallsBackToCharacterIcon`. Spec doc updated. Build clean; 52 related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)