### PR TITLE
Add a web UI for authoring work duties + fix duty conditionals

### DIFF
--- a/FChatDicebot.Tests/Unit/Dutyconditionalsupporttests.cs
+++ b/FChatDicebot.Tests/Unit/Dutyconditionalsupporttests.cs
@@ -1,0 +1,102 @@
+using FChatDicebot.BotCommands.Support;
+using FChatDicebot.Model;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Unit tests for DutyConditionalSupport, the shared prefix+key parser behind the
+    /// duty-choice filtering in !work and !volunteer. Covers the formats present in the
+    /// live Duties collection ("none", "None", "jobadventurer", "trndeepthroat",
+    /// "monflight") plus the malformed shapes that used to crash or silently hide choices.
+    /// </summary>
+    public class DutyConditionalSupportTests
+    {
+        static Conditional C(string type, int value = 0)
+        {
+            return new Conditional { type = type, value = value };
+        }
+
+        // --- Kind: three-letter prefix, case-insensitive ---
+
+        [Theory]
+        [InlineData("none", "non")]
+        [InlineData("None", "non")]   // live data contains both casings
+        [InlineData("NONE", "non")]
+        [InlineData("jobadventurer", "job")]
+        [InlineData("Jobadventurer", "job")]
+        [InlineData("trndeepthroat", "trn")]
+        [InlineData("curgold", "cur")]
+        [InlineData("monflight", "mon")]
+        public void Kind_ParsesPrefixCaseInsensitively(string type, string expected)
+        {
+            Assert.Equal(expected, DutyConditionalSupport.Kind(C(type)));
+        }
+
+        [Fact]
+        public void Kind_NullConditional_IsUnconditional()
+        {
+            Assert.Equal("non", DutyConditionalSupport.Kind(null));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Kind_MissingType_IsUnconditional(string type)
+        {
+            Assert.Equal("non", DutyConditionalSupport.Kind(C(type)));
+        }
+
+        [Theory]
+        [InlineData("no")]
+        [InlineData("x")]
+        public void Kind_TypeShorterThanPrefix_MatchesNoKind(string type)
+        {
+            Assert.Equal("", DutyConditionalSupport.Kind(C(type)));
+        }
+
+        [Fact]
+        public void Kind_TrimsWhitespaceBeforeParsing()
+        {
+            Assert.Equal("job", DutyConditionalSupport.Kind(C("  jobmaid  ")));
+        }
+
+        // --- Key: everything after the prefix ---
+
+        [Theory]
+        [InlineData("jobadventurer", "adventurer")]
+        [InlineData("trndeepthroat", "deepthroat")]
+        [InlineData("curgold", "gold")]
+        [InlineData("monflight", "flight")]
+        [InlineData("  monflight  ", "flight")]
+        public void Key_ReturnsEverythingAfterThePrefix(string type, string expected)
+        {
+            Assert.Equal(expected, DutyConditionalSupport.Key(C(type)));
+        }
+
+        [Theory]
+        [InlineData("non")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void Key_NoKeyPortion_ReturnsEmpty(string type)
+        {
+            Assert.Equal("", DutyConditionalSupport.Key(C(type)));
+        }
+
+        [Fact]
+        public void Key_IsMechanicalAfterPrefix_OnlyMeaningfulForKeyedKinds()
+        {
+            // Key() blindly returns everything after the 3-char prefix; callers only
+            // consult it for job/trn/cur/mon kinds, so "none" yielding "e" is harmless.
+            Assert.Equal("e", DutyConditionalSupport.Key(C("none")));
+            Assert.Equal("non", DutyConditionalSupport.Kind(C("none")));
+        }
+
+        [Fact]
+        public void Key_NullConditional_ReturnsEmpty()
+        {
+            Assert.Equal("", DutyConditionalSupport.Key(null));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauVolunteer.cs
+++ b/FChatDicebot/BotCommands/ChateauVolunteer.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.Runtime.Documents;
 using FChatDicebot.BotCommands.Base;
+using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
@@ -41,7 +42,7 @@ namespace FChatDicebot.BotCommands
             // Check if duty is from previous day and clean it up
             if (dutyInProgress != null && dutyInProgress.startTime < DateTime.UtcNow.Date)
             {
-                MonDB.removePendingInteraction(dutyInProgress.Id);
+                MonDB.removePendingDuty(dutyInProgress.Id);
                 dutyInProgress = null;
                 message += ChateauInteractionHandler.dutyFromPreviousDayText() + " Enough about the past though. Let's see what volunteer opportunity awaits you today... \n\n";
             }
@@ -173,13 +174,14 @@ namespace FChatDicebot.BotCommands
                     message += duty.startText + "\n";
                     foreach (KeyValuePair<string, DutyResult> keyvaluepair in duty.dutyResults)
                     {
-                        switch (keyvaluepair.Value.conditional.type.Substring(0, 3))
+                        string conditionalKey = DutyConditionalSupport.Key(keyvaluepair.Value.conditional);
+                        switch (DutyConditionalSupport.Kind(keyvaluepair.Value.conditional))
                         {
                             case "non": //none
                                 validResults.Add(keyvaluepair.Value);
                                 break;
                             case "job": //job experience
-                                if (checkDictionaryConditional(keyvaluepair.Value.conditional.type, keyvaluepair.Value.conditional.value, userProfile.jobExperience))
+                                if (checkDictionaryConditional(conditionalKey, keyvaluepair.Value.conditional.value, userProfile.jobExperience))
                                 {
                                     validResults.Add(keyvaluepair.Value);
                                 }
@@ -187,14 +189,14 @@ namespace FChatDicebot.BotCommands
                             case "trn": //training
                                 if (userProfile.lists.ContainsKey("trainings"))
                                 {
-                                    if (userProfile.lists["trainings"].Contains(keyvaluepair.Value.conditional.type.Substring(3)))
+                                    if (userProfile.lists["trainings"].Contains(conditionalKey))
                                     {
                                         validResults.Add(keyvaluepair.Value);
                                     }
                                 }
                                 break;
                             case "cur": //currency
-                                if (checkDictionaryConditional(keyvaluepair.Value.conditional.type, keyvaluepair.Value.conditional.value, userProfile.currencies))
+                                if (checkDictionaryConditional(conditionalKey, keyvaluepair.Value.conditional.value, userProfile.currencies))
                                 {
                                     validResults.Add(keyvaluepair.Value);
                                 }
@@ -202,7 +204,7 @@ namespace FChatDicebot.BotCommands
                             case "mon": //monster/species trait or category
                                 if (userProfile.characteristics.ContainsKey("monster"))
                                 {
-                                    if (MonDB.getIdentifier(userProfile.characteristics["monster"]).categories.Contains<string>(keyvaluepair.Value.conditional.type.Substring(3)))
+                                    if (MonDB.getIdentifier(userProfile.characteristics["monster"]).categories.Contains<string>(conditionalKey))
                                     {
                                         validResults.Add(keyvaluepair.Value);
                                     }

--- a/FChatDicebot/BotCommands/ChateauWork.cs
+++ b/FChatDicebot/BotCommands/ChateauWork.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.Runtime.Documents;
 using FChatDicebot.BotCommands.Base;
+using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
@@ -40,9 +41,9 @@ namespace FChatDicebot.BotCommands
 
             if (dutyInProgress != null && dutyInProgress.startTime < DateTime.UtcNow.Date) //duty in progress but from previous day, remove it
             {
-                MonDB.removePendingInteraction(dutyInProgress.Id);
+                MonDB.removePendingDuty(dutyInProgress.Id);
                 dutyInProgress = null;
-                message += ChateauInteractionHandler.dutyFromPreviousDayText() + " Enough about the past though. Let's focus on your new task for today... \n\n"; 
+                message += ChateauInteractionHandler.dutyFromPreviousDayText() + " Enough about the past though. Let's focus on your new task for today... \n\n";
             }
 
             if (!userProfile.characteristics.ContainsKey("job")) //no job, can not work
@@ -195,13 +196,14 @@ namespace FChatDicebot.BotCommands
                 message += duty.startText + "\n";
                 foreach (KeyValuePair<string, DutyResult> keyvaluepair in duty.dutyResults)
                 {
-                    switch (keyvaluepair.Value.conditional.type.Substring(0, 3))
+                    string conditionalKey = DutyConditionalSupport.Key(keyvaluepair.Value.conditional);
+                    switch (DutyConditionalSupport.Kind(keyvaluepair.Value.conditional))
                     {
                         case "non": //none
                             validResults.Add(keyvaluepair.Value);
                             break;
                         case "job": //job experience
-                            if (checkDictionaryConditional(keyvaluepair.Value.conditional.type, keyvaluepair.Value.conditional.value, userProfile.jobExperience))
+                            if (checkDictionaryConditional(conditionalKey, keyvaluepair.Value.conditional.value, userProfile.jobExperience))
                             {
                                 validResults.Add(keyvaluepair.Value);
                             }
@@ -209,14 +211,14 @@ namespace FChatDicebot.BotCommands
                         case "trn": //training
                             if (userProfile.lists.ContainsKey("trainings"))
                             {
-                                if (userProfile.lists["trainings"].Contains(keyvaluepair.Value.conditional.type.Substring(3)))
+                                if (userProfile.lists["trainings"].Contains(conditionalKey))
                                 {
                                     validResults.Add(keyvaluepair.Value);
                                 }
                             }
                             break;
                         case "cur": //currency
-                            if (checkDictionaryConditional(keyvaluepair.Value.conditional.type, keyvaluepair.Value.conditional.value, userProfile.currencies))
+                            if (checkDictionaryConditional(conditionalKey, keyvaluepair.Value.conditional.value, userProfile.currencies))
                             {
                                 validResults.Add(keyvaluepair.Value);
                             }
@@ -224,7 +226,7 @@ namespace FChatDicebot.BotCommands
                         case "mon": //monster/species trait or category
                             if (userProfile.characteristics.ContainsKey("monster"))
                             {
-                                if (MonDB.getIdentifier(userProfile.characteristics["monster"]).categories.Contains<string>(keyvaluepair.Value.conditional.type.Substring(3)))
+                                if (MonDB.getIdentifier(userProfile.characteristics["monster"]).categories.Contains<string>(conditionalKey))
                                 {
                                     validResults.Add(keyvaluepair.Value);
                                 }

--- a/FChatDicebot/BotCommands/Support/DutyConditionalSupport.cs
+++ b/FChatDicebot/BotCommands/Support/DutyConditionalSupport.cs
@@ -1,0 +1,35 @@
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// Shared parsing for the authored duty-choice conditionals that !work and !volunteer
+    /// filter on. A conditional's type is a three-letter kind prefix followed by the key to
+    /// look up: "jobadventurer" (5+ adventurer experience via value), "trndeepthroat" (has
+    /// the training), "curgold" (holds value-or-more of that currency), "monflight" (species
+    /// identifier carries that category), or "none" (always available).
+    ///
+    /// The kind prefix is matched case-insensitively because live Duties documents contain
+    /// both "none" and "None". A null conditional or blank type counts as "none" — the model
+    /// requires every duty to keep at least one unconditional choice, and a malformed type
+    /// must never crash the duty roll or silently strip every choice from a player's day.
+    /// </summary>
+    public static class DutyConditionalSupport
+    {
+        public static string Kind(Conditional conditional)
+        {
+            string type = conditional == null || conditional.type == null ? "" : conditional.type.Trim();
+            if (type.Length == 0)
+                return "non";
+            if (type.Length < 3)
+                return "";
+            return type.Substring(0, 3).ToLowerInvariant();
+        }
+
+        public static string Key(Conditional conditional)
+        {
+            string type = conditional == null || conditional.type == null ? "" : conditional.type.Trim();
+            return type.Length > 3 ? type.Substring(3) : "";
+        }
+    }
+}

--- a/scripts/work-duty-builder/README.md
+++ b/scripts/work-duty-builder/README.md
@@ -1,0 +1,96 @@
+# Work Duty Builder
+
+A local web UI for authoring the `!work` / `!volunteer` duties that live in the bot's
+`ChateauDb.Duties` Mongo collection. List, create, edit, duplicate and delete duties
+with a live preview of exactly what the bot will PM — no hand-written BSON, no more
+spreadsheet round-trips.
+
+The bot queries the duty list fresh every time someone works, so anything you save
+here is live immediately. **No bot restart needed.**
+
+## Run it
+
+```powershell
+cd scripts\work-duty-builder
+.\run.ps1
+```
+
+That compiles the tiny helper server (first run only), starts it on
+`http://localhost:8788/`, and opens your browser. The server binds localhost only.
+(The Random Event Builder uses 8787, so both tools can run at the same time.)
+
+The page can also be opened as a plain file (or in an embedded preview panel) — it
+falls back to calling the API at `http://localhost:8788`, so it works anywhere as
+long as the helper server is running. If you see "Helper server not reachable",
+start `run.ps1` and reload.
+
+Prerequisite: the FChatDicebot solution must have been built (Debug) at least once —
+the helper borrows the bot's MongoDB driver DLLs and binding redirects.
+
+Options: `-Port 9000`, `-Db OtherDb`, `-Conn mongodb://...`, `-NoBrowser`,
+`-DllSource <path to FChatDicebot\bin\Debug>`.
+
+## Desktop shortcut / standalone deploy
+
+The built tool is fully standalone — `bin\` (exe + DLLs + config) plus `ui.html`
+next to it is everything. To run it outside the repo (e.g. from a desktop or
+taskbar shortcut that shouldn't break when branches/worktrees change):
+
+```powershell
+$deploy = "C:\BotData\DiceBot\tools\work-duty-builder"
+New-Item -ItemType Directory -Force "$deploy\bin" | Out-Null
+Copy-Item bin\* "$deploy\bin" -Force
+Copy-Item ui.html, README.md $deploy -Force
+```
+
+Then point a shortcut at `$deploy\bin\WorkDutyBuilder.exe` with arguments
+`--open` (starts the server and opens the browser; closing the console window
+stops it). Because the shortcut targets an exe, it can be pinned to the taskbar
+as its own app. Re-run the copy above after changing the tool in the repo.
+
+## What the fields mean
+
+| Field | Meaning |
+| --- | --- |
+| label | Unique id for the duty (used by this tool to address it) |
+| job | Which job rolls this duty. A job with several duties picks one at random per work day. `default` is the fallback set used when a job has no duties of its own |
+| categories | Stored on the document (queryable via GetDutiesByCategory) but not used for selection |
+| startText | PMed when the duty starts, followed by the numbered choice list. BBCode ok |
+| choices | Shown in order as `!w 1`, `!w 2`, ... (`!v N` for volunteers). Choices a player doesn't qualify for are hidden and later ones renumber |
+| result text | PMed when the player picks that choice, followed by the rolled reward |
+| rewards | ONE is rolled per completion, weighted by `weight`; the amount is rolled between `min` and `max` inclusive. No rewards = pure flavor |
+
+Completing any choice also grants +1 job experience for the duty's job and uses up
+the player's daily work (or volunteer) slot.
+
+## Choice conditionals
+
+Each choice is either always available or gated. In the stored document the gate is
+`conditional.type` = a three-letter kind + the key, with `value` as the threshold:
+
+| Kind | Stored as | Available when |
+| --- | --- | --- |
+| always | `none` | Everyone sees it |
+| job experience | `job` + job, e.g. `jobadventurer` | That job's experience ≥ value |
+| training | `trn` + training, e.g. `trndeepthroat` | Player has the training |
+| currency | `cur` + currency, e.g. `curgold` | Currency balance ≥ value |
+| species | `mon` + category, e.g. `monflight` | Player's species identifier carries that category |
+
+Every duty must keep at least one always-available choice (the server refuses to
+save otherwise) — a player who fails every conditional would otherwise get a duty
+with zero choices and lose the work day.
+
+Note: before 2026-07-12 the bot matched `job`/`cur` conditionals against the full
+prefixed string (so they never unlocked) and treated the kind prefix
+case-sensitively (so `None` hid the choice entirely). Both are fixed on the branch
+that added this tool; job/cur gates only start working once that bot build is
+deployed.
+
+## Safety notes
+
+- **Save writes to the live database.** The Export buttons (JSON / mongosh insert)
+  are there if you'd rather stage a duty elsewhere first.
+- Deleting asks for confirmation, but there is no undo.
+- Job, currency, training and species dropdowns are read live from the
+  `Identifiers` collection; unknown keys show a warning but are kept, since
+  identifiers may be seeded later.

--- a/scripts/work-duty-builder/run.ps1
+++ b/scripts/work-duty-builder/run.ps1
@@ -1,0 +1,64 @@
+# Builds (if needed) and starts the Work Duty Builder - a local web UI for authoring
+# documents in the bot's ChateauDb.Duties collection (the !work / !volunteer duties).
+#
+#   .\run.ps1                # build + start on http://localhost:8788 and open the browser
+#   .\run.ps1 -Port 9000
+#   .\run.ps1 -Db SomeOtherDb -NoBrowser
+#   .\run.ps1 -DllSource "C:\path\to\FChatDicebot\bin\Debug"   # where the Mongo DLLs come from
+#
+# Requires the bot to have been built at least once (Debug) so the MongoDB driver DLLs
+# exist; compiles server.cs with the .NET Framework C# compiler that ships with Windows.
+param(
+    [int]$Port = 8788,
+    [string]$Db = "ChateauDb",
+    [string]$Conn = "mongodb://localhost:27017",
+    [string]$DllSource = "",
+    [switch]$NoBrowser
+)
+
+$ErrorActionPreference = "Stop"
+$here = $PSScriptRoot
+$bin = Join-Path $here "bin"
+
+# Locate the bot's built DLLs: same checkout first, then the main checkout when this
+# script is being run from inside a .claude\worktrees\<name> worktree.
+if (-not $DllSource) {
+    $candidates = @(
+        (Join-Path $here "..\..\FChatDicebot\bin\Debug"),
+        (Join-Path $here "..\..\..\..\..\FChatDicebot\bin\Debug")
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path (Join-Path $c "MongoDB.Driver.dll")) { $DllSource = $c; break }
+    }
+    if (-not $DllSource) {
+        throw "Could not find MongoDB.Driver.dll - build the FChatDicebot solution (Debug) first, or pass -DllSource."
+    }
+}
+
+New-Item -ItemType Directory -Force $bin | Out-Null
+
+# Copy runtime dependencies (cheap; skips unchanged files).
+robocopy $DllSource $bin *.dll /XO /NJH /NJS /NDL /NC /NS /NP | Out-Null
+if ($LASTEXITCODE -ge 8) { throw "robocopy failed copying DLLs from $DllSource" }
+
+# The driver needs the bot's assembly binding redirects. Use the BUILD OUTPUT config
+# (App.config + the redirects msbuild auto-generates), not the bare source App.config.
+$appConfig = Join-Path $DllSource "FChatDicebot.exe.config"
+if (-not (Test-Path $appConfig)) { $appConfig = Join-Path $DllSource "..\..\App.config" }
+Copy-Item $appConfig (Join-Path $bin "WorkDutyBuilder.exe.config") -Force
+
+# Compile if the source is newer than the exe.
+$exe = Join-Path $bin "WorkDutyBuilder.exe"
+$src = Join-Path $here "server.cs"
+if (-not (Test-Path $exe) -or (Get-Item $src).LastWriteTime -gt (Get-Item $exe).LastWriteTime) {
+    $csc = "$env:windir\Microsoft.NET\Framework64\v4.0.30319\csc.exe"
+    if (-not (Test-Path $csc)) { $csc = "$env:windir\Microsoft.NET\Framework\v4.0.30319\csc.exe" }
+    Write-Host "Compiling server.cs ..."
+    $refs = @("MongoDB.Driver.dll", "MongoDB.Driver.Core.dll", "MongoDB.Bson.dll") |
+        ForEach-Object { "/r:" + (Join-Path $bin $_) }
+    & $csc /nologo "/out:$exe" @refs $src
+    if ($LASTEXITCODE -ne 0) { throw "csc failed" }
+}
+
+if (-not $NoBrowser) { Start-Process "http://localhost:$Port/" }
+& $exe --port $Port --db $Db --conn $Conn --ui (Join-Path $here "ui.html")

--- a/scripts/work-duty-builder/server.cs
+++ b/scripts/work-duty-builder/server.cs
@@ -1,0 +1,495 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.RegularExpressions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Driver;
+
+// Local authoring helper for the !work / !volunteer duty system. Serves ui.html and a
+// small REST API over the live Duties collection so duties can be listed, authored,
+// edited and deleted without hand-writing BSON. Localhost only; started via run.ps1.
+//
+// The UI exchanges duties in an editor-friendly shape (choices as an ordered array,
+// conditionals split into kind/key/value); Normalize() converts that into the exact
+// document shape ChateauWork deserializes (dutyResults and rewardList as keyed
+// subdocuments, conditional.type as the 3-letter prefix + key, e.g. "jobadventurer").
+//
+// Compiled with the .NET Framework 4 csc (C# 5) against the bot's own MongoDB driver
+// DLLs - keep the syntax C#-5-compatible (no string interpolation / ?. / out var).
+class WorkDutyBuilderServer
+{
+    // Mirrors the duty pickers' switch in ChateauWork/ChateauVolunteer (via
+    // DutyConditionalSupport): none = always shown, job = job experience >= value,
+    // trn = has the training, cur = holds >= value of the currency, mon = the player's
+    // species identifier carries the category.
+    static readonly string[] ConditionalKinds = new string[] { "none", "job", "trn", "cur", "mon" };
+
+    static IMongoDatabase _db;
+    static string _uiPath;
+
+    static void Main(string[] args)
+    {
+        string port = "8788";
+        string conn = "mongodb://localhost:27017";
+        string dbName = "ChateauDb";
+        bool openBrowser = false;
+        _uiPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "ui.html");
+        for (int i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--open") openBrowser = true;
+            if (i + 1 >= args.Length) continue;
+            if (args[i] == "--port") port = args[i + 1];
+            if (args[i] == "--conn") conn = args[i + 1];
+            if (args[i] == "--db") dbName = args[i + 1];
+            if (args[i] == "--ui") _uiPath = args[i + 1];
+        }
+
+        MongoClient client = new MongoClient(conn);
+        _db = client.GetDatabase(dbName);
+
+        HttpListener listener = new HttpListener();
+        string prefix = "http://localhost:" + port + "/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        Console.WriteLine("Work Duty Builder listening on " + prefix);
+        Console.WriteLine("  database: " + dbName + " @ " + conn);
+        Console.WriteLine("  ui file:  " + Path.GetFullPath(_uiPath));
+        Console.WriteLine("Press Ctrl+C to stop.");
+
+        // --open: launch the default browser once we're listening (used by the
+        // desktop-shortcut deployment, which runs this exe without run.ps1).
+        if (openBrowser)
+            System.Diagnostics.Process.Start(prefix);
+
+        while (true)
+        {
+            HttpListenerContext ctx = listener.GetContext();
+            try
+            {
+                Handle(ctx);
+            }
+            catch (Exception exc)
+            {
+                TryWrite(ctx, 500, "application/json", "{\"error\":" + JsonEscape(exc.Message) + "}");
+            }
+        }
+    }
+
+    static void Handle(HttpListenerContext ctx)
+    {
+        string method = ctx.Request.HttpMethod;
+        string path = ctx.Request.Url.AbsolutePath;
+
+        // CORS: lets the UI drive the API when ui.html is opened outside the server
+        // (file:// or an embedded preview panel). The listener only binds localhost and
+        // the data is a hobby bot's duty list, so a permissive policy is acceptable.
+        if (method == "OPTIONS")
+        {
+            Write(ctx, 200, "text/plain", "");
+            return;
+        }
+
+        if (method == "GET" && (path == "/" || path == "/index.html"))
+        {
+            Write(ctx, 200, "text/html; charset=utf-8", File.ReadAllText(_uiPath, Encoding.UTF8));
+            return;
+        }
+        if (method == "GET" && path == "/api/duties")
+        {
+            List<BsonDocument> docs = Duties().Find(new BsonDocument()).ToList();
+            docs.Sort(delegate(BsonDocument a, BsonDocument b)
+            {
+                int byJob = string.Compare(Str(a, "job"), Str(b, "job"), StringComparison.OrdinalIgnoreCase);
+                if (byJob != 0) return byJob;
+                return string.Compare(Str(a, "label"), Str(b, "label"), StringComparison.OrdinalIgnoreCase);
+            });
+            StringBuilder sb = new StringBuilder("[");
+            for (int i = 0; i < docs.Count; i++)
+            {
+                BsonDocument d = docs[i];
+                if (d.Contains("_id"))
+                    d["_id"] = d["_id"].ToString();
+                if (i > 0) sb.Append(",");
+                sb.Append(ToStrictJson(d));
+            }
+            sb.Append("]");
+            Write(ctx, 200, "application/json", sb.ToString());
+            return;
+        }
+        if (method == "GET" && path == "/api/catalogs")
+        {
+            BsonDocument catalogs = new BsonDocument
+            {
+                { "jobs", new BsonArray(IdentifierTypes("job")) },
+                { "currencies", new BsonArray(IdentifierTypes("currency")) },
+                { "trainings", new BsonArray(IdentifierTypes("training")) },
+                { "monsterCategories", new BsonArray(MonsterCategories()) },
+                { "conditionalKinds", new BsonArray(ConditionalKinds) },
+            };
+            Write(ctx, 200, "application/json", ToStrictJson(catalogs));
+            return;
+        }
+        if (method == "POST" && path == "/api/duties")
+        {
+            BsonDocument body = ReadBody(ctx);
+            string error;
+            BsonDocument doc = Normalize(body, out error);
+            if (error != null) { Fail(ctx, error); return; }
+            if (LabelExists(Str(doc, "label"), null)) { Fail(ctx, "A duty labeled \"" + Str(doc, "label") + "\" already exists."); return; }
+            Duties().InsertOne(doc);
+            Ok(ctx, "Inserted \"" + Str(doc, "label") + "\".");
+            return;
+        }
+        if ((method == "PUT" || method == "DELETE") && path.StartsWith("/api/duties/"))
+        {
+            string label = WebUtility.UrlDecode(path.Substring("/api/duties/".Length));
+            BsonDocument existing = Duties().Find(LabelFilter(label)).FirstOrDefault();
+            if (existing == null) { Fail(ctx, "No duty labeled \"" + label + "\"."); return; }
+
+            if (method == "DELETE")
+            {
+                Duties().DeleteOne(LabelFilter(label));
+                Ok(ctx, "Deleted \"" + label + "\".");
+                return;
+            }
+
+            BsonDocument body = ReadBody(ctx);
+            string error;
+            BsonDocument doc = Normalize(body, out error);
+            if (error != null) { Fail(ctx, error); return; }
+            // Renames are allowed as long as the new label doesn't collide with a
+            // different document.
+            if (LabelExists(Str(doc, "label"), existing["_id"])) { Fail(ctx, "Another duty is already labeled \"" + Str(doc, "label") + "\"."); return; }
+            doc.InsertAt(0, new BsonElement("_id", existing["_id"]));
+            Duties().ReplaceOne(LabelFilter(label), doc);
+            Ok(ctx, "Updated \"" + Str(doc, "label") + "\".");
+            return;
+        }
+
+        Write(ctx, 404, "application/json", "{\"error\":\"not found\"}");
+    }
+
+    // ============================ Validation / normalization ============================
+
+    // Rebuilds the incoming editor JSON as a clean document in the exact shape the bot's
+    // Duty model deserializes, or reports the first structural problem. The UI sends
+    // choices as an ordered array with split conditionals; this produces the keyed
+    // dutyResults/rewardList subdocuments (key order is what !work numbers choices by).
+    // Key-existence checks for job/currency/training/species keys are left to the UI as
+    // soft warnings (identifiers may be seeded later).
+    static BsonDocument Normalize(BsonDocument body, out string error)
+    {
+        error = null;
+
+        string label = Trimmed(body, "label");
+        if (string.IsNullOrEmpty(label)) { error = "label is required."; return null; }
+
+        // GetDutiesByJob is an exact match against the job identifier (lowercase), so
+        // normalize the authored casing rather than storing a duty no job can roll.
+        string job = Trimmed(body, "job");
+        if (string.IsNullOrEmpty(job)) { error = "job is required (\"default\" is the fallback set)."; return null; }
+        job = job.ToLowerInvariant();
+
+        string startText = Trimmed(body, "startText");
+        if (string.IsNullOrEmpty(startText)) { error = "startText is required."; return null; }
+
+        BsonArray categories = new BsonArray();
+        BsonValue rawCategories;
+        if (body.TryGetValue("categories", out rawCategories) && rawCategories.IsBsonArray)
+        {
+            foreach (BsonValue c in rawCategories.AsBsonArray)
+            {
+                if (c.IsString && c.AsString.Trim().Length > 0)
+                    categories.Add(c.AsString.Trim());
+            }
+        }
+
+        BsonValue rawChoices;
+        if (!body.TryGetValue("choices", out rawChoices) || !rawChoices.IsBsonArray || rawChoices.AsBsonArray.Count == 0)
+        {
+            error = "At least one choice is required.";
+            return null;
+        }
+
+        BsonDocument dutyResults = new BsonDocument();
+        bool hasUnconditional = false;
+        int choiceIndex = 0;
+        foreach (BsonValue rawChoice in rawChoices.AsBsonArray)
+        {
+            choiceIndex++;
+            if (!rawChoice.IsBsonDocument) { error = "Choice " + choiceIndex + " is not an object."; return null; }
+            BsonDocument c = rawChoice.AsBsonDocument;
+
+            string choiceName = Trimmed(c, "choiceName");
+            if (string.IsNullOrEmpty(choiceName)) { error = "Choice " + choiceIndex + ": choiceName is required."; return null; }
+
+            string resultText = Trimmed(c, "resultText");
+            if (string.IsNullOrEmpty(resultText)) { error = "Choice " + choiceIndex + " (\"" + choiceName + "\"): resultText is required."; return null; }
+
+            string kind = OrDefault(Trimmed(c, "conditionalKind"), "none");
+            if (!ContainsIgnoreCase(ConditionalKinds, kind)) { error = "Choice " + choiceIndex + ": conditionalKind must be one of: " + string.Join(", ", ConditionalKinds); return null; }
+            kind = Canonical(ConditionalKinds, kind);
+
+            string key = OrDefault(Trimmed(c, "conditionalKey"), "");
+            int value = Int(c, "conditionalValue", 0);
+            if (kind == "none")
+            {
+                hasUnconditional = true;
+                key = "";
+                value = 0;
+            }
+            else
+            {
+                if (key.Length == 0) { error = "Choice " + choiceIndex + ": the " + kind + " conditional needs a key (which job/training/currency/species tag)."; return null; }
+                if (value < 0) { error = "Choice " + choiceIndex + ": conditional value cannot be negative."; return null; }
+                if (kind == "trn" || kind == "mon")
+                    value = 0; // presence checks; the bot ignores value for these
+            }
+
+            BsonDocument rewardList = new BsonDocument();
+            BsonValue rawRewards;
+            if (c.TryGetValue("rewards", out rawRewards) && rawRewards.IsBsonArray)
+            {
+                int rewardIndex = 0;
+                foreach (BsonValue rawReward in rawRewards.AsBsonArray)
+                {
+                    rewardIndex++;
+                    string where = "Choice " + choiceIndex + " reward " + rewardIndex;
+                    if (!rawReward.IsBsonDocument) { error = where + " is not an object."; return null; }
+                    BsonDocument r = rawReward.AsBsonDocument;
+
+                    string currency = Trimmed(r, "currency");
+                    if (string.IsNullOrEmpty(currency)) { error = where + ": a currency is required."; return null; }
+
+                    // Zero-weight entries aren't "never": the roll's <= comparison can
+                    // still land on them, so refuse the ambiguity outright.
+                    int weight = Int(r, "weight", 1);
+                    if (weight < 1) { error = where + ": weight must be at least 1."; return null; }
+
+                    int min = Int(r, "min", 0);
+                    int max = Int(r, "max", 0);
+                    if (max < min) { int t = min; min = max; max = t; }
+
+                    rewardList[UniqueKey(rewardList, currency)] = new BsonDocument
+                    {
+                        { "currency", currency },
+                        { "weight", weight },
+                        { "min", min },
+                        { "max", max },
+                    };
+                }
+            }
+
+            dutyResults[UniqueKey(dutyResults, choiceName)] = new BsonDocument
+            {
+                { "choiceName", choiceName },
+                { "resultText", resultText },
+                { "conditional", new BsonDocument
+                    {
+                        { "type", kind == "none" ? "none" : kind + key },
+                        { "value", value },
+                    }
+                },
+                { "rewardList", rewardList },
+            };
+        }
+
+        if (!hasUnconditional)
+        {
+            // A player who matches none of the conditionals would receive a duty with no
+            // choices and a dead work day - the model requires an always-available choice.
+            error = "At least one choice must have no conditional (always available).";
+            return null;
+        }
+
+        return new BsonDocument
+        {
+            { "label", label },
+            { "categories", categories },
+            { "job", job },
+            { "startText", startText },
+            { "dutyResults", dutyResults },
+        };
+    }
+
+    // Subdocument field names come from authored text: strip the characters Mongo
+    // forbids in keys and suffix duplicates ("copper", "copper_2", ...).
+    static string UniqueKey(BsonDocument host, string desired)
+    {
+        string cleaned = (desired ?? "").Replace(".", "_").TrimStart('$').Trim();
+        if (cleaned.Length == 0) cleaned = "entry";
+        string candidate = cleaned;
+        int n = 2;
+        while (host.Contains(candidate))
+        {
+            candidate = cleaned + "_" + n;
+            n++;
+        }
+        return candidate;
+    }
+
+    // ============================ Mongo helpers ============================
+
+    static IMongoCollection<BsonDocument> Duties()
+    {
+        return _db.GetCollection<BsonDocument>("Duties");
+    }
+
+    static FilterDefinition<BsonDocument> LabelFilter(string label)
+    {
+        return Builders<BsonDocument>.Filter.Regex("label",
+            new BsonRegularExpression("^" + Regex.Escape(label) + "$", "i"));
+    }
+
+    static bool LabelExists(string label, BsonValue excludeId)
+    {
+        BsonDocument found = Duties().Find(LabelFilter(label)).FirstOrDefault();
+        if (found == null) return false;
+        if (excludeId != null && found["_id"].Equals(excludeId)) return false;
+        return true;
+    }
+
+    static List<string> IdentifierTypes(string category)
+    {
+        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.AnyEq("categories", category);
+        List<BsonDocument> docs = _db.GetCollection<BsonDocument>("Identifiers").Find(filter).ToList();
+        List<string> names = new List<string>();
+        foreach (BsonDocument d in docs)
+        {
+            string name = Str(d, "type");
+            if (!string.IsNullOrEmpty(name)) names.Add(name);
+        }
+        names.Sort(StringComparer.OrdinalIgnoreCase);
+        return names;
+    }
+
+    // The "mon" conditional matches against the categories of the player's species
+    // identifier, so offer the union of categories across identifiers tagged "monster"
+    // (minus the marker itself). The UI keeps free entry as a fallback.
+    static List<string> MonsterCategories()
+    {
+        FilterDefinition<BsonDocument> filter = Builders<BsonDocument>.Filter.AnyEq("categories", "monster");
+        List<BsonDocument> docs = _db.GetCollection<BsonDocument>("Identifiers").Find(filter).ToList();
+        SortedSet<string> categories = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (BsonDocument d in docs)
+        {
+            BsonValue c;
+            if (!d.TryGetValue("categories", out c) || !c.IsBsonArray) continue;
+            foreach (BsonValue v in c.AsBsonArray)
+            {
+                if (v.IsString && v.AsString.Trim().Length > 0 &&
+                    !string.Equals(v.AsString, "monster", StringComparison.OrdinalIgnoreCase))
+                    categories.Add(v.AsString.Trim());
+            }
+        }
+        return categories.ToList();
+    }
+
+    // ============================ Field helpers ============================
+
+    static string Str(BsonDocument d, string field)
+    {
+        BsonValue v;
+        return d.TryGetValue(field, out v) && v.IsString ? v.AsString : null;
+    }
+
+    static string Trimmed(BsonDocument d, string field)
+    {
+        string s = Str(d, field);
+        return s == null ? null : s.Trim();
+    }
+
+    static string OrDefault(string s, string fallback)
+    {
+        return string.IsNullOrEmpty(s) ? fallback : s;
+    }
+
+    static int Int(BsonDocument d, string field, int fallback)
+    {
+        BsonValue v;
+        if (!d.TryGetValue(field, out v)) return fallback;
+        if (v.IsInt32) return v.AsInt32;
+        if (v.IsInt64) return (int)v.AsInt64;
+        if (v.IsDouble) return (int)v.AsDouble;
+        if (v.IsString)
+        {
+            int parsed;
+            if (int.TryParse(v.AsString, out parsed)) return parsed;
+        }
+        return fallback;
+    }
+
+    static bool ContainsIgnoreCase(string[] values, string candidate)
+    {
+        return values.Any(delegate(string v) { return string.Equals(v, candidate, StringComparison.OrdinalIgnoreCase); });
+    }
+
+    static string Canonical(string[] values, string candidate)
+    {
+        return values.First(delegate(string v) { return string.Equals(v, candidate, StringComparison.OrdinalIgnoreCase); });
+    }
+
+    // ============================ HTTP helpers ============================
+
+    static BsonDocument ReadBody(HttpListenerContext ctx)
+    {
+        using (StreamReader reader = new StreamReader(ctx.Request.InputStream, Encoding.UTF8))
+        {
+            return BsonDocument.Parse(reader.ReadToEnd());
+        }
+    }
+
+    static string ToStrictJson(BsonDocument doc)
+    {
+        return doc.ToJson(new JsonWriterSettings { OutputMode = JsonOutputMode.Strict });
+    }
+
+    static void Ok(HttpListenerContext ctx, string message)
+    {
+        Write(ctx, 200, "application/json", "{\"ok\":true,\"message\":" + JsonEscape(message) + "}");
+    }
+
+    static void Fail(HttpListenerContext ctx, string message)
+    {
+        Write(ctx, 400, "application/json", "{\"error\":" + JsonEscape(message) + "}");
+    }
+
+    static void Write(HttpListenerContext ctx, int status, string contentType, string body)
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes(body);
+        ctx.Response.AddHeader("Access-Control-Allow-Origin", "*");
+        ctx.Response.AddHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+        ctx.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type");
+        ctx.Response.StatusCode = status;
+        ctx.Response.ContentType = contentType;
+        ctx.Response.ContentLength64 = bytes.Length;
+        ctx.Response.OutputStream.Write(bytes, 0, bytes.Length);
+        ctx.Response.OutputStream.Close();
+    }
+
+    static void TryWrite(HttpListenerContext ctx, int status, string contentType, string body)
+    {
+        try { Write(ctx, status, contentType, body); }
+        catch (Exception) { /* response already gone */ }
+    }
+
+    static string JsonEscape(string s)
+    {
+        StringBuilder sb = new StringBuilder("\"");
+        foreach (char c in s ?? "")
+        {
+            if (c == '"') sb.Append("\\\"");
+            else if (c == '\\') sb.Append("\\\\");
+            else if (c == '\n') sb.Append("\\n");
+            else if (c == '\r') sb.Append("\\r");
+            else if (c == '\t') sb.Append("\\t");
+            else if (c < ' ') sb.Append("\\u").Append(((int)c).ToString("x4"));
+            else sb.Append(c);
+        }
+        return sb.Append("\"").ToString();
+    }
+}

--- a/scripts/work-duty-builder/ui.html
+++ b/scripts/work-duty-builder/ui.html
@@ -1,0 +1,952 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Chateau Work Duty Builder</title>
+<style>
+  :root {
+    --bg: #17121c;
+    --panel: #211a2a;
+    --panel2: #2a2136;
+    --border: #3a2f4a;
+    --text: #e8e2ee;
+    --muted: #9d92ac;
+    --accent: #c9789a;
+    --accent2: #c9a227;
+    --danger: #d46a6a;
+    --ok: #7fbf8e;
+    --radius: 10px;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--text);
+    font: 14px/1.5 "Segoe UI", system-ui, sans-serif;
+  }
+  header {
+    display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap;
+    padding: 14px 20px; border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, #241b30, #1c1526);
+  }
+  header h1 { font: 600 19px Georgia, serif; margin: 0; color: var(--accent); letter-spacing: .5px; }
+  header .sub { color: var(--muted); font-size: 12.5px; }
+  header .spacer { flex: 1; }
+  .layout {
+    display: grid; grid-template-columns: 270px minmax(430px, 1fr) minmax(360px, 460px);
+    gap: 16px; padding: 16px 20px; align-items: start;
+  }
+  @media (max-width: 1200px) { .layout { grid-template-columns: 240px 1fr; } .previewCol { grid-column: 1 / -1; } }
+
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); }
+  .panel h2 {
+    font: 600 12px "Segoe UI", sans-serif; text-transform: uppercase; letter-spacing: 1.2px;
+    color: var(--muted); margin: 0; padding: 11px 14px; border-bottom: 1px solid var(--border);
+  }
+  .panel .body { padding: 13px 14px; }
+
+  /* ---- sidebar ---- */
+  #filterBox { width: 100%; margin-bottom: 6px; }
+  #dutyList { list-style: none; margin: 0; padding: 6px; max-height: 62vh; overflow-y: auto; }
+  #dutyList li {
+    padding: 7px 10px; border-radius: 7px; cursor: pointer; margin-bottom: 2px;
+    display: flex; justify-content: space-between; align-items: center; gap: 8px;
+  }
+  #dutyList li.jobHead {
+    cursor: default; padding: 8px 4px 2px; color: var(--accent2);
+    font-size: 11px; text-transform: uppercase; letter-spacing: 1px;
+  }
+  #dutyList li:not(.jobHead):hover { background: var(--panel2); }
+  #dutyList li.active { background: #3a2647; outline: 1px solid var(--accent); }
+  #dutyList .lbl { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .badge {
+    font-size: 10.5px; padding: 1px 7px; border-radius: 9px; flex-shrink: 0;
+    background: var(--panel2); color: var(--muted); border: 1px solid var(--border);
+  }
+
+  /* ---- form ---- */
+  .row { display: flex; gap: 12px; margin-bottom: 12px; flex-wrap: wrap; }
+  .field { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 120px; }
+  .field.grow2 { flex: 2.5; }
+  label { font-size: 11.5px; color: var(--muted); text-transform: uppercase; letter-spacing: .7px; }
+  input, select, textarea {
+    background: var(--bg); color: var(--text); border: 1px solid var(--border);
+    border-radius: 7px; padding: 7px 9px; font: inherit;
+  }
+  input:focus, select:focus, textarea:focus { outline: 1px solid var(--accent); border-color: var(--accent); }
+  textarea { resize: vertical; min-height: 74px; }
+  .hint { font-size: 12px; color: var(--muted); }
+  .hint b { color: var(--text); font-weight: 600; }
+  .chips { display: flex; gap: 6px; flex-wrap: wrap; margin-top: 5px; }
+  .chip {
+    font-size: 11.5px; font-family: Consolas, monospace; cursor: pointer;
+    background: var(--panel2); border: 1px solid var(--border); color: var(--accent2);
+    border-radius: 6px; padding: 2px 8px;
+  }
+  .chip:hover { border-color: var(--accent2); }
+
+  /* ---- choices ---- */
+  .choice {
+    border: 1px solid var(--border); border-radius: var(--radius);
+    background: var(--panel2); padding: 12px; margin-bottom: 12px;
+  }
+  .choice .head { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .choice .head .title { font-weight: 600; color: var(--accent); white-space: nowrap; }
+  .reward { display: flex; gap: 8px; align-items: flex-end; margin-bottom: 8px; flex-wrap: wrap; }
+  .reward .field { min-width: 90px; }
+  .reward .field.num { flex: 0 0 70px; }
+  .reward .odds { flex: 0 0 52px; font-size: 12px; color: var(--accent2); padding-bottom: 8px; text-align: right; }
+
+  button {
+    background: var(--panel2); color: var(--text); border: 1px solid var(--border);
+    border-radius: 7px; padding: 7px 14px; font: inherit; cursor: pointer;
+  }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: #5a2c46; border-color: var(--accent); font-weight: 600; }
+  button.primary:hover { background: #6d3655; }
+  button.danger { color: var(--danger); }
+  button.danger:hover { border-color: var(--danger); }
+  button.small { padding: 3px 9px; font-size: 12px; }
+  button:disabled { opacity: .4; cursor: default; }
+
+  .actions { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin-top: 4px; }
+  #status { font-size: 13px; }
+  #status.ok { color: var(--ok); }
+  #status.err { color: var(--danger); }
+  .warnings { margin: 10px 0 0; padding: 0 0 0 18px; color: #e8c477; font-size: 12.5px; }
+
+  /* ---- preview ---- */
+  .previewMsg {
+    background: #14101a; border: 1px solid var(--border); border-radius: 8px;
+    padding: 11px 13px; margin-bottom: 10px; font-size: 13.5px; word-wrap: break-word;
+  }
+  .previewMsg .from { color: var(--accent); font-weight: 600; margin-right: 6px; }
+  .previewMsg sub { opacity: .8; }
+  .previewCaption { font-size: 11.5px; color: var(--muted); text-transform: uppercase; letter-spacing: .8px; margin: 12px 0 5px; }
+  .previewCaption:first-child { margin-top: 0; }
+  .lockNote { color: var(--accent2); }
+  .oddsTable { font-size: 12px; color: var(--muted); margin: -4px 0 10px 4px; }
+  .oddsTable b { color: var(--text); }
+  pre.export {
+    background: #14101a; border: 1px solid var(--border); border-radius: 8px;
+    padding: 10px 12px; font: 12px Consolas, monospace; overflow-x: auto;
+    max-height: 260px; white-space: pre; color: #cfc6dd;
+  }
+  .muted { color: var(--muted); }
+  .divider { border: none; border-top: 1px solid var(--border); margin: 14px 0; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Chateau Work Duty Builder</h1>
+  <span class="sub">authoring UI for the <b>Duties</b> collection &middot; used by <b>!work</b> and <b>!volunteer</b> &middot; picked up live (no bot restart needed)</span>
+  <span class="spacer"></span>
+  <span class="sub" id="dbInfo"></span>
+</header>
+
+<div class="layout">
+
+  <!-- ==================== sidebar ==================== -->
+  <div class="panel">
+    <h2>Duties</h2>
+    <div class="body" style="padding-bottom:0">
+      <input id="filterBox" placeholder="filter by job or label...">
+    </div>
+    <ul id="dutyList"></ul>
+    <div class="body" style="border-top:1px solid var(--border)">
+      <button class="primary" style="width:100%" onclick="newDuty()">+ New duty</button>
+    </div>
+  </div>
+
+  <!-- ==================== form ==================== -->
+  <div class="panel">
+    <h2 id="formTitle">Duty</h2>
+    <div class="body" id="formBody" style="display:none">
+
+      <div class="row">
+        <div class="field grow2">
+          <label>Label (unique id)</label>
+          <input id="f_label" placeholder="e.g. PolishTheSilverware">
+        </div>
+        <div class="field">
+          <label>Job</label>
+          <input id="f_job" list="jobOptions" placeholder="maid">
+          <datalist id="jobOptions"></datalist>
+        </div>
+      </div>
+      <div class="hint" style="margin:-6px 0 12px">When a player with this job uses <b>!work</b> (or anyone uses <b>!volunteer</b> for it), one of the job's duties is rolled at random. Job <b>default</b> is the fallback when a job has no duties yet.</div>
+
+      <div class="row">
+        <div class="field grow2">
+          <label>Categories (comma-separated, optional)</label>
+          <input id="f_categories" placeholder="martial, mercantile, lewd">
+        </div>
+      </div>
+
+      <div class="field" style="margin-bottom:12px">
+        <label>Start text (sets the scene, then choices are listed) — BBCode ok</label>
+        <textarea id="f_start" placeholder="The head maid hands you a list of chores..."></textarea>
+        <div class="chips">
+          <span class="chip" onclick="insertAtCursor('f_start','[b][/b]')">[b]</span>
+          <span class="chip" onclick="insertAtCursor('f_start','[i][/i]')">[i]</span>
+          <span class="chip" onclick="insertAtCursor('f_start','[u][/u]')">[u]</span>
+          <span class="chip" onclick="insertAtCursor('f_start','[sub][/sub]')">[sub]</span>
+        </div>
+      </div>
+
+      <hr class="divider">
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:10px">
+        <b>Choices</b>
+        <span class="hint">shown in order as !w 1, !w 2, ... — one reward is rolled by weight</span>
+        <span style="flex:1"></span>
+        <button class="small" onclick="addChoice()">+ Add choice</button>
+      </div>
+      <div id="choices"></div>
+
+      <ul class="warnings" id="warnings"></ul>
+
+      <hr class="divider">
+      <div class="actions">
+        <button class="primary" onclick="save()">Save to database</button>
+        <button onclick="duplicateDuty()" id="btnDup">Duplicate</button>
+        <button class="danger" onclick="removeDuty()" id="btnDel">Delete</button>
+        <span id="status"></span>
+      </div>
+    </div>
+    <div class="body" id="formPlaceholder">
+      <span class="muted">Select a duty on the left, or create a new one.</span>
+    </div>
+  </div>
+
+  <!-- ==================== preview ==================== -->
+  <div class="panel previewCol">
+    <h2>Live preview</h2>
+    <div class="body" id="previewBody" style="display:none">
+      <div class="previewCaption">When they !work (PM from the bot)</div>
+      <div class="previewMsg" id="pv_start"></div>
+      <div class="hint" id="pv_numberNote" style="margin:-4px 0 4px"></div>
+      <div id="pv_choices"></div>
+      <hr class="divider">
+      <div class="previewCaption" style="display:flex;align-items:center;gap:8px">
+        Export
+        <button class="small" onclick="copyExport('json')">Copy JSON</button>
+        <button class="small" onclick="copyExport('mongosh')">Copy mongosh insert</button>
+      </div>
+      <pre class="export" id="pv_export"></pre>
+    </div>
+    <div class="body" id="previewPlaceholder"><span class="muted">Nothing to preview yet.</span></div>
+  </div>
+
+</div>
+
+<script>
+'use strict';
+
+// ============================ state ============================
+
+var catalogs = { jobs: [], currencies: [], trainings: [], monsterCategories: [], conditionalKinds: [] };
+var duties = [];
+var current = null;        // working copy being edited (editor shape: choices array)
+var originalLabel = null;  // label the doc had when loaded (null = brand new)
+
+var BOT_NAME = 'Chateau Contract';
+
+var KIND_LABELS = {
+  none: 'always — every player sees it',
+  job:  'job experience — needs N+ completions',
+  trn:  'training — needs the training',
+  cur:  'currency — needs N+ on hand',
+  mon:  'species — needs a species tag'
+};
+
+// ============================ boot ============================
+
+// When this file is opened directly (file:// or an embedded preview panel) there is
+// no http origin to resolve relative URLs against, so talk to the helper server at
+// its default address instead. Served normally, same-origin relative paths are used.
+var API = (location.protocol === 'http:' || location.protocol === 'https:') && location.host
+  ? '' : 'http://localhost:8788';
+
+Promise.all([
+  fetch(API + '/api/catalogs').then(function (r) { return r.json(); }),
+  fetch(API + '/api/duties').then(function (r) { return r.json(); })
+]).then(function (results) {
+  catalogs = results[0];
+  duties = results[1];
+  var dl = document.getElementById('jobOptions');
+  ['default'].concat(catalogs.jobs || []).forEach(function (j) {
+    var op = document.createElement('option');
+    op.value = j;
+    dl.appendChild(op);
+  });
+  updateDbInfo();
+  renderList();
+}).catch(function () {
+  document.getElementById('dbInfo').textContent =
+    'Helper server not reachable - start it with scripts\\work-duty-builder\\run.ps1, then open http://localhost:8788/ (or reload this panel).';
+});
+
+function updateDbInfo() {
+  document.getElementById('dbInfo').textContent =
+    duties.length + ' dut' + (duties.length === 1 ? 'y' : 'ies') + ' in collection';
+}
+
+function reloadDuties() {
+  return fetch(API + '/api/duties').then(function (r) { return r.json(); }).then(function (list) {
+    duties = list;
+    updateDbInfo();
+    renderList();
+  });
+}
+
+// ============================ db shape <-> editor shape ============================
+
+// The DB stores choices/rewards as keyed subdocuments; the editor uses ordered arrays.
+// JS object key order preserves the document's field order, which is exactly the order
+// !work numbers choices in.
+function toEditor(doc) {
+  var choices = [];
+  Object.keys(doc.dutyResults || {}).forEach(function (k) {
+    var r = doc.dutyResults[k] || {};
+    var cond = r.conditional || {};
+    var type = (cond.type == null ? '' : String(cond.type)).trim();
+    var kind = 'none', key = '';
+    if (type.length >= 3) {
+      var prefix = type.slice(0, 3).toLowerCase();
+      if (prefix === 'non') { kind = 'none'; }
+      else if (['job', 'trn', 'cur', 'mon'].indexOf(prefix) >= 0) { kind = prefix; key = type.slice(3); }
+      else { kind = 'none'; key = ''; choicesWarn(r.choiceName || k, type); }
+    }
+    var rewards = [];
+    Object.keys(r.rewardList || {}).forEach(function (rk) {
+      var rw = r.rewardList[rk] || {};
+      rewards.push({
+        currency: rw.currency || rk,
+        weight: rw.weight == null ? 1 : rw.weight,
+        min: rw.min == null ? 0 : rw.min,
+        max: rw.max == null ? 0 : rw.max
+      });
+    });
+    choices.push({
+      choiceName: r.choiceName || k,
+      resultText: r.resultText || '',
+      conditionalKind: kind,
+      conditionalKey: key,
+      conditionalValue: cond.value == null ? 0 : cond.value,
+      rewards: rewards
+    });
+  });
+  return {
+    label: doc.label || '',
+    job: doc.job || '',
+    categories: doc.categories || [],
+    startText: doc.startText || '',
+    choices: choices
+  };
+}
+
+var loadWarnings = [];
+function choicesWarn(name, type) {
+  loadWarnings.push('Choice "' + name + '" had unrecognized conditional "' + type +
+    '" - it was loaded as "always"; saving will store it that way.');
+}
+
+// What the server will write: the exact Duty document shape the bot deserializes.
+// Mirrored here so the export pane shows real DB documents.
+function toDbShape(ed) {
+  var dutyResults = {};
+  ed.choices.forEach(function (c) {
+    var rewardList = {};
+    (c.rewards || []).forEach(function (r) {
+      var key = uniqueKey(rewardList, r.currency || 'entry');
+      rewardList[key] = { currency: r.currency, weight: r.weight, min: r.min, max: r.max };
+    });
+    var key = uniqueKey(dutyResults, c.choiceName || 'entry');
+    dutyResults[key] = {
+      choiceName: c.choiceName,
+      resultText: c.resultText,
+      conditional: {
+        type: c.conditionalKind === 'none' ? 'none' : c.conditionalKind + c.conditionalKey,
+        value: (c.conditionalKind === 'job' || c.conditionalKind === 'cur') ? (c.conditionalValue || 0) : 0
+      },
+      rewardList: rewardList
+    };
+  });
+  return {
+    label: ed.label,
+    categories: ed.categories,
+    job: (ed.job || '').toLowerCase(),
+    startText: ed.startText,
+    dutyResults: dutyResults
+  };
+}
+
+function uniqueKey(host, desired) {
+  var cleaned = String(desired).replace(/\./g, '_').replace(/^\$+/, '').trim() || 'entry';
+  var candidate = cleaned, n = 2;
+  while (Object.prototype.hasOwnProperty.call(host, candidate)) { candidate = cleaned + '_' + n; n++; }
+  return candidate;
+}
+
+// ============================ sidebar ============================
+
+function renderList() {
+  var ul = document.getElementById('dutyList');
+  var filter = document.getElementById('filterBox').value.trim().toLowerCase();
+  ul.innerHTML = '';
+  var lastJob = null;
+  var shown = 0;
+  duties.forEach(function (d) {
+    var hay = (d.job + ' ' + d.label).toLowerCase();
+    if (filter && hay.indexOf(filter) < 0) return;
+    shown++;
+    if (d.job !== lastJob) {
+      lastJob = d.job;
+      var head = document.createElement('li');
+      head.className = 'jobHead';
+      head.textContent = d.job;
+      ul.appendChild(head);
+    }
+    var li = document.createElement('li');
+    if (originalLabel && d.label === originalLabel) li.className = 'active';
+    var lbl = document.createElement('span');
+    lbl.className = 'lbl';
+    lbl.textContent = d.label;
+    var badge = document.createElement('span');
+    badge.className = 'badge';
+    var n = Object.keys(d.dutyResults || {}).length;
+    badge.textContent = n + (n === 1 ? ' choice' : ' choices');
+    li.appendChild(lbl); li.appendChild(badge);
+    li.onclick = function () { selectDuty(d.label); };
+    ul.appendChild(li);
+  });
+  if (!shown) {
+    var empty = document.createElement('li');
+    empty.innerHTML = '<span class="muted" style="padding:0 4px">' + (filter ? 'No matches.' : 'No duties yet.') + '</span>';
+    empty.style.cursor = 'default';
+    ul.appendChild(empty);
+  }
+}
+
+document.getElementById('filterBox').addEventListener('input', renderList);
+
+function selectDuty(label) {
+  var d = duties.filter(function (x) { return x.label === label; })[0];
+  if (!d) return;
+  loadWarnings = [];
+  current = toEditor(JSON.parse(JSON.stringify(d)));
+  originalLabel = d.label;
+  loadForm();
+}
+
+function newDuty() {
+  loadWarnings = [];
+  current = {
+    label: '', job: '', categories: [], startText: '',
+    choices: [blankChoice()]
+  };
+  originalLabel = null;
+  loadForm();
+}
+
+function blankChoice() {
+  return { choiceName: '', resultText: '', conditionalKind: 'none', conditionalKey: '', conditionalValue: 0, rewards: [] };
+}
+
+function duplicateDuty() {
+  if (!current) return;
+  current = collect();
+  current.label = current.label + '_copy';
+  originalLabel = null;
+  loadForm();
+  setStatus('Editing a copy — save to insert it as a new duty.', 'ok');
+}
+
+// ============================ form ============================
+
+function loadForm() {
+  document.getElementById('formBody').style.display = '';
+  document.getElementById('formPlaceholder').style.display = 'none';
+  document.getElementById('previewBody').style.display = '';
+  document.getElementById('previewPlaceholder').style.display = 'none';
+  document.getElementById('formTitle').textContent =
+    originalLabel ? 'Edit: ' + originalLabel : 'New duty';
+  document.getElementById('btnDel').style.display = originalLabel ? '' : 'none';
+  document.getElementById('btnDup').style.display = originalLabel ? '' : 'none';
+
+  setVal('f_label', current.label);
+  setVal('f_job', current.job);
+  setVal('f_categories', (current.categories || []).join(', '));
+  setVal('f_start', current.startText);
+  renderChoices();
+  refresh();
+  setStatus('', '');
+  renderList();
+}
+
+function setVal(id, v) { document.getElementById(id).value = v == null ? '' : v; }
+
+['f_label', 'f_job', 'f_categories', 'f_start'].forEach(function (id) {
+  document.getElementById(id).addEventListener('input', refresh);
+});
+
+function collect() {
+  return {
+    label: document.getElementById('f_label').value.trim(),
+    job: document.getElementById('f_job').value.trim(),
+    categories: document.getElementById('f_categories').value
+      .split(',').map(function (s) { return s.trim(); }).filter(Boolean),
+    startText: document.getElementById('f_start').value.trim(),
+    choices: current.choices
+  };
+}
+
+function insertAtCursor(id, text) {
+  var el = document.getElementById(id);
+  var start = el.selectionStart, end = el.selectionEnd;
+  el.value = el.value.slice(0, start) + text + el.value.slice(end);
+  var pos = text.indexOf('[/') > 0 ? start + text.indexOf('[/') : start + text.length;
+  el.focus(); el.setSelectionRange(pos, pos);
+  refresh();
+}
+
+// ============================ choices ============================
+
+function addChoice() {
+  current.choices.push(blankChoice());
+  renderChoices(); refresh();
+}
+
+function renderChoices() {
+  var host = document.getElementById('choices');
+  host.innerHTML = '';
+  current.choices.forEach(function (c, ci) {
+    host.appendChild(choiceCard(c, ci));
+  });
+}
+
+function choiceCard(c, ci) {
+  var card = document.createElement('div');
+  card.className = 'choice';
+
+  var head = document.createElement('div');
+  head.className = 'head';
+  head.innerHTML = '<span class="title">!w ' + (ci + 1) + '</span>';
+  var nameField = document.createElement('input');
+  nameField.placeholder = 'Choice name (shown in the option list)';
+  nameField.value = c.choiceName || '';
+  nameField.style.flex = '1';
+  nameField.oninput = function () { c.choiceName = nameField.value; refresh(); };
+  head.appendChild(nameField);
+  var up = document.createElement('button');
+  up.className = 'small'; up.textContent = '↑'; up.title = 'Move up';
+  up.disabled = ci === 0;
+  up.onclick = function () { moveChoice(ci, -1); };
+  head.appendChild(up);
+  var down = document.createElement('button');
+  down.className = 'small'; down.textContent = '↓'; down.title = 'Move down';
+  down.disabled = ci === current.choices.length - 1;
+  down.onclick = function () { moveChoice(ci, 1); };
+  head.appendChild(down);
+  var rm = document.createElement('button');
+  rm.className = 'small danger'; rm.textContent = 'Remove';
+  rm.onclick = function () { current.choices.splice(ci, 1); renderChoices(); refresh(); };
+  head.appendChild(rm);
+  card.appendChild(head);
+
+  // ---- availability (conditional) ----
+  var condRow = document.createElement('div');
+  condRow.className = 'row';
+  condRow.style.marginBottom = '8px';
+
+  var kindField = document.createElement('div');
+  kindField.className = 'field';
+  kindField.innerHTML = '<label>Available to</label>';
+  var kindSel = document.createElement('select');
+  ['none', 'job', 'trn', 'cur', 'mon'].forEach(function (k) {
+    var op = document.createElement('option');
+    op.value = k; op.textContent = KIND_LABELS[k];
+    if (c.conditionalKind === k) op.selected = true;
+    kindSel.appendChild(op);
+  });
+  kindSel.onchange = function () {
+    c.conditionalKind = kindSel.value;
+    c.conditionalKey = '';
+    renderChoices(); refresh();
+  };
+  kindField.appendChild(kindSel);
+  condRow.appendChild(kindField);
+
+  if (c.conditionalKind !== 'none') {
+    var pool = c.conditionalKind === 'job' ? (catalogs.jobs || [])
+             : c.conditionalKind === 'trn' ? (catalogs.trainings || [])
+             : c.conditionalKind === 'cur' ? (catalogs.currencies || [])
+             : (catalogs.monsterCategories || []);
+    var keyField = document.createElement('div');
+    keyField.className = 'field';
+    var keyLabel = c.conditionalKind === 'job' ? 'Job' :
+                   c.conditionalKind === 'trn' ? 'Training' :
+                   c.conditionalKind === 'cur' ? 'Currency' : 'Species tag';
+    keyField.innerHTML = '<label>' + keyLabel + '</label>';
+    var keyInput;
+    if (pool.length) {
+      keyInput = document.createElement('select');
+      var blank = document.createElement('option');
+      blank.value = ''; blank.textContent = '— pick —';
+      keyInput.appendChild(blank);
+      var matched = false;
+      pool.forEach(function (p) {
+        var op = document.createElement('option');
+        op.value = p; op.textContent = p;
+        if ((c.conditionalKey || '').toLowerCase() === p.toLowerCase()) { op.selected = true; matched = true; }
+        keyInput.appendChild(op);
+      });
+      // Keep a key that isn't in the current catalog (legacy doc / other db)
+      // selectable so editing doesn't silently drop it.
+      if (c.conditionalKey && !matched) {
+        var keep = document.createElement('option');
+        keep.value = c.conditionalKey; keep.textContent = c.conditionalKey + ' (not in catalog)';
+        keep.selected = true;
+        keyInput.appendChild(keep);
+      }
+      keyInput.onchange = function () { c.conditionalKey = keyInput.value; refresh(); };
+    } else {
+      keyInput = document.createElement('input');
+      keyInput.value = c.conditionalKey || '';
+      keyInput.placeholder = 'e.g. flight';
+      keyInput.oninput = function () { c.conditionalKey = keyInput.value; refresh(); };
+    }
+    keyField.appendChild(keyInput);
+    condRow.appendChild(keyField);
+  }
+
+  if (c.conditionalKind === 'job' || c.conditionalKind === 'cur') {
+    var valField = document.createElement('div');
+    valField.className = 'field';
+    valField.style.flex = '0 0 110px';
+    valField.innerHTML = '<label>' + (c.conditionalKind === 'job' ? 'Min experience' : 'Min amount') + '</label>';
+    var valInput = document.createElement('input');
+    valInput.type = 'number'; valInput.min = 0;
+    valInput.value = c.conditionalValue == null ? 0 : c.conditionalValue;
+    valInput.oninput = function () { c.conditionalValue = parseInt(valInput.value, 10) || 0; refresh(); };
+    valField.appendChild(valInput);
+    condRow.appendChild(valField);
+  }
+  card.appendChild(condRow);
+
+  // ---- result text ----
+  var rt = document.createElement('div');
+  rt.className = 'field';
+  rt.innerHTML = '<label>Result text (PMed when they pick this) — BBCode ok</label>';
+  var ta = document.createElement('textarea');
+  ta.value = c.resultText || '';
+  ta.placeholder = 'You spend the afternoon polishing until you can see your reflection...';
+  ta.oninput = function () { c.resultText = ta.value; refresh(); };
+  rt.appendChild(ta);
+  card.appendChild(rt);
+
+  // ---- rewards ----
+  var rewardsHost = document.createElement('div');
+  rewardsHost.style.marginTop = '10px';
+  var totalWeight = (c.rewards || []).reduce(function (s, r) { return s + Math.max(0, r.weight || 0); }, 0);
+  (c.rewards || []).forEach(function (r, ri) {
+    rewardsHost.appendChild(rewardRow(c, r, ri, totalWeight));
+  });
+  card.appendChild(rewardsHost);
+
+  var addR = document.createElement('button');
+  addR.className = 'small'; addR.textContent = '+ Add reward';
+  addR.onclick = function () {
+    if (!c.rewards) c.rewards = [];
+    c.rewards.push({ currency: '', weight: 1, min: 1, max: 1 });
+    renderChoices(); refresh();
+  };
+  card.appendChild(addR);
+
+  return card;
+}
+
+function moveChoice(ci, delta) {
+  var moved = current.choices.splice(ci, 1)[0];
+  current.choices.splice(ci + delta, 0, moved);
+  renderChoices(); refresh();
+}
+
+function rewardRow(choice, r, ri, totalWeight) {
+  var row = document.createElement('div');
+  row.className = 'reward';
+
+  var curField = document.createElement('div');
+  curField.className = 'field';
+  curField.innerHTML = '<label>Currency</label>';
+  var sel = document.createElement('select');
+  var blank = document.createElement('option');
+  blank.value = ''; blank.textContent = '— pick a currency —';
+  sel.appendChild(blank);
+  var matched = false;
+  (catalogs.currencies || []).forEach(function (cur) {
+    var op = document.createElement('option');
+    op.value = cur; op.textContent = cur;
+    if ((r.currency || '').toLowerCase() === cur.toLowerCase()) { op.selected = true; matched = true; }
+    sel.appendChild(op);
+  });
+  if (r.currency && !matched) {
+    var keep = document.createElement('option');
+    keep.value = r.currency; keep.textContent = r.currency + ' (not in catalog)';
+    keep.selected = true;
+    sel.appendChild(keep);
+  }
+  sel.onchange = function () { r.currency = sel.value; refresh(); };
+  curField.appendChild(sel);
+  row.appendChild(curField);
+
+  [['weight', 'weight'], ['min', 'min'], ['max', 'max']].forEach(function (pair) {
+    var f = document.createElement('div');
+    f.className = 'field num';
+    f.innerHTML = '<label>' + pair[0] + '</label>';
+    var inp = document.createElement('input');
+    inp.type = 'number'; inp.value = r[pair[1]] == null ? 0 : r[pair[1]];
+    inp.oninput = function () { r[pair[1]] = parseInt(inp.value, 10) || 0; renderOddsOnly(); refresh(); };
+    f.appendChild(inp);
+    row.appendChild(f);
+  });
+
+  var odds = document.createElement('div');
+  odds.className = 'odds';
+  odds.textContent = totalWeight > 0 ? Math.round(100 * Math.max(0, r.weight || 0) / totalWeight) + '%' : '';
+  row.appendChild(odds);
+
+  var rm = document.createElement('button');
+  rm.className = 'small danger'; rm.textContent = '×'; rm.title = 'Remove reward';
+  rm.onclick = function () { choice.rewards.splice(ri, 1); renderChoices(); refresh(); };
+  row.appendChild(rm);
+
+  return row;
+}
+
+// Re-rendering every card on each keystroke would drop input focus, so odds badges
+// are refreshed in place while typing.
+function renderOddsOnly() {
+  var cards = document.querySelectorAll('#choices .choice');
+  current.choices.forEach(function (c, ci) {
+    if (!cards[ci]) return;
+    var total = (c.rewards || []).reduce(function (s, r) { return s + Math.max(0, r.weight || 0); }, 0);
+    var badges = cards[ci].querySelectorAll('.odds');
+    (c.rewards || []).forEach(function (r, ri) {
+      if (badges[ri]) badges[ri].textContent = total > 0 ? Math.round(100 * Math.max(0, r.weight || 0) / total) + '%' : '';
+    });
+  });
+}
+
+// ============================ engine-mirroring preview ============================
+
+function refresh() {
+  if (!current) return;
+  var ed = collect();
+  current = ed; // keep choices reference + scalars in sync
+  renderPreview(ed);
+  renderWarnings(ed);
+  renderExport(ed);
+}
+
+function bbToHtml(s) {
+  var h = String(s == null ? '' : s)
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  h = h.replace(/\[b\]([\s\S]*?)\[\/b\]/gi, '<strong>$1</strong>');
+  h = h.replace(/\[i\]([\s\S]*?)\[\/i\]/gi, '<em>$1</em>');
+  h = h.replace(/\[u\]([\s\S]*?)\[\/u\]/gi, '<u>$1</u>');
+  h = h.replace(/\[sub\]([\s\S]*?)\[\/sub\]/gi, '<sub>$1</sub>');
+  h = h.replace(/\[url=([^\]]*)\]([\s\S]*?)\[\/url\]/gi, '<u>$2</u>');
+  h = h.replace(/\[user\]([\s\S]*?)\[\/user\]/gi, '<span style="color:#90c0e8;font-weight:600">$1</span>');
+  h = h.replace(/\[color=([a-z]+)\]([\s\S]*?)\[\/color\]/gi, '<span style="color:$1">$2</span>');
+  h = h.replace(/\n/g, '<br>');
+  return h;
+}
+
+function conditionText(c) {
+  switch (c.conditionalKind) {
+    case 'job': return 'only with ' + (c.conditionalValue || 0) + '+ ' + (c.conditionalKey || '?') + ' job experience';
+    case 'trn': return 'only with the ' + (c.conditionalKey || '?') + ' training';
+    case 'cur': return 'only with ' + (c.conditionalValue || 0) + '+ ' + (c.conditionalKey || '?') + ' on hand';
+    case 'mon': return 'only for species tagged ' + (c.conditionalKey || '?');
+    default: return 'always available';
+  }
+}
+
+function renderPreview(ed) {
+  // Mirrors ChateauWork: startText + "\n" + "!w 1: name | !w 2: name | ..."
+  var offer = ed.startText + '\n' + ed.choices.map(function (c, i) {
+    return '!w ' + (i + 1) + ': ' + (c.choiceName || '(unnamed)');
+  }).join(' | ');
+  document.getElementById('pv_start').innerHTML =
+    '<span class="from">' + BOT_NAME + ':</span>' + bbToHtml(offer);
+
+  var conditionalCount = ed.choices.filter(function (c) { return c.conditionalKind !== 'none'; }).length;
+  document.getElementById('pv_numberNote').innerHTML = conditionalCount
+    ? 'Numbers above assume every conditional is met — a player who doesn’t qualify for a choice simply doesn’t see it, and later choices renumber. <b>!volunteer</b> shows the same duty with <b>!v</b> numbers.'
+    : '<b>!volunteer</b> shows the same duty with <b>!v</b> numbers.';
+
+  var host = document.getElementById('pv_choices');
+  host.innerHTML = '';
+  ed.choices.forEach(function (c, i) {
+    var cap = document.createElement('div');
+    cap.className = 'previewCaption';
+    cap.innerHTML = 'If they pick !w ' + (i + 1) +
+      (c.conditionalKind !== 'none' ? ' <span class="lockNote">(' + conditionText(c) + ')</span>' : '');
+    host.appendChild(cap);
+
+    // Mirrors the completion PM: resultText + blank line + the rolled reward line.
+    var total = (c.rewards || []).reduce(function (s, r) { return s + Math.max(0, r.weight || 0); }, 0);
+    var top = null;
+    (c.rewards || []).forEach(function (r) { if (!top || (r.weight || 0) > (top.weight || 0)) top = r; });
+
+    var lines = [c.resultText || '(no result text)'];
+    if (top && top.currency) {
+      var sample = Math.floor(((top.min || 0) + (top.max || 0)) / 2);
+      lines.push('');
+      lines.push('You received [b]' + sample + ' ' + top.currency + '[/b]!');
+    }
+    var msg = document.createElement('div');
+    msg.className = 'previewMsg';
+    msg.innerHTML = '<span class="from">' + BOT_NAME + ':</span>' + bbToHtml(lines.join('\n'));
+    host.appendChild(msg);
+
+    if ((c.rewards || []).length) {
+      var tbl = document.createElement('div');
+      tbl.className = 'oddsTable';
+      tbl.innerHTML = (c.rewards || []).map(function (r) {
+        var pct = total > 0 ? Math.round(100 * Math.max(0, r.weight || 0) / total) : 0;
+        var range = (r.min === r.max) ? String(r.max) : r.min + '–' + r.max;
+        return pct + '% → <b>' + range + ' ' + (r.currency || '?') + '</b>';
+      }).join(' &nbsp;·&nbsp; ');
+      host.appendChild(tbl);
+    } else {
+      var none = document.createElement('div');
+      none.className = 'oddsTable';
+      none.textContent = 'No rewards — flavor only (the completion PM will have no "You received" line).';
+      host.appendChild(none);
+    }
+  });
+}
+
+function renderWarnings(ed) {
+  var w = loadWarnings.slice();
+  if (!ed.label) w.push('Label is required.');
+  if (!ed.job) w.push('Job is required.');
+  else if (ed.job.toLowerCase() !== 'default' &&
+           (catalogs.jobs || []).map(lc).indexOf(lc(ed.job)) < 0)
+    w.push('"' + ed.job + '" is not an existing job identifier — no one can be employed in it yet.');
+  if (!ed.startText) w.push('Start text is required.');
+  if (!ed.choices.length) w.push('At least one choice is required.');
+  if (ed.choices.length && !ed.choices.some(function (c) { return c.conditionalKind === 'none'; }))
+    w.push('No always-available choice: a player who meets no conditionals would get a dead work day. The server will refuse to save this.');
+
+  var names = {};
+  ed.choices.forEach(function (c, i) {
+    var n = i + 1;
+    if (!c.choiceName) w.push('Choice ' + n + ': name is required.');
+    else {
+      var k = lc(c.choiceName);
+      if (names[k]) w.push('Choices ' + names[k] + ' and ' + n + ' have the same name.');
+      else names[k] = n;
+    }
+    if (!c.resultText) w.push('Choice ' + n + ': result text is required.');
+    if (c.conditionalKind !== 'none' && !c.conditionalKey)
+      w.push('Choice ' + n + ': pick which ' + (c.conditionalKind === 'job' ? 'job' : c.conditionalKind === 'trn' ? 'training' : c.conditionalKind === 'cur' ? 'currency' : 'species tag') + ' the conditional checks.');
+    if ((c.conditionalKind === 'job' || c.conditionalKind === 'cur') && (c.conditionalValue || 0) < 1)
+      w.push('Choice ' + n + ': a minimum of 0 is always met — this conditional does nothing.');
+    (c.rewards || []).forEach(function (r, ri) {
+      if (!r.currency) w.push('Choice ' + n + ' reward ' + (ri + 1) + ': pick a currency.');
+      if ((r.weight || 0) < 1) w.push('Choice ' + n + ' reward ' + (ri + 1) + ': weight must be at least 1.');
+      if (r.currency && Math.max(r.min || 0, r.max || 0) <= 0)
+        w.push('Choice ' + n + ' reward ' + (ri + 1) + ': max ≤ 0 means the player receives nothing (or loses currency if negative).');
+    });
+  });
+  var ul = document.getElementById('warnings');
+  ul.innerHTML = '';
+  w.forEach(function (msg) {
+    var li = document.createElement('li');
+    li.textContent = msg;
+    ul.appendChild(li);
+  });
+}
+
+function lc(s) { return String(s).toLowerCase(); }
+
+function renderExport(ed) {
+  document.getElementById('pv_export').textContent = JSON.stringify(toDbShape(ed), null, 2);
+}
+
+function copyExport(kind) {
+  var json = JSON.stringify(toDbShape(collect()), null, 2);
+  var text = kind === 'mongosh'
+    ? '// mongosh — run against the bot’s server\nuse ChateauDb\ndb.Duties.insertOne(' + json + ')'
+    : json;
+  navigator.clipboard.writeText(text).then(function () {
+    setStatus('Copied ' + (kind === 'mongosh' ? 'mongosh insert' : 'JSON') + ' to clipboard.', 'ok');
+  });
+}
+
+// ============================ persistence ============================
+
+function save() {
+  var ed = collect();
+  // The server expects the editor shape (ordered choices array) and builds the
+  // keyed document itself.
+  var payload = {
+    label: ed.label,
+    job: ed.job,
+    categories: ed.categories,
+    startText: ed.startText,
+    choices: ed.choices.map(function (c) {
+      return {
+        choiceName: c.choiceName,
+        resultText: c.resultText,
+        conditionalKind: c.conditionalKind,
+        conditionalKey: c.conditionalKey,
+        conditionalValue: c.conditionalValue,
+        rewards: c.rewards
+      };
+    })
+  };
+  var req = originalLabel
+    ? fetch(API + '/api/duties/' + encodeURIComponent(originalLabel), { method: 'PUT', body: JSON.stringify(payload) })
+    : fetch(API + '/api/duties', { method: 'POST', body: JSON.stringify(payload) });
+  req.then(function (r) { return r.json(); }).then(function (res) {
+    if (res.error) { setStatus(res.error, 'err'); return; }
+    loadWarnings = [];
+    setStatus(res.message, 'ok');
+    originalLabel = ed.label;
+    document.getElementById('formTitle').textContent = 'Edit: ' + ed.label;
+    document.getElementById('btnDel').style.display = '';
+    document.getElementById('btnDup').style.display = '';
+    reloadDuties();
+  }).catch(function (e) { setStatus('Request failed: ' + e, 'err'); });
+}
+
+function removeDuty() {
+  if (!originalLabel) return;
+  if (!confirm('Delete "' + originalLabel + '" from the live database?')) return;
+  fetch(API + '/api/duties/' + encodeURIComponent(originalLabel), { method: 'DELETE' })
+    .then(function (r) { return r.json(); })
+    .then(function (res) {
+      if (res.error) { setStatus(res.error, 'err'); return; }
+      setStatus(res.message, 'ok');
+      current = null; originalLabel = null;
+      document.getElementById('formBody').style.display = 'none';
+      document.getElementById('formPlaceholder').style.display = '';
+      document.getElementById('previewBody').style.display = 'none';
+      document.getElementById('previewPlaceholder').style.display = '';
+      document.getElementById('formTitle').textContent = 'Duty';
+      reloadDuties();
+    });
+}
+
+function setStatus(msg, cls) {
+  var el = document.getElementById('status');
+  el.textContent = msg;
+  el.className = cls;
+}
+</script>
+
+</body>
+</html>

--- a/wiki-docs/Database-and-Persistence.md
+++ b/wiki-docs/Database-and-Persistence.md
@@ -222,77 +222,114 @@ var pending = GetPendingCommands("Bob");
 
 #### 4. Duties
 
-**Purpose:** Job system - task definitions
+**Purpose:** Job system - the authored duty scenarios `!work` and `!volunteer` roll from
+
+Each document is one scenario for one job. When a player works, one of their job's
+duties is picked at random; if a job has no duties, the `"default"` job's duties are
+used as a fallback. Model classes: `Duty`, `DutyResult`, `Reward`, `Conditional` in
+`FChatDicebot/Model/ChateauDB.cs`.
 
 **Document Structure:**
 
 ```json
 {
   "_id": ObjectId("..."),
-  "jobName": "maid",
-  "taskDescriptions": [
-    "Clean the manor",
-    "Serve tea to guests",
-    "Organize the library",
-    "Polish silverware",
-    "Prepare bedrooms"
-  ],
-  "baseReward": {
-    "tokens": 50,
-    "gold": 10
-  },
-  "experienceGrant": 10,
-  "conditions": [
-    {
-      "conditionType": "random",
-      "probability": 0.1,
-      "effect": {
-        "bonusTokens": 25,
-        "message": "You found a tip!"
+  "label": "PolishTheSilverware",
+  "categories": ["mercantile"],
+  "job": "maid",
+  "startText": "The head maid hands you a list of chores...",
+  "dutyResults": {
+    "Dust the shelves": {
+      "choiceName": "Dust the shelves",
+      "resultText": "You dust until you can see your reflection.",
+      "conditional": { "type": "none", "value": 0 },
+      "rewardList": {
+        "copper": { "currency": "copper", "weight": 9, "min": 5, "max": 20 },
+        "silver": { "currency": "silver", "weight": 1, "min": 1, "max": 3 }
       }
+    },
+    "Fly to the chandelier": {
+      "choiceName": "Fly to the chandelier",
+      "resultText": "Only the winged can dust up here.",
+      "conditional": { "type": "monflight", "value": 0 },
+      "rewardList": { }
     }
-  ]
+  }
 }
 ```
 
-**Indexes:**
-- `jobName` (unique)
+`dutyResults` is a keyed subdocument (`Dictionary<string, DutyResult>` in code); its
+field order is the order choices are numbered in (`!w 1`, `!w 2`, ...). On completion
+ONE reward is rolled from `rewardList`, weighted by `weight`, for an amount between
+`min` and `max` inclusive; an empty `rewardList` is pure flavor.
+
+**Conditionals:** `conditional.type` is a three-letter kind prefix plus a lookup key,
+parsed by `BotCommands/Support/DutyConditionalSupport.cs`:
+
+| Type | Choice is shown when |
+| --- | --- |
+| `none` | Always |
+| `job` + job, e.g. `jobadventurer` | That job's experience >= `value` |
+| `trn` + training, e.g. `trndeepthroat` | Player has the training |
+| `cur` + currency, e.g. `curgold` | Currency balance >= `value` |
+| `mon` + category, e.g. `monflight` | Player's species identifier carries that category |
+
+Every duty must keep at least one `none` choice - a player who fails every
+conditional would otherwise get a duty with zero choices and lose the work day.
+
+**Queried by:** `label` (exact), `job` (exact, lowercase), `categories` (contains).
+No indexes are created; the collection is small.
 
 **Key Methods:**
 
 ```csharp
-Duty GetDuty(string jobName)
-void AddDuty(Duty duty)
-List<string> GetRandomTask(string jobName)
+Duty GetDuty(string dutyLabel)
+void SetDuty(string label, Duty newDuty)
+List<Duty> GetDutiesByJob(string job)
+List<Duty> GetDutiesByCategory(string category)
 ```
+
+**Authoring:** duties are seeded externally, not by the bot. Use the Work Duty
+Builder (`scripts/work-duty-builder`, `run.ps1`, http://localhost:8788) - it edits
+this collection live with validation and a preview of the resulting PMs.
 
 #### 5. PendingDuties
 
-**Purpose:** Active work assignments
+**Purpose:** A started work/volunteer session awaiting the player's choice
+
+Created when `!work` or `!volunteer` presents a duty's choices; deleted when the
+player answers with `!w N` / `!v N` (rewards granted, job experience +1, daily
+timer set), or cleaned up on their next invocation if it's from a previous
+Chateau day. Model class: `PendingDuty` in `FChatDicebot/Model/ChateauDB.cs`.
 
 **Document Structure:**
 
 ```json
 {
   "_id": ObjectId("..."),
-  "userName": "Alice",
-  "jobName": "maid",
-  "taskDescription": "Clean the manor",
-  "assignedTime": ISODate("2025-11-22T08:00:00Z"),
-  "completed": false
+  "dutyResults": [
+    { "choiceName": "...", "resultText": "...", "conditional": {...}, "rewardList": {...} }
+  ],
+  "dutyLabel": "PolishTheSilverware",
+  "job": "maid",
+  "awaitingInputFrom": "Alice",
+  "startTime": ISODate("2025-11-22T08:00:00Z")
 }
 ```
 
-**Indexes:**
-- `userName`
-- `completed`
+Unlike `Duties`, `dutyResults` here is an ARRAY: only the choices the player
+qualified for, in the order they were numbered - the player's `!w N` indexes
+straight into it.
+
+**Queried by:** `awaitingInputFrom` (exact). No indexes are created.
 
 **Key Methods:**
 
 ```csharp
-PendingDuty GetPendingDuty(string userName)
-void AssignDuty(string userName, string jobName, string task)
-void CompleteDuty(ObjectId id)
+void AddPendingDuty(PendingDuty toAdd)
+PendingDuty GetPendingDuty(string awaitingInputFrom)
+void SetPendingDuty(PendingDuty updatedDuty)
+void DeletePendingDuty(ObjectId dutyId)
 ```
 
 #### 6. Commands
@@ -716,9 +753,14 @@ public interface IChateauDatabase
     bool IncrementCountWithRateLimit(string userName, string countName, TimeSpan rateLimit);
 
     // Duty operations
-    Duty GetDuty(string jobName);
-    PendingDuty GetPendingDuty(string userName);
-    void AssignDuty(string userName, string jobName, string task);
+    Duty GetDuty(string dutyLabel);
+    void SetDuty(string label, Duty newDuty);
+    List<Duty> GetDutiesByJob(string job);
+    List<Duty> GetDutiesByCategory(string category);
+    void AddPendingDuty(PendingDuty toAdd);
+    PendingDuty GetPendingDuty(string awaitingInputFrom);
+    void SetPendingDuty(PendingDuty updatedDuty);
+    void DeletePendingDuty(ObjectId dutyId);
 
     // Identifier operations
     List<string> GetIdentifiers(string category);

--- a/wiki-docs/Interaction-System.md
+++ b/wiki-docs/Interaction-System.md
@@ -604,47 +604,40 @@ Bot: Alice has employed Bob as a maid!
 
 ### Work Command
 
-**Daily Duty:**
+**Daily Duty (two-step, via PM):**
 
 ```
 Bob: !work
-Bot: Bob performs their duty as a maid: [random task]
-Bob has earned 50 tokens!
+Bot (PM): The head maid hands you a list of chores...
+         !w 1: Dust the shelves | !w 2: Polish the silver
+Bob: !w 2
+Bot (PM): Gleaming! ...
+         You received [b]12 copper[/b]!
 ```
 
-**Implementation:**
-1. Fetch duty for job type
-2. Check if already worked today (cooldown)
-3. Complete the duty
-4. Grant rewards (tokens, experience)
-5. Set work cooldown (24 hours)
+**Implementation** (`BotCommands/ChateauWork.cs`):
+1. Remove a stale pending duty left over from a previous Chateau day, if any
+2. If a pending duty is waiting, the number is the player's choice: post its
+   `resultText`, roll ONE reward from the choice's weighted `rewardList`,
+   grant +1 job experience, set the daily work timer, delete the pending duty
+   (a 25% MANOR kickback may go to the employer - see Employer earnings)
+3. Otherwise pick a random duty for the player's job (falling back to the
+   `default` job's duties), filter its choices by their conditionals (job
+   experience / training / currency / species - see
+   `BotCommands/Support/DutyConditionalSupport.cs`), PM the numbered choice
+   list, and store a `PendingDuty`
 
-**Duty Database:**
-
-```csharp
-{
-  "jobName": "maid",
-  "taskDescriptions": [
-    "Clean the manor",
-    "Serve tea to guests",
-    "Organize the library"
-  ],
-  "rewards": {
-    "tokens": 50,
-    "experience": 10
-  }
-}
-```
+Duty documents live in the `Duties` collection; see
+[Database-and-Persistence](Database-and-Persistence.md) for the real schema
+(label/job/startText/dutyResults). They are authored with the Work Duty
+Builder (`scripts/work-duty-builder`).
 
 ### Volunteer
 
-Try other jobs without being employed:
-
-```
-Bob: !volunteer
-Bot: Bob tries their hand at being a chef: [random task]
-Bob earned 10 tokens! (Volunteers earn less than employees)
-```
+`!volunteer {job}` runs the same duty flow for a job you are NOT employed in
+(answers use `!v N`). It has its own daily timer, separate from `!work`, rolls
+the same duties for the same rewards, and grants job experience for the job
+being tried.
 
 ## Transformation System
 


### PR DESCRIPTION
## What

**Work Duty Builder** — `scripts/work-duty-builder`, a twin of the random-event builder for the `ChateauDb.Duties` collection (`run.ps1` → http://localhost:8788; the event builder keeps 8787 so both can run at once):

- Sidebar lists every duty grouped by job with a filter box; create / edit / duplicate / delete.
- Choices edited in order (`!w 1`, `!w 2`, …) with reorder buttons, plain-English availability dropdowns (always / job experience / training / currency / species tag) backed by live `Identifiers` catalogs, and weighted currency rewards with computed % odds.
- Live preview mirrors the bot's PMs exactly — start text + `!w N:` option line, per-choice completion messages, lock annotations like *(only with 5+ adventurer job experience)*.
- Validation: refuses duties with no always-available choice (a player failing every conditional would get a dead work day), requires weight ≥ 1, swaps reversed min/max, lowercases the job, sanitizes Mongo keys, dedupes duplicate currency keys. JSON / mongosh export for staging elsewhere.

**Duty-picker fixes** in `!work` and `!volunteer`, extracted into a shared `DutyConditionalSupport` parser (+25 unit tests):

1. `job`/`cur` conditionals looked up the full prefixed string (`"jobadventurer"`) in dictionaries keyed by the bare name (`"adventurer"`), so those choices **never unlocked**. Live data authored with them exists today.
2. The kind prefix was matched case-sensitively; live docs typed `"None"` silently dropped the choice — an all-`"None"` duty (e.g. alchemist `GatherAlchemistIngredients`) resolved to **zero choices** and wasted the player's work day.
3. Stale previous-day pending duties were deleted from `PendingCommands` instead of `PendingDuties`, so they piled up and **permanently wedged** that player's `!work`/`!volunteer`.

**Wiki corrections** — `Database-and-Persistence.md` §4/§5 and the `IChateauDatabase` excerpt documented a fictional schema (`jobName`/`taskDescriptions`/`AssignDuty`…); rewritten to the real `Duty`/`DutyResult`/`Reward`/`Conditional` shapes, conditional prefix table, and real methods. `Interaction-System.md`'s matching fiction (single-step work, tokens, "volunteers earn less") replaced with the real two-step flow.

## Why

Duties were authored via a spreadsheet and hand-written BSON; the random-event builder proved the local-web-UI workflow. Building it against the live collection surfaced the three bugs above.

## Reviewer notes

- The bot fixes only take effect on the next deploy; the builder works against the live DB immediately (it queries fresh each `!work`).
- CRUD was smoke-tested against a scratch database (validation paths, case-insensitive label addressing, rename-collision checks); the live DB was untouched. Full suite: 1487 tests pass.
- `DutyConditionalSupport.Key()` is mechanical (everything after the 3-char prefix) and only consulted for keyed kinds — `Key("none") == "e"` is documented as harmless in the tests.
- No player-facing bot strings changed; the tool's own copy is owner-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)