### PR TITLE
Rework dossier layout around a consistent section-shape rule

### DIFF
--- a/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
@@ -535,9 +535,80 @@ namespace FChatDicebot.Tests.Unit
             string result = InvokeBuildCurrentlyEmploysSection("Boss");
 
             Assert.Contains("Currently employs", result);
-            Assert.Contains("Maids", result);
-            Assert.Contains("2", result);
-            Assert.Contains("Cook", result);
+            // Roles are pluralised by headcount and name their employees, mirroring Bonds.
+            Assert.Contains("[u]Maids:[/u] Worker 1, Worker 2", result);
+            Assert.Contains("[u]Cook:[/u] Other", result);
+            // Two roles is under the threshold, so nothing is hidden.
+            Assert.DoesNotContain("[spoiler]", result);
+        }
+
+        [Fact]
+        public void BuildCurrentlyEmploysSection_UnderThreshold_NoSpoilerOrSummary()
+        {
+            new ProfileBuilder().WithUserName("Boss").WithDisplayName("Boss").BuildAndSave(_fixture.Database);
+            foreach (string job in new[] { "maid", "cook", "artist", "athlete", "bartender", "builder" })
+            {
+                new ProfileBuilder()
+                    .WithUserName("W_" + job)
+                    .WithDisplayName("W " + job)
+                    .WithCharacteristic("employer", "Boss")
+                    .WithCharacteristic("job", job)
+                    .BuildAndSave(_fixture.Database);
+            }
+
+            string result = InvokeBuildCurrentlyEmploysSection("Boss");
+
+            // Exactly at SpoilerLineThreshold (6 roles) — still fully visible.
+            Assert.DoesNotContain("[spoiler]", result);
+            Assert.DoesNotContain("residents across", result);
+        }
+
+        [Fact]
+        public void BuildCurrentlyEmploysSection_OverThreshold_CollapsesWithCountSummary()
+        {
+            new ProfileBuilder().WithUserName("Boss").WithDisplayName("Boss").BuildAndSave(_fixture.Database);
+            string[] jobs = { "maid", "cook", "artist", "athlete", "bartender", "builder", "brute" };
+            foreach (string job in jobs)
+            {
+                new ProfileBuilder()
+                    .WithUserName("W_" + job)
+                    .WithDisplayName("W " + job)
+                    .WithCharacteristic("employer", "Boss")
+                    .WithCharacteristic("job", job)
+                    .BuildAndSave(_fixture.Database);
+            }
+
+            string result = InvokeBuildCurrentlyEmploysSection("Boss");
+
+            // 7 roles is past the threshold: header and scale stay visible, detail collapses.
+            Assert.Contains("[b]Currently employs:[/b] 7 residents across 7 roles [spoiler]", result);
+            Assert.EndsWith("[/spoiler]\n", result);
+            // Every employee is still present inside the spoiler — collapsing hides, never truncates.
+            foreach (string job in jobs)
+            {
+                Assert.Contains("W " + job, result);
+            }
+        }
+
+        [Fact]
+        public void BuildCurrentlyEmploysSection_OrdersByHeadcountThenNamesAlphabetically()
+        {
+            new ProfileBuilder().WithUserName("Boss").WithDisplayName("Boss").BuildAndSave(_fixture.Database);
+            new ProfileBuilder().WithUserName("Solo").WithDisplayName("Solo")
+                .WithCharacteristic("employer", "Boss").WithCharacteristic("job", "cook")
+                .BuildAndSave(_fixture.Database);
+            foreach (string name in new[] { "Zara", "Alice", "Mabel" })
+            {
+                new ProfileBuilder().WithUserName(name).WithDisplayName(name)
+                    .WithCharacteristic("employer", "Boss").WithCharacteristic("job", "maid")
+                    .BuildAndSave(_fixture.Database);
+            }
+
+            string result = InvokeBuildCurrentlyEmploysSection("Boss");
+
+            // Biggest team leads, and names within a role read alphabetically.
+            Assert.True(result.IndexOf("Maids:") < result.IndexOf("Cook:"));
+            Assert.Contains("[u]Maids:[/u] Alice, Mabel, Zara", result);
         }
 
         [Fact]
@@ -703,6 +774,234 @@ namespace FChatDicebot.Tests.Unit
 
         #endregion
 
+        #region Section shape rules (inline tallies vs. line lists vs. spoilers)
+
+        [Fact]
+        public void InlineSections_RenderAsASingleRow()
+        {
+            // The whole point of the layout pass: a block whose rows are "label: number"
+            // is one wrapped row, not one line per entry. Previously "Currently employs"
+            // and "Days of Experience" disagreed despite identical data shape.
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithJobExperience("maid", 5)
+                .WithJobExperience("cook", 3)
+                .WithJobExperience("artist", 2)
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildJobExperienceSection(profile);
+
+            Assert.Equal(1, result.Split('\n').Length - 1); // exactly one trailing newline
+            Assert.Contains("[u]Maid:[/u] 5", result);
+            Assert.Contains("[u]Cook:[/u] 3", result);
+            Assert.DoesNotContain("[spoiler]", result);
+        }
+
+        [Fact]
+        public void InlineSections_DoNotTrailASeparator()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCount("kiss", 10)
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildCasualInteractionsSection(profile);
+
+            Assert.EndsWith("10\n", result);
+        }
+
+        [Fact]
+        public void BuildBondsSection_OverThreshold_CollapsesWithCountSummary()
+        {
+            var builder = new ProfileBuilder().WithUserName("TestUser").WithDisplayName("Test User");
+            string[] bondTypes = { "marriage", "sibling", "ally", "rival", "client", "pet", "thrall" };
+            foreach (string bondType in bondTypes)
+            {
+                new ProfileBuilder().WithUserName("B_" + bondType).WithDisplayName("B " + bondType)
+                    .BuildAndSave(_fixture.Database);
+                builder.WithListItem("bond" + bondType + "initiated", "B_" + bondType);
+            }
+            var profile = builder.BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildBondsSection(profile);
+
+            Assert.Contains("7 across 7 kinds [spoiler]", result);
+            Assert.EndsWith("[/spoiler]\n", result);
+            foreach (string bondType in bondTypes)
+            {
+                Assert.Contains("B " + bondType, result);
+            }
+        }
+
+        [Fact]
+        public void BuildOffspringSection_MergesSiredAndBirthedIntoOneRow()
+        {
+            new ProfileBuilder()
+                .WithUserName("Carrier")
+                .WithDisplayName("Carrier")
+                .WithListItem("offspring", "2026-05-26: ogre brood of 4 (parent: TestUser)")
+                .BuildAndSave(_fixture.Database);
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithListItem("offspring", "2026-05-26: goblin brood of 5 (parent: Someone)")
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildOffspringSection(profile, "TestUser");
+
+            Assert.StartsWith("[b]Offspring:[/b]", result);
+            Assert.Contains("[u]Sired:[/u] Ogres: 4", result);
+            Assert.Contains("[u]Birthed:[/u] Goblins: 5", result);
+            Assert.Equal(1, result.Split('\n').Length - 1);
+        }
+
+        [Fact]
+        public void BuildOffspringSection_RendersOneHalfAloneWhenTheOtherIsAbsent()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithListItem("offspring", "2026-05-26: goblin brood of 5 (parent: Someone)")
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildOffspringSection(profile, "TestUser");
+
+            Assert.Contains("[u]Birthed:[/u] Goblins: 5", result);
+            Assert.DoesNotContain("Sired", result);
+        }
+
+        [Fact]
+        public void BuildAtAGlanceSection_MergesTitlesAndCurrency()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCurrency("gold", 12)
+                .BuildAndSave(_fixture.Database);
+            profile.titles = new List<Title> { new Title { titleText = "The Brave", givenBy = "Alice" } };
+            _fixture.Database.SetProfile("TestUser", profile);
+
+            string result = InvokeBuildAtAGlanceSection(_fixture.Database.GetProfile("TestUser"));
+
+            Assert.Contains("[b]Titles earned:[/b] 1", result);
+            Assert.Contains("[b]Most abundant currency:[/b] 12 gold", result);
+            Assert.Equal(1, result.Split('\n').Length - 1);
+        }
+
+        [Fact]
+        public void BuildAtAGlanceSection_NoTitlesOrCurrency_ReturnsEmpty()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .BuildAndSave(_fixture.Database);
+
+            Assert.Empty(InvokeBuildAtAGlanceSection(profile));
+        }
+
+        [Fact]
+        public void BuildFullDossier_BareProfile_GetsRecentArrivalNote()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildFullDossier(profile, "TestUser");
+
+            Assert.Contains("A recent arrival to the Chateau", result);
+        }
+
+        [Fact]
+        public void BuildFullDossier_JobButNoInteractions_HasNoRecentArrivalNote()
+        {
+            // A job is content in its own right, so it suppresses the note even before the
+            // resident has interacted with anyone.
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCharacteristic("job", "butler")
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildFullDossier(profile, "TestUser");
+
+            Assert.DoesNotContain("A recent arrival to the Chateau", result);
+            Assert.Contains("Currently working as a", result);
+        }
+
+        [Fact]
+        public void BuildFullDossier_ProfileWithContent_HasNoRecentArrivalNote()
+        {
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCount("kiss", 3)
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildFullDossier(profile, "TestUser");
+
+            Assert.DoesNotContain("A recent arrival to the Chateau", result);
+            Assert.Contains("Casual interactions", result);
+        }
+
+        [Fact]
+        public void BuildFullDossier_GroupsRelationshipsBeforeTallies()
+        {
+            new ProfileBuilder().WithUserName("Hire").WithDisplayName("Hire")
+                .WithCharacteristic("employer", "TestUser").WithCharacteristic("job", "maid")
+                .BuildAndSave(_fixture.Database);
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCount("kiss", 3)
+                .WithJobExperience("maid", 4)
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildFullDossier(profile, "TestUser");
+
+            // Employs is a roster now, so it sits with the relationship blocks rather than
+            // among the numeric tallies.
+            Assert.True(result.IndexOf("Currently employs") < result.IndexOf("Casual interactions"));
+            Assert.True(result.IndexOf("Casual interactions") < result.IndexOf("Days of [b]Experience[/b]"));
+        }
+
+        [Fact]
+        public void BuildFullDossier_HasNoUnbalancedSpoilerTags()
+        {
+            new ProfileBuilder().WithUserName("Hire").WithDisplayName("Hire")
+                .WithCharacteristic("employer", "TestUser").WithCharacteristic("job", "maid")
+                .BuildAndSave(_fixture.Database);
+            var profile = new ProfileBuilder()
+                .WithUserName("TestUser")
+                .WithDisplayName("Test User")
+                .WithCount("kiss", 3)
+                // An unrecognised job used to emit an unclosed [spoiler] via JobToText,
+                // swallowing every later section of the dossier.
+                .WithJobExperience("notarealjob", 4)
+                .BuildAndSave(_fixture.Database);
+
+            string result = InvokeBuildFullDossier(profile, "TestUser");
+
+            Assert.Equal(
+                CountOccurrences(result, "[spoiler]"),
+                CountOccurrences(result, "[/spoiler]"));
+        }
+
+        private static int CountOccurrences(string haystack, string needle)
+        {
+            int count = 0, index = 0;
+            while ((index = haystack.IndexOf(needle, index, StringComparison.Ordinal)) != -1)
+            {
+                count++;
+                index += needle.Length;
+            }
+            return count;
+        }
+
+        #endregion
+
         #region Helper Methods for Reflection
 
         private string InvokeBuildJobSection(Profile profile)
@@ -794,6 +1093,27 @@ namespace FChatDicebot.Tests.Unit
             var method = typeof(ChateauDossier).GetMethod("BuildInteractionCountsSection",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             return (string)method.Invoke(_dossier, new object[] { profile });
+        }
+
+        private string InvokeBuildOffspringSection(Profile profile, string targetUser)
+        {
+            var method = typeof(ChateauDossier).GetMethod("BuildOffspringSection",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return (string)method.Invoke(_dossier, new object[] { profile, targetUser });
+        }
+
+        private string InvokeBuildAtAGlanceSection(Profile profile)
+        {
+            var method = typeof(ChateauDossier).GetMethod("BuildAtAGlanceSection",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return (string)method.Invoke(_dossier, new object[] { profile });
+        }
+
+        private string InvokeBuildFullDossier(Profile profile, string targetUser)
+        {
+            var method = typeof(ChateauDossier).GetMethod("BuildFullDossier",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            return (string)method.Invoke(_dossier, new object[] { profile, targetUser });
         }
 
         #endregion

--- a/FChatDicebot.Tests/Unit/Textformatnumbercommastests.cs
+++ b/FChatDicebot.Tests/Unit/Textformatnumbercommastests.cs
@@ -1,0 +1,84 @@
+using FChatDicebot;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Covers <see cref="TextFormat.ApplyNumberCommas"/>, which every private message now
+    /// runs through unconditionally (BotMain.SendPrivateMessage). It used to comma-ise every
+    /// digit run in the message via a bare \d+, which corrupted anything that merely contained
+    /// digits — eicon names, character names, dates. These tests pin the "standalone numbers
+    /// only" rule that makes it safe to apply everywhere.
+    /// </summary>
+    public class TextFormatNumberCommasTests
+    {
+        [Theory]
+        [InlineData("14837 gold", "14,837 gold")]
+        [InlineData("You have 1000 chips.", "You have 1,000 chips.")]
+        [InlineData("Total: 1234567", "Total: 1,234,567")]
+        public void FormatsStandaloneNumbers(string input, string expected)
+        {
+            Assert.Equal(expected, TextFormat.ApplyNumberCommas(input));
+        }
+
+        [Theory]
+        [InlineData("999")]
+        [InlineData("Titles earned: 34")]
+        [InlineData("")]
+        public void LeavesShortNumbersUnchanged(string input)
+        {
+            Assert.Equal(input, TextFormat.ApplyNumberCommas(input));
+        }
+
+        [Theory]
+        // An eicon whose name contains digits must survive intact or the icon breaks.
+        [InlineData("[eicon]kanna1000[/eicon]")]
+        // F-Chat character names may contain digits.
+        [InlineData("[user]Robot2000[/user] arrived.")]
+        // Dates would otherwise render as "2,026-05-26".
+        [InlineData("2026-05-26: goblin brood of 3")]
+        // Decimals and URLs.
+        [InlineData("a rate of 1.5000 per day")]
+        [InlineData("see example.com/page/1234 for more")]
+        // Digits inside a BBCode tag's attributes.
+        [InlineData("[color=1234]text[/color]")]
+        // A name that is entirely numeric still has to survive — the digits touch only
+        // brackets, so the standalone rule can't tell it from a figure on its own.
+        [InlineData("[eicon]1000[/eicon]")]
+        [InlineData("[user]4815162342[/user]")]
+        [InlineData("[Eicon]1000[/Eicon]")]
+        public void LeavesEmbeddedDigitsUnchanged(string input)
+        {
+            Assert.Equal(input, TextFormat.ApplyNumberCommas(input));
+        }
+
+        [Fact]
+        public void StillFormatsNumbersInsideFormattingTags()
+        {
+            // [b] and friends wrap presentation, not an identifier, so a figure inside one
+            // is a real number and should format.
+            Assert.Equal("[b]14,837[/b] gold", TextFormat.ApplyNumberCommas("[b]14837[/b] gold"));
+        }
+
+        [Fact]
+        public void FormatsStandaloneNumberAlongsideProtectedText()
+        {
+            // The protected constructs and a real figure coexist in the same message.
+            string input = "[user]Robot2000[/user] earned 14837 gold on 2026-05-26.";
+            string expected = "[user]Robot2000[/user] earned 14,837 gold on 2026-05-26.";
+
+            Assert.Equal(expected, TextFormat.ApplyNumberCommas(input));
+        }
+
+        [Fact]
+        public void OverlongDigitRunIsLeftAloneRatherThanThrowing()
+        {
+            // Longer than a long can hold; previously long.Parse threw and the catch-all
+            // discarded formatting for the entire message.
+            string input = "count 12345678901234567890 here and 9999 there";
+
+            Assert.Equal("count 12345678901234567890 here and 9,999 there",
+                TextFormat.ApplyNumberCommas(input));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -52,7 +52,9 @@ namespace FChatDicebot.BotCommands
 
             var database = MonDB.GetDatabase();
             int pendingMinutesKeep = InteractionProcessors.GroupInteractionResolver.PendingMinutesKeep;
-            int maxNoSpoilerLength = 500;
+            // Raised from 500: consent readouts were collapsing into a spoiler more often
+            // than the length really warranted, hiding ordinary-sized results behind a click.
+            int maxNoSpoilerLength = 1000;
             string privateMessage = string.Empty;
             string channelMessage = string.Empty;
 

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -146,6 +146,83 @@ namespace FChatDicebot.BotCommands
             { "dosetake", "Addicted" }
         };
 
+        // ---------------------------------------------------------------------------
+        // Section rendering
+        //
+        // Every block in the dossier is one of two shapes, decided by what a row holds:
+        //
+        //   Inline  — the row is a short label and a single number ("Maids: 5"). The whole
+        //             block renders as one wrapped row. Used for the tally blocks.
+        //   Lines   — the row carries names or prose ("Spouses: Alice, Bob, Carol"). Each
+        //             row gets its own line.
+        //
+        // Before this, blocks with identical data shape disagreed: "Days of Experience"
+        // (job -> number) was inline while "Currently employs" (job -> number) was one line
+        // per job, which is what made a heavy employer's dossier enormous.
+        //
+        // A Lines block longer than SpoilerLineThreshold collapses into a [spoiler], with a
+        // count summary left visible so the reader knows the scale without opening it.
+        // Inline blocks are one line by construction and never collapse.
+        // ---------------------------------------------------------------------------
+
+        /// <summary>Row count above which a Lines-shaped section collapses into a spoiler.</summary>
+        public const int SpoilerLineThreshold = 6;
+
+        /// <summary>Gap between entries in an Inline-shaped section.</summary>
+        private const string InlineSeparator = "   ";
+
+        /// <summary>
+        /// Renders an Inline section: one wrapped row of "label: value" cells under a header.
+        /// <paramref name="header"/> carries its own BBCode and trailing colon. Returns empty
+        /// for an empty cell list so callers can append unconditionally.
+        /// </summary>
+        private static string RenderInlineSection(string header, IList<string> cells)
+        {
+            if (cells == null || cells.Count == 0) return string.Empty;
+            return header + " " + string.Join(InlineSeparator, cells) + "\n";
+        }
+
+        /// <summary>
+        /// Renders a Lines section: one line per row under a header. Past
+        /// <see cref="SpoilerLineThreshold"/> rows the body is wrapped in a spoiler and
+        /// <paramref name="summary"/> (e.g. "23 residents across 11 roles") is shown beside
+        /// the header so the collapsed block still reports its own size.
+        /// </summary>
+        private static string RenderLineSection(string header, string summary, IList<string> rows)
+        {
+            if (rows == null || rows.Count == 0) return string.Empty;
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(header);
+            if (rows.Count > SpoilerLineThreshold)
+            {
+                if (!string.IsNullOrEmpty(summary))
+                {
+                    sb.Append(' ').Append(summary);
+                }
+                sb.Append(" [spoiler]\n");
+                sb.Append(string.Join("\n", rows));
+                sb.Append("[/spoiler]\n");
+            }
+            else
+            {
+                sb.Append('\n');
+                sb.Append(string.Join("\n", rows));
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Joins the cluster strings that actually produced content, separating each with a
+        /// blank line. Skipping empties is what stops a resident with no active curses from
+        /// getting a stray gap where the state cluster would have been.
+        /// </summary>
+        private static string JoinClusters(params string[] clusters)
+        {
+            return string.Join("\n", clusters.Where(c => !string.IsNullOrEmpty(c)));
+        }
+
         /// <summary>
         /// Constructor for dependency injection (for testing)
         /// </summary>
@@ -199,64 +276,57 @@ namespace FChatDicebot.BotCommands
         }
 
         /// <summary>
-        /// Builds the complete dossier by calling all section builders
+        /// Builds the complete dossier, grouped into themed clusters separated by blank
+        /// lines: who they are, what's currently affecting them, who they're connected to,
+        /// what they've racked up, and what happened lately. Sections were previously
+        /// emitted in the order the features shipped, which scattered related facts.
         /// </summary>
         private string BuildFullDossier(Profile profile, string targetUser)
         {
-            StringBuilder sb = new StringBuilder();
-
-            // Build all sections
+            // Who they are.
             string header = BuildNameTitleSpecialties(profile, targetUser);
             string jobSection = BuildJobSection(profile);
-            string activeCurses = BuildActiveCursesSection(profile);
-            string activeParasites = BuildActiveParasitesSection(profile);
-            string activeBreaks = BuildActiveBreaksSection(profile);
-            string activeOdorizes = BuildActiveOdorizesSection(profile);
-            string casualSection = BuildCasualInteractionsSection(profile);
-            string interactionCountsSection = BuildInteractionCountsSection(profile);
-            string marksSection = BuildMarksSection(profile);
-            string bondsSection = BuildBondsSection(profile);
-            string siredSection = BuildSiredSection(targetUser);
-            string birthedSection = BuildBirthedSection(profile);
-            string plantedSection = BuildPersonallyPlantedSection(targetUser);
-            string employsSection = BuildCurrentlyEmploysSection(targetUser);
-            string titlesEarnedSection = BuildTitlesEarnedSection(profile);
-            string abundantCurrencySection = BuildMostAbundantCurrencySection(profile);
-            string experienceSection = BuildJobExperienceSection(profile);
-            string lastReportedSection = BuildLastReportedSection(targetUser);
-            string lastSeenSection = BuildLastSeenSection(targetUser);
+            string identity = header + jobSection;
 
-            // Assemble the full dossier
-            sb.Append(header);
-            sb.Append(jobSection);
-            sb.Append(activeCurses);
-            sb.Append(activeParasites);
-            sb.Append(activeBreaks);
-            sb.Append(activeOdorizes);
-            sb.Append("\n");
-            sb.Append(casualSection);
-            sb.Append(interactionCountsSection);
-            sb.Append(marksSection);
-            sb.Append(bondsSection);
-            sb.Append(siredSection);
-            sb.Append(birthedSection);
-            sb.Append(plantedSection);
-            sb.Append(employsSection);
-            sb.Append(titlesEarnedSection);
-            sb.Append(abundantCurrencySection);
-            sb.Append(experienceSection);
-            sb.Append("\n");
-            sb.Append(lastReportedSection);
-            sb.Append(lastSeenSection);
+            // What's currently on them.
+            string state =
+                BuildActiveCursesSection(profile) +
+                BuildActiveParasitesSection(profile) +
+                BuildActiveBreaksSection(profile) +
+                BuildActiveOdorizesSection(profile);
 
-            // Check if this is a new arrival with no meaningful content
-            string finalText = sb.ToString();
-            if (finalText == header + "\n\n")
+            // Who they know. "Currently employs" lives here rather than with the tallies
+            // because it now names the residents, making it a roster like Bonds and Marks.
+            string relationships =
+                BuildBondsSection(profile) +
+                BuildMarksSection(profile) +
+                BuildCurrentlyEmploysSection(targetUser);
+
+            // What they've done.
+            string tallies =
+                BuildCasualInteractionsSection(profile) +
+                BuildInteractionCountsSection(profile) +
+                BuildOffspringSection(profile, targetUser) +
+                BuildPersonallyPlantedSection(targetUser) +
+                BuildAtAGlanceSection(profile) +
+                BuildJobExperienceSection(profile);
+
+            // What happened lately.
+            string lately =
+                BuildLastReportedSection(targetUser) +
+                BuildLastSeenSection(targetUser);
+
+            // A profile with nothing but a name gets the new-arrival note. Checking the
+            // content sections directly (rather than the old string-equality check against
+            // header + "\n\n") keeps this correct as sections get added or reordered. A job
+            // counts as content — it's something in their file, even with no interactions yet.
+            if (jobSection.Length == 0 && state.Length == 0 && relationships.Length == 0
+                && tallies.Length == 0 && lately.Length == 0)
             {
-                sb.Append("[sub]A recent arrival to the Chateau. There doesn't seem to be much in their file... there will be more to read once they interact with others. Maybe you should give them a !kiss[/sub]");
+                return identity + "\n[sub]A recent arrival to the Chateau. There doesn't seem to be much in their file... there will be more to read once they interact with others. Maybe you should give them a !kiss[/sub]";
             }
 
-            return sb.ToString();
+            return JoinClusters(identity, state, relationships, tallies, lately);
         }
 
         /// <summary>
@@ -371,12 +441,17 @@ namespace FChatDicebot.BotCommands
             StringBuilder sb = new StringBuilder();
             string job = Utils.JobToText(profile.characteristics["job"]);
 
+            // Both branches need the "Currently working" lead-in: without it a self-employed
+            // resident's line rendered as a bare fragment ("as a Boss") with nothing in front
+            // of it, because the lead-in only existed inside the employer branch.
+            sb.Append("Currently working ");
+
             if (profile.characteristics.ContainsKey("employer"))
             {
                 Profile employerProfile = _database.GetProfile(profile.characteristics["employer"]);
                 if (employerProfile != null)
                 {
-                    sb.Append("Currently working under ");
+                    sb.Append("under ");
                     sb.Append(employerProfile.displayName);
                     sb.Append(" ");
                 }
@@ -398,16 +473,15 @@ namespace FChatDicebot.BotCommands
         private string BuildActiveCursesSection(Profile profile)
         {
             var curses = CurseInstance.LoadAll(profile);
-            if (curses.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Active Curses:[/b]");
+            List<string> rows = new List<string>();
             foreach (var curse in curses)
             {
                 string applierName = string.IsNullOrEmpty(curse.AppliedBy) ? "someone" : ResolveDisplayName(curse.AppliedBy);
-                sb.Append("\n[u]").Append(Utils.Capitalize(curse.Curse ?? string.Empty)).Append(":[/u] from ").Append(applierName);
+                rows.Add("[u]" + Utils.Capitalize(curse.Curse ?? string.Empty) + ":[/u] from " + applierName);
             }
-            sb.Append('\n');
-            return sb.ToString();
+            // Bare count: the header already names what's being counted, so "7 curses" here
+            // would just repeat itself.
+            return RenderLineSection("[b]Active Curses:[/b]", rows.Count.ToString(), rows);
         }
 
         /// <summary>
@@ -418,20 +492,19 @@ namespace FChatDicebot.BotCommands
         private string BuildActiveParasitesSection(Profile profile)
         {
             var parasites = ParasiteInstance.LoadAll(profile);
-            if (parasites.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Active Parasites:[/b]");
+            List<string> rows = new List<string>();
             foreach (var p in parasites)
             {
                 string infesterName = string.IsNullOrEmpty(p.InfestedBy) ? "an unknown source" : ResolveDisplayName(p.InfestedBy);
-                sb.Append("\n[u]").Append(ScentText.Capitalize(ParasiteText.ParasiteName(p.Parasite))).Append(":[/u] from ").Append(infesterName);
+                string row = "[u]" + ScentText.Capitalize(ParasiteText.ParasiteName(p.Parasite)) + ":[/u] from " + infesterName;
                 if (p.SpreadFromContact && DateTime.UtcNow < p.GraceUntil)
                 {
-                    sb.Append(" (still within !purge grace window)");
+                    row += " (still within !purge grace window)";
                 }
+                rows.Add(row);
             }
-            sb.Append('\n');
-            return sb.ToString();
+            // Bare count, as with Active Curses — the header already says what these are.
+            return RenderLineSection("[b]Active Parasites:[/b]", rows.Count.ToString(), rows);
         }
 
         /// <summary>
@@ -442,16 +515,11 @@ namespace FChatDicebot.BotCommands
         private string BuildActiveBreaksSection(Profile profile)
         {
             var breaks = BreakInstance.LoadAll(profile);
-            if (breaks.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Active Breaks:[/b]");
-            foreach (var b in breaks)
-            {
-                sb.Append("\n[u]").Append(Utils.BodypartToText(b.Part ?? string.Empty)).Append(":[/u] ")
-                  .Append(b.Severity).Append(b.Severity == 1 ? " day remaining" : " days remaining");
-            }
-            sb.Append('\n');
-            return sb.ToString();
+            List<string> cells = breaks
+                .Select(b => "[u]" + Utils.Capitalize(Utils.BodypartToText(b.Part ?? string.Empty)) + ":[/u] "
+                    + b.Severity + (b.Severity == 1 ? " day left" : " days left"))
+                .ToList();
+            return RenderInlineSection("[b]Active Breaks:[/b]", cells);
         }
 
         /// <summary>
@@ -460,9 +528,7 @@ namespace FChatDicebot.BotCommands
         private string BuildActiveOdorizesSection(Profile profile)
         {
             var scents = ScentLayer.LoadAll(profile);
-            if (scents.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Active Scents:[/b]");
+            List<string> cells = new List<string>();
             foreach (var s in scents)
             {
                 // Route through the SSOT scent-phrase helper (same one !odorize itself uses)
@@ -472,11 +538,10 @@ namespace FChatDicebot.BotCommands
                 string appliedByDisplay = _database.GetDisplayName(s.AppliedBy) ?? s.AppliedBy;
                 string scentPhrase = ScentText.ScentPhrase(scentIdentifier, s.Scent, appliedByDisplay);
 
-                sb.Append("\n[u]").Append(Utils.Capitalize(scentPhrase)).Append(":[/u] ")
-                  .Append(s.Layers).Append(s.Layers == 1 ? " layer" : " layers");
+                cells.Add("[u]" + Utils.Capitalize(scentPhrase) + ":[/u] "
+                    + s.Layers + (s.Layers == 1 ? " layer" : " layers"));
             }
-            sb.Append('\n');
-            return sb.ToString();
+            return RenderInlineSection("[b]Active Scents:[/b]", cells);
         }
 
         /// <summary>
@@ -487,6 +552,20 @@ namespace FChatDicebot.BotCommands
         {
             var sired = Support.ChateauStatisticsSupport.SiredByMonsterType(_database.GetAllProfiles(), targetUser);
             return BuildPerMonsterBlock("Sired", sired);
+        }
+
+        /// <summary>
+        /// Sired and Birthed are both per-monster offspring tallies and both usually short,
+        /// so they share one row instead of owning a header each.
+        /// </summary>
+        private string BuildOffspringSection(Profile profile, string targetUser)
+        {
+            List<string> cells = new List<string>();
+            string sired = BuildSiredSection(targetUser);
+            string birthed = BuildBirthedSection(profile);
+            if (!string.IsNullOrEmpty(sired)) cells.Add(sired);
+            if (!string.IsNullOrEmpty(birthed)) cells.Add(birthed);
+            return RenderInlineSection("[b]Offspring:[/b]", cells);
         }
 
         /// <summary>
@@ -516,26 +595,27 @@ namespace FChatDicebot.BotCommands
                 if (!byPlant.ContainsKey(plant)) byPlant[plant] = 0;
                 byPlant[plant]++;
             }
-            if (byPlant.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Has personally planted:[/b]");
-            foreach (var kv in byPlant.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
-            {
-                string label = kv.Value == 1 ? Utils.Capitalize(kv.Key) : Utils.Capitalize(kv.Key) + "s";
-                sb.Append("\n[u]").Append(label).Append(":[/u] ").Append(kv.Value);
-            }
-            sb.Append('\n');
-            return sb.ToString();
+            List<string> cells = byPlant
+                .OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key)
+                .Select(kv => "[u]" + (kv.Value == 1 ? Utils.Capitalize(kv.Key) : Utils.Capitalize(kv.Key) + "s") + ":[/u] " + kv.Value)
+                .ToList();
+            return RenderInlineSection("[b]Has personally planted:[/b]", cells);
         }
 
         /// <summary>
-        /// Per-job current headcount for residents this user employs. Scans all profiles for
+        /// Per-job roster of residents this user employs, naming each employee the way the
+        /// Bonds section names bonded residents. Scans all profiles for
         /// <c>characteristics["employer"]</c> matching the target's userName.
+        ///
+        /// This used to print a bare headcount per job, one job per line, which is what made
+        /// a large employer's dossier balloon — the same job-to-number shape that "Days of
+        /// Experience" had always rendered as a single inline row. Now that the rows carry
+        /// names it's a Lines section, and the spoiler threshold keeps the length in check.
         /// </summary>
         private string BuildCurrentlyEmploysSection(string targetUser)
         {
             var allProfiles = _database.GetAllProfiles();
-            Dictionary<string, int> byJob = new Dictionary<string, int>();
+            Dictionary<string, List<string>> byJob = new Dictionary<string, List<string>>();
             foreach (var p in allProfiles)
             {
                 if (p?.characteristics == null) continue;
@@ -545,19 +625,22 @@ namespace FChatDicebot.BotCommands
                 if (string.Equals(p.userName, targetUser, StringComparison.OrdinalIgnoreCase)) continue; // skip self
                 string job = (p.characteristics["job"] ?? string.Empty).ToLowerInvariant();
                 if (string.IsNullOrEmpty(job)) continue;
-                if (!byJob.ContainsKey(job)) byJob[job] = 0;
-                byJob[job]++;
+                if (!byJob.ContainsKey(job)) byJob[job] = new List<string>();
+                byJob[job].Add(string.IsNullOrEmpty(p.displayName) ? p.userName : p.displayName);
             }
             if (byJob.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Currently employs:[/b]");
-            foreach (var entry in byJob.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
-            {
-                string label = entry.Value == 1 ? Utils.JobToText(entry.Key) : Utils.JobToPlural(entry.Key);
-                sb.Append("\n[u]").Append(label).Append(":[/u] ").Append(entry.Value);
-            }
-            sb.Append('\n');
-            return sb.ToString();
+
+            // Biggest teams first (ties alphabetical by job) so the roles that define this
+            // employer lead; names within a role are alphabetical for a stable read.
+            List<string> rows = byJob
+                .OrderByDescending(kv => kv.Value.Count).ThenBy(kv => kv.Key)
+                .Select(kv => "[u]" + (kv.Value.Count == 1 ? Utils.JobToText(kv.Key) : Utils.JobToPlural(kv.Key)) + ":[/u] "
+                    + string.Join(", ", kv.Value.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)))
+                .ToList();
+
+            int totalEmployees = byJob.Sum(kv => kv.Value.Count);
+            string summary = totalEmployees + " residents across " + rows.Count + " roles";
+            return RenderLineSection("[b]Currently employs:[/b]", summary, rows);
         }
 
         /// <summary>
@@ -568,7 +651,23 @@ namespace FChatDicebot.BotCommands
         {
             int count = profile.titles?.Count ?? 0;
             if (count <= 0) return string.Empty;
-            return "[b]Titles earned:[/b] " + count + "\n";
+            return "[b]Titles earned:[/b] " + count;
+        }
+
+        /// <summary>
+        /// Two standalone one-line facts — titles earned and wealthiest currency — sharing a
+        /// row so they read as an at-a-glance stat line rather than owning a line each.
+        /// Either half renders alone when the other is absent.
+        /// </summary>
+        private string BuildAtAGlanceSection(Profile profile)
+        {
+            List<string> cells = new List<string>();
+            string titles = BuildTitlesEarnedSection(profile);
+            string currency = BuildMostAbundantCurrencySection(profile);
+            if (!string.IsNullOrEmpty(titles)) cells.Add(titles);
+            if (!string.IsNullOrEmpty(currency)) cells.Add(currency);
+            if (cells.Count == 0) return string.Empty;
+            return string.Join(InlineSeparator, cells) + "\n";
         }
 
         /// <summary>
@@ -584,27 +683,26 @@ namespace FChatDicebot.BotCommands
             int max = positive.Max(kv => kv.Value);
             var top = positive.Where(kv => kv.Value == max).Select(kv => kv.Key).OrderBy(k => k).ToList();
             string currencyText = string.Join("/", top);
-            return "[b]Most abundant currency:[/b] " + max + " " + currencyText + "\n";
+            return "[b]Most abundant currency:[/b] " + max + " " + currencyText;
         }
 
         /// <summary>
-        /// Shared block layout for the Sired / Birthed / similar per-monster sections.
-        /// Mirrors the Bonds section style — header on its own line, then "Type: count"
-        /// rows.
+        /// Shared fragment for the Sired / Birthed per-monster tallies. Returns a single
+        /// labelled cell ("[u]Sired:[/u] Goblins: 12, Ogres: 4") for the caller to place in
+        /// an Inline section, or empty when nothing is countable.
         /// </summary>
         private string BuildPerMonsterBlock(string label, Dictionary<string, int> counts)
         {
             if (counts == null || counts.Count == 0) return string.Empty;
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]").Append(label).Append(":[/b]");
+            List<string> parts = new List<string>();
             foreach (var entry in counts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
             {
                 if (entry.Value <= 0) continue;
                 string monster = entry.Value == 1 ? Utils.Capitalize(entry.Key) : Utils.Capitalize(entry.Key) + "s";
-                sb.Append("\n[u]").Append(monster).Append(":[/u] ").Append(entry.Value);
+                parts.Add(monster + ": " + entry.Value);
             }
-            sb.Append('\n');
-            return sb.ToString();
+            if (parts.Count == 0) return string.Empty;
+            return "[u]" + label + ":[/u] " + string.Join(", ", parts);
         }
 
         /// <summary>
@@ -638,28 +736,11 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
-            if (casualCounts.Count == 0)
-            {
-                return string.Empty;
-            }
-
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Casual interactions:[/b] ");
-
-            foreach (var count in casualCounts)
-            {
-                if (CountDisplayNames.ContainsKey(count.Key))
-                {
-                    sb.Append("[u]");
-                    sb.Append(CountDisplayNames[count.Key]);
-                    sb.Append(":[/u] ");
-                    sb.Append(count.Value);
-                    sb.Append("   ");
-                }
-            }
-
-            sb.Append("\n");
-            return sb.ToString();
+            List<string> cells = casualCounts
+                .Where(c => CountDisplayNames.ContainsKey(c.Key))
+                .Select(c => "[u]" + CountDisplayNames[c.Key] + ":[/u] " + c.Value)
+                .ToList();
+            return RenderInlineSection("[b]Casual interactions:[/b]", cells);
         }
 
         /// <summary>
@@ -693,20 +774,16 @@ namespace FChatDicebot.BotCommands
                 if (total > 0) summed[pair.Key] = total;
             }
 
-            if (individual.Count == 0 && summed.Count == 0) return string.Empty;
-
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Notable counts:[/b] ");
+            List<string> cells = new List<string>();
             foreach (var entry in summed)
             {
-                sb.Append("[u]").Append(entry.Key).Append(":[/u] ").Append(entry.Value).Append("   ");
+                cells.Add("[u]" + entry.Key + ":[/u] " + entry.Value);
             }
             foreach (var entry in individual.OrderBy(kv => CountDisplayNames[kv.Key]))
             {
-                sb.Append("[u]").Append(CountDisplayNames[entry.Key]).Append(":[/u] ").Append(entry.Value).Append("   ");
+                cells.Add("[u]" + CountDisplayNames[entry.Key] + ":[/u] " + entry.Value);
             }
-            sb.Append('\n');
-            return sb.ToString();
+            return RenderInlineSection("[b]Notable counts:[/b]", cells);
         }
 
         /// <summary>
@@ -719,42 +796,39 @@ namespace FChatDicebot.BotCommands
                 return string.Empty;
             }
 
-            StringBuilder sb = new StringBuilder();
-            bool hasMarks = false;
+            List<string> rows = new List<string>();
+            int totalMarks = 0;
 
             foreach (var list in profile.lists)
             {
                 if (list.Key.EndsWith("marks") && list.Value.Count > 0)
                 {
-                    if (!hasMarks)
-                    {
-                        sb.Append("Currently known [b]Marks[/b]");
-                        hasMarks = true;
-                    }
-
                     string bodyPart = list.Key.Substring(0, list.Key.Length - 5);
-                    sb.Append("\n[u]");
-                    sb.Append(Utils.BodypartToText(bodyPart));
-                    sb.Append(":[/u]");
 
+                    // A listed marker only shows up if their profile still carries a "mark"
+                    // characteristic, so gather the symbols first: a bodypart whose markers
+                    // all failed to resolve would otherwise emit a label with nothing after
+                    // it and still inflate the "across N places" summary.
+                    List<string> symbols = new List<string>();
                     foreach (string marker in list.Value)
                     {
                         Profile markerProfile = _database.GetProfile(marker);
                         if (markerProfile != null && markerProfile.characteristics.ContainsKey("mark"))
                         {
-                            sb.Append(" ");
-                            sb.Append(markerProfile.characteristics["mark"]);
+                            symbols.Add(markerProfile.characteristics["mark"]);
                         }
                     }
+                    if (symbols.Count == 0) continue;
+
+                    totalMarks += symbols.Count;
+                    // BodypartToText returns a bare lowercase key ("neck"); every other
+                    // labelled row in the dossier capitalises, so capitalise here too.
+                    rows.Add("[u]" + Utils.Capitalize(Utils.BodypartToText(bodyPart)) + ":[/u] "
+                        + string.Join(" ", symbols));
                 }
             }
 
-            if (hasMarks)
-            {
-                sb.Append("\n");
-            }
-
-            return sb.ToString();
+            return RenderLineSection("Currently known [b]Marks[/b]:", totalMarks + " across " + rows.Count + " places", rows);
         }
 
         /// <summary>
@@ -767,19 +841,13 @@ namespace FChatDicebot.BotCommands
                 return string.Empty;
             }
 
-            StringBuilder sb = new StringBuilder();
-            bool hasBonds = false;
+            List<string> rows = new List<string>();
+            int totalBonds = 0;
 
             foreach (var list in profile.lists)
             {
                 if (list.Key.StartsWith("bond") && list.Value.Count > 0)
                 {
-                    if (!hasBonds)
-                    {
-                        sb.Append("\nCurrently known [b]Bonds[/b]:");
-                        hasBonds = true;
-                    }
-
                     string bondType = string.Empty;
                     bool isInitiated = false;
 
@@ -796,10 +864,6 @@ namespace FChatDicebot.BotCommands
 
                     if (!string.IsNullOrEmpty(bondType))
                     {
-                        sb.Append("\n[u]");
-                        sb.Append(Utils.Capitalize(Utils.BondToPlural(bondType, isInitiated)));
-                        sb.Append(":[/u] ");
-
                         List<string> displayNames = new List<string>();
                         foreach (string bonder in list.Value)
                         {
@@ -810,17 +874,14 @@ namespace FChatDicebot.BotCommands
                             }
                         }
 
-                        sb.Append(string.Join(", ", displayNames));
+                        totalBonds += displayNames.Count;
+                        rows.Add("[u]" + Utils.Capitalize(Utils.BondToPlural(bondType, isInitiated)) + ":[/u] "
+                            + string.Join(", ", displayNames));
                     }
                 }
             }
 
-            if (hasBonds)
-            {
-                sb.Append("\n");
-            }
-
-            return sb.ToString();
+            return RenderLineSection("Currently known [b]Bonds[/b]:", totalBonds + " across " + rows.Count + " kinds", rows);
         }
 
         /// <summary>
@@ -833,20 +894,10 @@ namespace FChatDicebot.BotCommands
                 return string.Empty;
             }
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append("\nDays of [b]Experience[/b] working as... \n");
-
-            foreach (var jobExp in profile.jobExperience)
-            {
-                sb.Append("[u]");
-                sb.Append(Utils.JobToText(jobExp.Key));
-                sb.Append(":[/u] ");
-                sb.Append(jobExp.Value);
-                sb.Append("   ");
-            }
-
-            sb.Append("\n");
-            return sb.ToString();
+            List<string> cells = profile.jobExperience
+                .Select(jobExp => "[u]" + Utils.JobToText(jobExp.Key) + ":[/u] " + jobExp.Value)
+                .ToList();
+            return RenderInlineSection("Days of [b]Experience[/b] working as...", cells);
         }
 
         /// <summary>

--- a/FChatDicebot/BotMain.cs
+++ b/FChatDicebot/BotMain.cs
@@ -1598,7 +1598,12 @@ namespace FChatDicebot
         public void SendPrivateMessage(string message, MessageAddress address)// string recipient)
         {
             ChannelSettings settings = GetChannelSettings(address);
-            message = TextFormat.ApplyNumberCommasIfNecessary(message, settings);
+            // Private messages always get thousands separators. ShowCommasInNumbers is a
+            // per-channel setting and a PM has no channel — GetChannelSettings returns null
+            // for a channel-less address — so routing through ApplyNumberCommasIfNecessary
+            // meant no PM ever got commas, however large the figure (the dossier's "Most
+            // abundant currency" line being the one that made this obvious).
+            message = TextFormat.ApplyNumberCommas(message);
             message = TextFormat.SubstituteInCurrencyName(message, settings);
             message = TextFormat.SpoilerAllIfEnabled(message, settings);
 

--- a/FChatDicebot/TextFormat.cs
+++ b/FChatDicebot/TextFormat.cs
@@ -120,6 +120,32 @@ namespace FChatDicebot
                 return chatMessage;
         }
 
+        // Matches, in priority order: an identifier-bearing BBCode element and its contents,
+        // any other BBCode tag, or a standalone number. Only the last is reformatted.
+        //
+        // The first alternative exists because those tags wrap a *name*, and a name that
+        // happens to be numeric ("[eicon]1000[/eicon]") would otherwise be comma'd into a
+        // broken icon — the digits touch only brackets, so the standalone rule alone can't
+        // see the difference. Contents can't contain brackets, so [^\[\]]* is both precise
+        // and backtracking-safe.
+        //
+        // "Standalone" then excludes any digit run touching a word character, hyphen, dot or
+        // slash, keeping the formatter off:
+        //   [user]Robot2000[/user]    F-Chat names may contain digits
+        //   2026-05-26                dates, which otherwise render as "2,026-05-26"
+        //   1.5 / example.com/1234    decimals and URLs
+        // A bare "14837 gold" still formats, and so does "[b]14837[/b]". This used to be a
+        // plain \d+ over the whole string, which mangled all of the above wherever number
+        // commas were switched on.
+        private static readonly Regex StandaloneNumberRegex = new Regex(
+            @"(?<wrapped>\[(?<tagname>eicon|icon|user|session)\][^\[\]]*\[/\k<tagname>\])" +
+            @"|(?<tag>\[[^\]]*\])" +
+            @"|(?<![\w\-./])(?<num>\d+)(?![\w\-./])",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        /// <summary>Digits beyond this can't fit a long, so they're left alone rather than throwing.</summary>
+        private const int MaxFormattableDigits = 18;
+
         public static string ApplyNumberCommas(string chatMessage)
         {
             try
@@ -130,14 +156,20 @@ namespace FChatDicebot
                     return chatMessage;
                 }
 
-                // Regular expression to match sequences of digits
-                var regex = new Regex(@"\d+");
-
-                // Replace each match with a formatted version that includes commas
-                return regex.Replace(chatMessage, match =>
+                return StandaloneNumberRegex.Replace(chatMessage, match =>
                 {
-                    // Format the number with commas
-                    return long.Parse(match.Value).ToString("N0");
+                    if (match.Groups["wrapped"].Success || match.Groups["tag"].Success)
+                    {
+                        return match.Value;
+                    }
+
+                    string digits = match.Groups["num"].Value;
+                    if (digits.Length > MaxFormattableDigits)
+                    {
+                        return digits;
+                    }
+
+                    return long.Parse(digits).ToString("N0");
                 });
             }
             catch (Exception exc)

--- a/FChatDicebot/Utils.cs
+++ b/FChatDicebot/Utils.cs
@@ -662,7 +662,11 @@ namespace FChatDicebot
             }
             else
             {
-                return "Purveyor of New Professions [spoiler]that means [user]Queen Contract[/user] needs to update Utils.JobToText to include " + job + ", go tell her to fix it!";
+                // The [/spoiler] here is load-bearing: every other "go tell her to fix it"
+                // string closes its tag, and this one didn't — so an unrecognised job
+                // rendered anywhere mid-message (the dossier's employs/experience blocks
+                // being the worst case) swallowed everything after it into the spoiler.
+                return "Purveyor of New Professions [spoiler]that means [user]Queen Contract[/user] needs to update Utils.JobToText to include " + job + ", go tell her to fix it![/spoiler]";
             }
         }
 

--- a/wiki-docs/specs/Statistics-and-Dossier.md
+++ b/wiki-docs/specs/Statistics-and-Dossier.md
@@ -256,6 +256,80 @@ For dossier:
 - **Dossier counts row is split into two:** `Casual interactions:` (existing, unchanged) and a new `Notable counts:` row that holds the give/take split for non-casual counters (`Orgasms`, `Bodyparts Exhausted`, `Curses Endured`, `Costume Changes`, `Golden Showers`, `Personal Payments`) plus summed entries (`Marks Shared`, `Meals Shared`). The original spec left section title as implementer's call; this is the as-shipped split.
 - **`ChateauStatisticsSupport` is a shared helper** under [FChatDicebot/BotCommands/Support/](../../FChatDicebot/BotCommands/Support/), not collocated with any single command. The auto-registration loop scans `FChatDicebot.BotCommands` for `ChatBotCommand` subclasses and crashes on static classes in that namespace — `Support` is a sibling namespace to keep the static helper out of its path.
 
+## Dossier layout pass (2026-07-26)
+
+The per-resident blocks above each picked their own render shape, which made the most active
+residents' dossiers enormous. `Currently employs` was the trigger — a bare headcount per job,
+one job per line — but the underlying problem was that `Days of Experience` (job → number) had
+always rendered as a single inline row while `Currently employs` (job → number) rendered one
+line per job. Same data shape, opposite treatment.
+
+**Every block now has one of two shapes, chosen by what a row holds:**
+
+| Shape | Row holds | Renders as | Blocks |
+|---|---|---|---|
+| Inline | short label + a single number | one wrapped row | Casual interactions, Notable counts, Offspring, Has personally planted, Days of Experience, Active Breaks, Active Scents |
+| Lines | names or prose | one line per row | Active Curses, Active Parasites, Bonds, Marks, Currently employs |
+
+**Spoiler collapse.** A Lines block over `ChateauDossier.SpoilerLineThreshold` (6) rows wraps its
+body in `[spoiler]` and shows a count summary beside the header (`Currently employs: 23 residents
+across 11 roles`). Collapsing hides, never truncates — every entry is still inside. Inline blocks
+are one line by construction and never collapse. This mirrors the existing pattern in
+[ChateauConsent.cs](../../FChatDicebot/BotCommands/ChateauConsent.cs), which spoilers its channel
+message past 500 chars.
+
+Threshold is measured in rendered rows, not characters or wrapped visual lines — chosen over a
+character count so the rule matches what makes a dossier *feel* long. A very wide inline row
+(e.g. a resident with experience in all 62 jobs) still wraps in-client without collapsing.
+
+**Section order** is grouped into themed clusters, separated by blank lines, replacing the
+feature-shipped-in-this-order sequence: identity & job → current state → relationships →
+lifetime tallies → recent activity. Empty clusters emit no separator.
+
+**Other changes in this pass:**
+- **`Currently employs` names its employees**, like Bonds does, instead of printing a headcount.
+  Roles sort by headcount descending; names within a role sort alphabetically. This makes it a
+  roster, so it moved into the relationships cluster. It does not duplicate `!business`, which is
+  the employer's private *earnings* ledger rather than a public roster.
+- **`Sired` + `Birthed` merged** into one `Offspring:` row; either half renders alone.
+- **`Titles earned` + `Most abundant currency` merged** into one at-a-glance row.
+- **Empty-state detection rewritten.** The new-arrival note used to be triggered by string-equality
+  against `header + "\n\n"`, which would silently stop firing on any reorder; it now checks whether
+  the four content clusters are all empty.
+- **Fixed: unclosed `[spoiler]` in `Utils.JobToText`.** The unknown-job fallback string opened a
+  spoiler and never closed it — the only one of the eight "go tell her to fix it" strings missing
+  its closer. An unrecognised job in the employs or experience block swallowed the entire rest of
+  the dossier into a spoiler. Covered by `BuildFullDossier_HasNoUnbalancedSpoilerTags`.
+- **Fixed: self-employed residents' job line** read as a bare fragment (`as a Boss`) because the
+  "Currently working" lead-in only existed inside the employer branch.
+- **Fixed: mark and break bodypart labels** rendered lowercase (`neck:`) while every other labelled
+  row capitalised.
+- **Fixed: mark rows with no resolvable marker** emitted a label with nothing after it and inflated
+  the "across N places" summary; they're now skipped.
+
+**Private messages now always get thousands separators.** `ShowCommasInNumbers` is a per-channel
+setting and a PM has no channel, so `GetChannelSettings` returned null and *no* PM ever got commas
+however large the figure — the dossier's `Most abundant currency` line is what surfaced it.
+[BotMain.SendPrivateMessage](../../FChatDicebot/BotMain.cs) now calls `TextFormat.ApplyNumberCommas`
+unconditionally instead of the `IfNecessary` variant.
+
+Making that safe required hardening the formatter. It matched a bare `\d+` across the whole
+message, so it comma'd anything containing digits — `[eicon]kanna1000[/eicon]` became a broken
+icon, `[user]Robot2000[/user]` a broken name tag, `2026-05-26` became `2,026-05-26`. It now only
+formats *standalone* numbers (digit runs not touching a word character, hyphen, dot or slash) and
+passes through BBCode tags plus the full contents of the identifier-bearing ones
+(`eicon`/`icon`/`user`/`session`), which protects an entirely-numeric name like `[eicon]1000[/eicon]`
+that the standalone rule can't distinguish from a figure. Formatting tags are unaffected, so
+`[b]14837[/b]` still becomes `[b]14,837[/b]`. An overlong digit run is now left alone rather than
+throwing `long.Parse` and silently discarding formatting for the whole message. Covered by
+[Textformatnumbercommastests.cs](../../FChatDicebot.Tests/Unit/Textformatnumbercommastests.cs).
+
+This also fixes the same corruption in channels that had `ShowCommasInNumbers` switched on.
+
+**Unrelated drive-by:** `ChateauConsent`'s in-channel spoiler threshold went from 500 to 1000
+characters — ordinary-sized consent readouts were collapsing behind a click more often than the
+length warranted.
+
 ## Files (as-shipped)
 
 **New:**


### PR DESCRIPTION
## Why

Queen Contract's dossier had grown enormous, and the bulk of the length was the employee list rendering one job per line despite each row being just a job name and a single number.

The underlying problem was broader than that one block. Every section picked its own render shape based on when the feature shipped, so two blocks with *identical* data shape disagreed: `Days of Experience` (job → number) rendered as one inline row, while `Currently employs` (job → number) rendered one line per job.

## The rule

Blocks now pick a shape from what a row actually holds:

| Shape | Row holds | Renders as | Blocks |
|---|---|---|---|
| Inline | short label + a number | one wrapped row | Casual interactions, Notable counts, Offspring, Has personally planted, Days of Experience, Active Breaks, Active Scents |
| Lines | names or prose | one line each | Active Curses, Active Parasites, Bonds, Marks, Currently employs |

A Lines block over `SpoilerLineThreshold` (6) rows collapses into a `[spoiler]` with a count summary beside the header — `Currently employs: 23 residents across 16 roles`. Collapsing **hides, never truncates**; a test asserts every employee is still present inside the spoiler. This mirrors the existing pattern in `ChateauConsent`, which spoilers its channel message past a character threshold.

The threshold is measured in rendered rows rather than characters, chosen so the rule matches what makes a dossier *feel* long. A very wide inline row still wraps in-client without collapsing.

## Also in this pass

- **`Currently employs` names its employees**, like Bonds does, instead of printing a headcount. Roles sort by headcount descending, names alphabetically within a role. That makes it a roster, so it moved into the relationships cluster. It doesn't duplicate `!business`, which is the employer's private *earnings* ledger rather than a public roster.
- **`Sired` + `Birthed` merged** into one `Offspring:` row; either half renders alone.
- **`Titles earned` + `Most abundant currency` merged** into one at-a-glance row.
- **Sections regrouped into themed clusters**: identity → current state → relationships → lifetime tallies → recent activity.
- **Empty-state detection rewritten.** The new-arrival note was triggered by string equality against `header + "\n\n"`, which would have silently stopped firing on any reorder.

## Pre-existing bugs fixed

Surfaced while reworking the rendering:

1. **`Utils.JobToText` opened a `[spoiler]` and never closed it** in its unknown-job fallback — the only one of eight such "go tell her to fix it" strings missing its closer. An unrecognised job in the employs or experience block swallowed the entire rest of the dossier into a spoiler.
2. **Self-employed residents' job line read as a bare fragment** (`as a Boss`), because the "Currently working" lead-in only existed inside the employer branch.
3. **Mark and break bodypart labels rendered lowercase** (`neck:`) while every other labelled row capitalised.
4. **Mark rows whose markers no longer resolve** emitted a label with nothing after it and inflated the `across N places` summary.

## PMs now get thousands separators

`ShowCommasInNumbers` is a per-channel setting and a PM has no channel, so `GetChannelSettings` returns null and **no PM ever got commas**, however large the figure. The dossier's `Most abundant currency` line is what surfaced it.

Making that safe required hardening the formatter first. It matched a bare `\d+` across the whole message, so applying it to all 231 PM call sites as-written would have corrupted anything merely containing digits:

- `[eicon]kanna1000[/eicon]` → `kanna1,000`, a broken icon
- `[user]Robot2000[/user]` → a broken name tag
- `2026-05-26` → `2,026-05-26`

It now formats only *standalone* numbers — digit runs not touching a word character, hyphen, dot or slash — and passes through BBCode tags plus the full contents of the identifier-bearing ones (`eicon`/`icon`/`user`/`session`). That last part protects an entirely-numeric name like `[eicon]1000[/eicon]`, where the digits touch only brackets and the standalone rule can't tell it from a real figure. Formatting tags are unaffected, so `[b]14837[/b]` → `[b]14,837[/b]` as intended.

Two things fell out of that: an overlong digit run now passes through instead of throwing `long.Parse` and silently discarding formatting for the whole message, and channels that already had the setting switched on get the same corruption fixed.

## Drive-by

`ChateauConsent`'s in-channel spoiler threshold raised 500 → 1000 characters — ordinary-sized consent readouts were collapsing behind a click more often than the length warranted. Independent of the dossier's row-count threshold.

## Testing

1668 tests pass (19 new). New coverage: section shape rules, spoiler collapse above/at/below threshold with contents preserved, employs ordering and naming, the merged Offspring and at-a-glance rows, cluster ordering, empty-state behaviour, balanced spoiler tags across a full dossier, and the number formatter's protected constructs.

Sample rendering of a heavy user was eyeballed during development; all wording was reviewed and approved by the owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
