### PR TITLE
Add !pet casual interaction command

### DIFF
--- a/FChatDicebot.Tests/Unit/Interactioneicontests.cs
+++ b/FChatDicebot.Tests/Unit/Interactioneicontests.cs
@@ -67,6 +67,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         [InlineData("hire", new[] { "employ" })]
         [InlineData("purify", new[] { "purify" })]
         [InlineData("sit", new[] { "sit" })]
+        [InlineData("pet", new[] { "pet" })]
         [InlineData("pay", new[] { "paymentGive", "paymentReceive" })]
         public void TryResolveTokenToVerbKeys_MapsTokens(string token, string[] expected)
         {
@@ -132,6 +133,35 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             Assert.Contains("[eicon]ihand[/eicon]", suffix);
             Assert.DoesNotContain("[eicon]rbutt[/eicon]", suffix);
+        }
+
+        [Fact]
+        public void CompletionSuffix_Pet_ShowsRecipientEicon_TheOneBeingPetted()
+        {
+            // Unlike the other directional casuals, !pet surfaces the recipient's eicon (their
+            // "being petted" icon), not the initiator's.
+            var initiator = new ProfileBuilder().WithCharacteristic("eicon_pet", "[eicon]ihand[/eicon]").Build();
+            var recipient = new ProfileBuilder().WithCharacteristic("eicon_pet", "[eicon]beingpet[/eicon]").Build();
+            var processor = new PetProcessor(_database);
+
+            string message = processor.GetCompletionMessageWithStatusEffects(initiator, recipient, "", "pet");
+
+            Assert.Contains("[eicon]beingpet[/eicon]", message);
+            Assert.DoesNotContain("[eicon]ihand[/eicon]", message);
+        }
+
+        [Fact]
+        public void GroupEiconSuffix_Pet_RecipientsOnly()
+        {
+            var initiator = new ProfileBuilder().WithCharacteristic("eicon_pet", "[eicon]ihand[/eicon]").Build();
+            var c1 = new ProfileBuilder().WithCharacteristic("eicon_pet", "[eicon]pet1[/eicon]").Build();
+            var c2 = new ProfileBuilder().WithCharacteristic("eicon_pet", "[eicon]pet2[/eicon]").Build();
+            var processor = new PetProcessor(_database);
+
+            string suffix = processor.GetGroupEiconSuffix("pet", initiator, new List<Profile> { c1, c2 });
+
+            // Each petted recipient's icon shows; the initiator's does not.
+            Assert.Equal(" [eicon]pet1[/eicon] [eicon]pet2[/eicon]", suffix);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Petprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Petprocessortests.cs
@@ -1,0 +1,177 @@
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Casual;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using MongoDB.Bson;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Unit tests for PetProcessor (directional casual: petgive / pettake). The custom eicon
+    /// belongs to the recipient (the one being petted), not the initiator — the reverse of the
+    /// other directional casuals.
+    /// </summary>
+    [Collection("Database")]
+    public class PetProcessorTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+        private readonly PetProcessor _processor;
+
+        public PetProcessorTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            _processor = new PetProcessor(_database);
+        }
+
+        [Fact]
+        public void InteractionType_ReturnsPet()
+        {
+            Assert.Equal("pet", _processor.InteractionType);
+        }
+
+        [Fact]
+        public void InvestmentLevel_ReturnsCasual()
+        {
+            Assert.Equal("casual", _processor.InvestmentLevel);
+        }
+
+        [Fact]
+        public void GroupSpec_IsDirectional_GiveTake()
+        {
+            var spec = _processor.GroupSpec;
+            Assert.NotNull(spec);
+            Assert.Equal(GroupCountKind.Directional, spec.Kind);
+            Assert.Equal("petgive", spec.GiveKey);
+            Assert.Equal("pettake", spec.TakeKey);
+        }
+
+        [Fact]
+        public void ProcessInteraction_ValidPet_ReturnsPetString()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            string result = _processor.ProcessInteraction(pendingCommand);
+
+            Assert.Equal("pet", result);
+        }
+
+        [Fact]
+        public void ProcessInteraction_FirstPet_IncrementsDifferentCounts()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var alice = _database.GetProfile("Alice");
+            var bob = _database.GetProfile("Bob");
+
+            // Initiator is the one petting (petgive); recipient is petted (pettake).
+            Assert.Equal(1, alice.counts["petgive"]);
+            Assert.Equal(1, bob.counts["pettake"]);
+        }
+
+        [Fact]
+        public void ProcessInteraction_SavesInteractionToHistory()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var pendingCommand = MakePending("Alice", "Bob");
+            _database.AddPendingCommand(pendingCommand);
+
+            _processor.ProcessInteraction(pendingCommand);
+
+            var interactions = _database.GetInteractionsByInitiator("Alice");
+            Assert.Contains(interactions, i => i.type == "pet");
+        }
+
+        [Fact]
+        public void GetCompletionMessage_IncludesBothNames_AndResolvesTokens()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice the Adventurer").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob the Bold").BuildAndSave(_database);
+
+            // Run enough times to exercise the token-bearing descriptors and confirm no
+            // raw {token} placeholder ever survives into the rendered message.
+            for (int i = 0; i < 50; i++)
+            {
+                string message = _processor.GetCompletionMessage(initiator, recipient, "");
+                Assert.Contains("Alice the Adventurer", message);
+                Assert.Contains("Bob the Bold", message);
+                Assert.DoesNotContain("{petgiver}", message);
+                Assert.DoesNotContain("{pettaker}", message);
+            }
+        }
+
+        [Fact]
+        public void CompletionEicon_UsesRecipientsEicon_NotInitiators()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            var recipient = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            InteractionEiconSupport.SetInteractionEicon(initiator, "pet", "petterIcon");
+            InteractionEiconSupport.SetInteractionEicon(recipient, "pet", "beingpetIcon");
+
+            string message = _processor.GetCompletionMessageWithStatusEffects(initiator, recipient, "", "pet");
+
+            // The one being petted (recipient) is the eicon subject.
+            Assert.Contains("beingpetIcon", message);
+            Assert.DoesNotContain("petterIcon", message);
+        }
+
+        [Fact]
+        public void GroupEiconSuffix_ShowsEachRecipientsEicon_NotInitiators()
+        {
+            var initiator = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            var carol = new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+
+            InteractionEiconSupport.SetInteractionEicon(initiator, "pet", "petterIcon");
+            InteractionEiconSupport.SetInteractionEicon(bob, "pet", "bobPet");
+            InteractionEiconSupport.SetInteractionEicon(carol, "pet", "carolPet");
+
+            string suffix = _processor.GetGroupEiconSuffix("pet", initiator, new List<Profile> { bob, carol });
+
+            Assert.Contains("bobPet", suffix);
+            Assert.Contains("carolPet", suffix);
+            Assert.DoesNotContain("petterIcon", suffix);
+        }
+
+        private static PendingCommand MakePending(string initiator, string recipient)
+        {
+            return new PendingCommand
+            {
+                Id = ObjectId.GenerateNewId(),
+                pendingInteraction = new Interaction
+                {
+                    initiator = initiator,
+                    recipient = recipient,
+                    type = "pet",
+                    identifier = "",
+                    investmentLevel = "casual"
+                },
+                awaitingConsentFrom = recipient
+            };
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -37,6 +37,8 @@ namespace FChatDicebot.BotCommands
             { "boobhattake", "Boobhats Worn" },
             { "lickgive", "Licks Given" },
             { "licktake", "Licks Received" },
+            { "petgive", "Pets Given" },
+            { "pettake", "Pets Received" },
             { "lapsitgive", "Laps Sat On" },
             { "lapsittake", "Sitters Supported" },
             { "climaxtake", "Orgasms" },
@@ -70,6 +72,8 @@ namespace FChatDicebot.BotCommands
             { "boobhattake", "Boob Wearing" },
             { "lickgive", "Licking" },
             { "licktake", "Living Lollipop" },
+            { "petgive", "Petting" },
+            { "pettake", "Petted" },
             { "lapsitgive", "Lap Sitting" },
             { "lapsittake", "Lap Providing" }
         };

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -115,6 +115,7 @@ namespace FChatDicebot.BotCommands
                 "!bully",
                 "!boobhat",
                 "!lick",
+                "!pet",
                 "!lap",
                 "!sit"
             };

--- a/FChatDicebot/BotCommands/ChateauPet.cs
+++ b/FChatDicebot/BotCommands/ChateauPet.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.SavedData;
+using Newtonsoft.Json;
+using FChatDicebot.DiceFunctions;
+using FChatDicebot.Model;
+
+namespace FChatDicebot.BotCommands
+{
+    public class ChateauPet : ChatBotCommand
+    {
+        public ChateauPet()
+        {
+            Name = "pet";
+            Aliases = new string[] { };
+            Category = "Casual Interaction";
+            ShortDescription = "Pet another resident (or residents)";
+            LongDescription = "Give another resident (or residents) some pets once they !consent. A gentle bit of headpats and scritches. With !seteicon pet, the icon that shows is the one being petted (set your own 'being petted' eicon so onlookers see it whenever someone pets you).";
+            Usage = "!pet [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "cuddle", "lick", "consent", "dossier" };
+            CooldownDuration = "30 minutes (but can still interact without incrementing count)";
+            CooldownAppliesTo = "both initiator and recipient";
+            IdentifierCategory = null;
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, MessageAddress address, UserGeneratedCommand command)
+        {
+            string characterName = address.character;
+            string channel = address.channel;
+            var groupTargets = commandController.GetUserNamesFromCommandTerms(rawTerms);
+            if (groupTargets.Count > 1)
+            {
+                Support.CasualGroupCommandSupport.Run(bot, characterName, channel, "pet", groupTargets);
+                return;
+            }
+
+            string recipient = commandController.GetUserNameFromCommandTerms(rawTerms);
+            Profile recipientProfile = MonDB.getProfile(recipient);
+            Profile initiatorProfile = MonDB.getProfile(characterName);
+            if (recipientProfile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notFoundText(recipient), characterName);
+            }
+            else
+            {
+                var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor("pet");
+                string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, null);
+
+                Interaction pet = new Interaction();
+                pet.initiator = characterName;
+                pet.recipient = recipient;
+                pet.type = "pet";
+                pet.investmentLevel = "casual";
+                pet.interactionTime = DateTime.UtcNow;
+
+                PendingCommand pendingPet = new PendingCommand();
+                pendingPet.pendingInteraction = pet;
+                pendingPet.awaitingConsentFrom = recipient;
+
+                MonDB.addPendingCommand(pendingPet);
+
+                bot.SendMessageInChannel(message, channel);
+            }
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauSeteicon.cs
+++ b/FChatDicebot/BotCommands/ChateauSeteicon.cs
@@ -21,7 +21,7 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "General";
             ShortDescription = "Set your personal eicon for an interaction";
-            LongDescription = "Set a special eicon to show for your interactions of the specified type. Once set, whenever you perform that interaction the onlookers will see your eicon alongside the result. For mutual interactions (!kiss, !cuddle, !handhold and !bond) and group interactions, all participants' eicons will show. For !climax and !climaxfor, the eicon for the one climaxing will show. For all other interactions, the initiator's eicon will show.\n\n"
+            LongDescription = "Set a special eicon to show for your interactions of the specified type. Once set, whenever you perform that interaction the onlookers will see your eicon alongside the result. For mutual interactions (!kiss, !cuddle, !handhold and !bond) and group interactions, all participants' eicons will show. For !climax and !climaxfor, the eicon for the one climaxing will show. For !pet, the eicon for the one being petted will show (set your own 'being petted' eicon). For all other interactions, the initiator's eicon will show.\n\n"
                 + "Set one with !seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]. Leave the eicon off to clear it. Message !seteicon on its own to see everything you've set.";
             Usage = "!seteicon {interaction} [noparse][eicon]YourEicon[/eicon][/noparse]\nor\n!seteicon {interaction}   (to clear it)\nor\n!seteicon   (to list what you've set)";
             RelatedCommands = new string[] { "dossier" };

--- a/FChatDicebot/BotCommands/ChateauSystemTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauSystemTitles.cs
@@ -168,6 +168,20 @@ namespace FChatDicebot
                 ("licktake", 100, "Spit Shined"),
                 ("licktake", 500, "Lollipop"),
 
+                // Pet - giving (the one petting)
+                ("petgive", 1, "Pat, Pat"),
+                ("petgive", 10, "Petter"),
+                ("petgive", 50, "Head Patter"),
+                ("petgive", 100, "Pet Whisperer"),
+                ("petgive", 500, "Gives The Best Scritches"),
+
+                // Pet - taking (the one being petted)
+                ("pettake", 1, "Good Pet"),
+                ("pettake", 10, "Petted"),
+                ("pettake", 50, "Headpat Enjoyer"),
+                ("pettake", 100, "Very Good Pet"),
+                ("pettake", 500, "Purrs On Command"),
+
                 // INVOLVED INTERACTION titles
 
                 // Milking - giving
@@ -637,6 +651,14 @@ namespace FChatDicebot
                     (4, "Hat Trick"),
                     (7, "Mad Hatter"),
                     (11, "Capping"),
+                },
+                ["pet"] = new[]
+                {
+                    (3, "Petting Zoo"),
+                    (5, "Menagerie"),
+                    (7, "Herder"),
+                    (9, "Pack Leader"),
+                    (11, "Whole Kennel"),
                 },
             };
 

--- a/FChatDicebot/BotCommands/ChateauSystemTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauSystemTitles.cs
@@ -169,18 +169,18 @@ namespace FChatDicebot
                 ("licktake", 500, "Lollipop"),
 
                 // Pet - giving (the one petting)
-                ("petgive", 1, "Pat, Pat"),
-                ("petgive", 10, "Petter"),
-                ("petgive", 50, "Head Patter"),
-                ("petgive", 100, "Pet Whisperer"),
-                ("petgive", 500, "Gives The Best Scritches"),
+                ("petgive", 1, "[i]Pets You[/i]"),
+                ("petgive", 10, "Scritch Supplier"),
+                ("petgive", 50, "Power Petter"),
+                ("petgive", 100, "Gives The Best Scritches"),
+                ("petgive", 500, "Put on this Plane to Pet"),
 
                 // Pet - taking (the one being petted)
                 ("pettake", 1, "Good Pet"),
-                ("pettake", 10, "Petted"),
-                ("pettake", 50, "Headpat Enjoyer"),
+                ("pettake", 10, "Petteded"),
+                ("pettake", 50, "Scritches Please"),
                 ("pettake", 100, "Very Good Pet"),
-                ("pettake", 500, "Purrs On Command"),
+                ("pettake", 500, "Put on this Plane to be Pet"),
 
                 // INVOLVED INTERACTION titles
 
@@ -654,11 +654,10 @@ namespace FChatDicebot
                 },
                 ["pet"] = new[]
                 {
-                    (3, "Petting Zoo"),
-                    (5, "Menagerie"),
-                    (7, "Herder"),
-                    (9, "Pack Leader"),
-                    (11, "Whole Kennel"),
+                    (4, "Pet Pet Pet"),
+                    (6, "Need More Limbs!"),
+                    (9, "Octopets"),
+                    (11, "Epetomy"),
                 },
             };
 

--- a/FChatDicebot/InteractionCountMigration.cs
+++ b/FChatDicebot/InteractionCountMigration.cs
@@ -179,6 +179,11 @@ namespace FChatDicebot.Migration
                     result.Add((recipient, "licktake"));
                     break;
 
+                case "pet":
+                    result.Add((initiator, "petgive"));
+                    result.Add((recipient, "pettake"));
+                    break;
+
                 // lapsit: !lap → initiator is the lap (lapsittake), recipient sits (lapsitgive)
                 case "lap":
                     result.Add((initiator, "lapsittake"));

--- a/FChatDicebot/InteractionProcessors/Casual/PetProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/PetProcessor.cs
@@ -1,0 +1,134 @@
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.InteractionProcessors.Casual
+{
+    /// <summary>
+    /// Processor for the pet interaction: the initiator pets the recipient. Directional
+    /// casual — <c>petgive</c> goes to the one doing the petting, <c>pettake</c> to the one
+    /// being petted. Modeled on <see cref="LickProcessor"/> / <see cref="SpankProcessor"/>.
+    ///
+    /// Its custom <c>!seteicon pet</c> icon is the <b>recipient's</b> (unlike most directional
+    /// casuals, which show the initiator's): residents typically keep a "my character being
+    /// petted" eicon, so the natural icon to surface is the pet's, not the petter's. See
+    /// <see cref="GetEiconSubject"/> and <see cref="GetGroupEiconSuffix"/>.
+    /// </summary>
+    public class PetProcessor : InteractionProcessorBase
+    {
+        public override string InteractionType => "pet";
+        public override string InvestmentLevel => "casual";
+
+        private static readonly TimeSpan RateLimit = TimeSpan.FromMinutes(30);
+
+        // Directional group model: initiator +R petgive, each recipient +1 pettake.
+        public override GroupSpec GroupSpec => GroupSpec.Directional("petgive", "pettake");
+
+        // {petgiver} = the one petting (initiator); {pettaker} = the one being petted
+        // (recipient; for a multi-target pet this resolves to the first consenter — see
+        // GetGroupCompletionMessage).
+        private static readonly List<string> PetDescriptors = new List<string>
+        {
+            "Who's a good pet? {pettaker} is.",
+            "Scritch scritch scritch.",
+            "Pat, pat, pat.",
+            "A few gentle strokes behind the ears.",
+            "{pettaker} leans into it happily.",
+            "There, there."
+        };
+
+        /// <summary>
+        /// Constructor for dependency injection (for testing)
+        /// </summary>
+        public PetProcessor(IChateauDatabase database) : base(database)
+        {
+        }
+
+        /// <summary>
+        /// Legacy constructor for backward compatibility
+        /// </summary>
+        public PetProcessor() : base()
+        {
+        }
+
+        public override string ProcessInteraction(PendingCommand command)
+        {
+            string initiator = command.pendingInteraction.initiator;
+            string recipient = command.pendingInteraction.recipient;
+
+            // Save the interaction to history
+            Database.AddInteraction(command.pendingInteraction);
+
+            // Increment counts with rate limiting (give/take variants).
+            // Initiator is the one petting (petgive); recipient is petted (pettake).
+            _lastRateLimitMessage = IncrementDifferentCountsWithRateLimit(
+                initiator, recipient, "petgive", "pettake", RateLimit);
+
+            // Remove pending interaction
+            Database.DeletePendingCommand(command.Id);
+
+            return "pet";
+        }
+
+        public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            string descriptor = GetRandomDescriptor(PetDescriptors)
+                .Replace("{petgiver}", initiatorProfile.displayName)
+                .Replace("{pettaker}", recipientProfile.displayName);
+
+            return $"{initiatorProfile.displayName} gently pets {recipientProfile.displayName}. {descriptor}";
+        }
+
+        public override string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier)
+        {
+            if (consentersInOrder.Count == 1)
+                return GetCompletionMessage(initiatorProfile, consentersInOrder[0], identifier);
+
+            // {pettaker} in a multi-target pet resolves to the first consenter (deterministic).
+            string descriptor = GetRandomDescriptor(PetDescriptors)
+                .Replace("{petgiver}", initiatorProfile.displayName)
+                .Replace("{pettaker}", consentersInOrder[0].displayName);
+
+            // "Alice pets Bob, Carol, and Dave. {descriptor}".
+            string names = JoinNamesSerial(consentersInOrder.Select(p => p.displayName).ToList());
+            return $"{initiatorProfile.displayName} pets {names}. {descriptor}";
+        }
+
+        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            return initiatorProfile.displayName + " wants to pet " + recipientProfile.displayName + ". Do you !consent to some scritches?";
+        }
+
+        /// <summary>
+        /// The custom <c>!seteicon pet</c> icon belongs to the one being petted — the recipient —
+        /// since residents keep a "being petted" eicon rather than a "petting someone" one.
+        /// </summary>
+        protected override Profile GetEiconSubject(string interactionVerb, Profile initiatorProfile, Profile recipientProfile)
+        {
+            return recipientProfile ?? initiatorProfile;
+        }
+
+        /// <summary>
+        /// Group custom-eicon flourish: each petted recipient's own <c>pet</c> eicon (in consent
+        /// order), not the initiator's. Mirrors the 1:1 <see cref="GetEiconSubject"/> redirect so
+        /// a group pet surfaces every "being petted" icon rather than the petter's.
+        /// </summary>
+        public override string GetGroupEiconSuffix(string interactionVerb, Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder)
+        {
+            string verb = string.IsNullOrEmpty(interactionVerb) ? InteractionType : interactionVerb;
+            if (InteractionEiconSupport.IsSelfRendered(verb)) return string.Empty;
+
+            var eicons = new List<string>();
+            if (consentersInOrder != null)
+            {
+                foreach (var consenter in consentersInOrder)
+                {
+                    AddInteractionEicon(eicons, consenter, verb);
+                }
+            }
+            return JoinEiconSuffix(eicons);
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionEiconSupport.cs
@@ -58,6 +58,7 @@ namespace FChatDicebot.InteractionProcessors
             { "lap", new[] { "lap" } },
             { "sit", new[] { "sit" } },
             { "lick", new[] { "lick" } },
+            { "pet", new[] { "pet" } },
             { "spank", new[] { "spank" } },
             // Involved
             { "climax", new[] { "climax" } },
@@ -99,7 +100,7 @@ namespace FChatDicebot.InteractionProcessors
         /// </summary>
         public static readonly string[] CanonicalTokensInOrder = new[]
         {
-            "boobhat", "bully", "cuddle", "handhold", "kiss", "lap", "sit", "lick", "spank",
+            "boobhat", "bully", "cuddle", "handhold", "kiss", "lap", "sit", "lick", "pet", "spank",
             "climax", "dressup", "feed", "golden", "milk", "pay",
             "birth", "bond", "breed", "consume", "corrupt", "purify", "employ", "entitle",
             "mark", "objectify", "petrify", "plant", "train",

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorRegistry.cs
@@ -33,6 +33,7 @@ namespace FChatDicebot.InteractionProcessors
             RegisterProcessor(new BullyProcessor());
             RegisterProcessor(new BoobhatProcessor());
             RegisterProcessor(new LickProcessor());
+            RegisterProcessor(new PetProcessor());
             // LapsitProcessor backs both !lap and !sit — same instance under two type keys
             // so each verb routes to the shared give/take logic.
             var lapsit = new LapsitProcessor();

--- a/wiki-docs/specs/Custom-Interaction-Eicons.md
+++ b/wiki-docs/specs/Custom-Interaction-Eicons.md
@@ -39,6 +39,7 @@ Driven by `InteractionProcessorBase.EiconAppliesToBothParties`:
 
 - **Directional (default):** only the initiator's eicon shows (e.g. `!spank`, `!mark`, `!feed`, `!corrupt`).
 - **Symmetric:** both parties' eicons show. Overridden to `true` on the mutual, co-equal interactions: **`cuddle`, `kiss`, `handhold`, `bond`**.
+- **Redirected subject:** a directional interaction can still point the single eicon at the *other* party by overriding `GetEiconSubject`. `!climax`/`!climaxfor` point it at whoever actually climaxed, and **`!pet`** points it at the recipient — residents keep a "my character being petted" eicon, so the natural icon is the pet's, not the petter's.
 
 Self-interactions (e.g. solo `!climax`) collapse to a single eicon.
 
@@ -48,6 +49,7 @@ The group path ([`GroupInteractionResolver`](../../FChatDicebot/InteractionProce
 
 - Symmetric group casuals (`cuddle`/`kiss`/`handhold`): every participant who set an eicon shows it.
 - Directional group casuals (`spank`/`bully`/`lick`/`boobhat`): only the initiator's.
+- Recipient-subject group casual (`pet`): overrides `GetGroupEiconSuffix` to show each petted recipient's eicon (in consent order), mirroring its 1:1 `GetEiconSubject` redirect — the initiator's is not shown.
 - **No de-duplication:** if several participants picked the same eicon it shows once per participant (e.g. three lipstick marks on a group kiss).
 
 ### Lap-stack per-position rule (totem pole)


### PR DESCRIPTION
## Summary

Adds a new directional casual interaction, `!pet`, modeled on `!lick`/`!spank` (`petgive` for the one petting, `pettake` for the one being petted), wired into every existing casual-interaction subsystem.

## Changes

- **PetProcessor** (`InteractionProcessors/Casual/PetProcessor.cs`): directional group spec (`petgive`/`pettake`), 30-minute count rate limit, consent warning, and 1:1 + group completion messages with descriptor flavor lines.
- **ChateauPet** command (`BotCommands/ChateauPet.cs`): the `!pet` chat command, including multi-target routing through `CasualGroupCommandSupport` so group pets get the shared consent flow, group counts, and group-size titles.
- **`!seteicon` support**: `pet` added to the token map and canonical list. Unlike the other directional casuals, the eicon shown is the **recipient's** (their "being petted" icon) — many residents keep a "my character being petted" eicon, so `GetEiconSubject` (1:1) and `GetGroupEiconSuffix` (group, one icon per petted recipient in consent order) are overridden to point at the pet rather than the petter. The `!seteicon` help text documents this.
- **Titles**:
  - `petgive` count milestones (the one petting): 1 → *[i]Pets You[/i]*, 10 → *Scritch Supplier*, 50 → *Power Petter*, 100 → *Gives The Best Scritches*, 500 → *Put on this Plane to Pet*.
  - `pettake` count milestones (the one petted): 1 → *Good Pet*, 10 → *Petteded*, 50 → *Scritches Please*, 100 → *Very Good Pet*, 500 → *Put on this Plane to be Pet*.
  - `pet` group-size titles: 4 → *Pet Pet Pet*, 6 → *Need More Limbs!*, 9 → *Octopets*, 11 → *Epetomy*.
- **Dossier**: count display labels (Pets Given / Pets Received) and casual-specialist text (Petting / Petted).
- **Help**: `!pet` added to the casual commands list.
- **Migration**: `pet` case added to `InteractionCountMigration`'s give/take key mapping.
- **Docs**: eicon spec (`wiki-docs/specs/Custom-Interaction-Eicons.md`) updated with the recipient-subject directionality rule.

## Tests

- `Petprocessortests.cs`: interaction type/level, directional group spec, count increments, history persistence, descriptor token resolution, and recipient-eicon directionality (1:1 and group).
- `Interactioneicontests.cs`: `pet` token mapping plus 1:1 and group suffix tests confirming the recipient's eicon shows and the initiator's does not.

Note: this environment has no .NET Framework 4.8 build tooling, so the change was verified by review against the sibling processors and test fixtures rather than a local build — CI / a local build should be the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqwH1rjoGdCVfKJe2nM6xF