### PR TITLE
Remind residents of !no in every consent prompt

### DIFF
--- a/FChatDicebot.Tests/Unit/Consentdeclinehinttests.cs
+++ b/FChatDicebot.Tests/Unit/Consentdeclinehinttests.cs
@@ -1,0 +1,210 @@
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit.InteractionProcessors
+{
+    /// <summary>
+    /// Locks the "every consent prompt names !no" rule. The reminder is appended once, by
+    /// <see cref="InteractionProcessorBase.GetConsentWarning"/> /
+    /// <see cref="InteractionProcessorBase.GetGroupConsentWarning"/>, so these tests guard the
+    /// helper's behaviour and the structural fact that no processor can slip past the wrapper.
+    /// </summary>
+    [Collection("Database")]
+    public class ConsentDeclineHintTests
+    {
+        // The registry builds every processor with its parameterless constructor, which
+        // resolves MonDB.GetDatabase() — so this class needs the database fixture even though
+        // none of the prompts under test read from it.
+        public ConsentDeclineHintTests(TestDatabaseFixture fixture)
+        {
+            fixture.Reset();
+        }
+
+        // -------------------------------------------------------------------
+        // WithDeclineHint
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void WithDeclineHint_AppendsHintAfterThePrompt()
+        {
+            Assert.Equal(
+                "Alice wants to pet Bob. Do you !consent to some scritches? (or !no)",
+                ConsentWarningText.WithDeclineHint("Alice wants to pet Bob. Do you !consent to some scritches?"));
+        }
+
+        [Fact]
+        public void WithDeclineHint_IsIdempotent()
+        {
+            string once = ConsentWarningText.WithDeclineHint("Do you !consent?");
+            string twice = ConsentWarningText.WithDeclineHint(once);
+
+            Assert.Equal(once, twice);
+        }
+
+        [Fact]
+        public void WithDeclineHint_HintAlreadyMidString_NotAppendedAgain()
+        {
+            // What a fragment-carrying prompt looks like: the reminder sits with the question
+            // and status-effect fragments trail it.
+            string composed = "Do you !consent? (or !no) [musk lingers]";
+
+            Assert.Equal(composed, ConsentWarningText.WithDeclineHint(composed));
+        }
+
+        [Fact]
+        public void WithDeclineHint_BespokeVariant_SuppressesTheDefault()
+        {
+            string composed = "The first to !consent gets to be under Alice! "
+                + ConsentWarningText.DeclineHintVariant("to opt out entirely");
+
+            Assert.Equal("The first to !consent gets to be under Alice! (or !no to opt out entirely)", composed);
+            Assert.Equal(composed, ConsentWarningText.WithDeclineHint(composed));
+        }
+
+        [Fact]
+        public void WithDeclineHint_CollapsesTrailingWhitespaceBeforeTheHint()
+        {
+            Assert.Equal("Do you !consent? (or !no)", ConsentWarningText.WithDeclineHint("Do you !consent?   "));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void WithDeclineHint_EmptyPrompt_LeftAlone(string prompt)
+        {
+            Assert.Equal(prompt, ConsentWarningText.WithDeclineHint(prompt));
+        }
+
+        // -------------------------------------------------------------------
+        // Structural: nothing bypasses the shared entry points
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void EveryRegisteredProcessor_InheritsTheSharedConsentEntryPoints()
+        {
+            var offenders = new List<string>();
+
+            foreach (var processor in DistinctRegisteredProcessors())
+            {
+                Type type = processor.GetType();
+
+                MethodInfo single = type.GetMethod("GetConsentWarning",
+                    BindingFlags.Public | BindingFlags.Instance,
+                    null,
+                    new[] { typeof(Profile), typeof(Profile), typeof(string) },
+                    null);
+                if (single == null || single.DeclaringType != typeof(InteractionProcessorBase))
+                {
+                    offenders.Add(type.Name + ".GetConsentWarning");
+                }
+
+                MethodInfo group = type.GetMethod("GetGroupConsentWarning",
+                    BindingFlags.Public | BindingFlags.Instance,
+                    null,
+                    new[] { typeof(Profile), typeof(IReadOnlyList<Profile>), typeof(string) },
+                    null);
+                if (group == null || group.DeclaringType != typeof(InteractionProcessorBase))
+                {
+                    offenders.Add(type.Name + ".GetGroupConsentWarning");
+                }
+            }
+
+            Assert.True(offenders.Count == 0,
+                "These processors shadow the shared consent entry point, so their prompts would "
+                + "lose the '" + ConsentWarningText.DeclineHint + "' reminder. Override "
+                + "BuildConsentWarning / BuildGroupConsentWarning instead: "
+                + string.Join(", ", offenders));
+        }
+
+        // -------------------------------------------------------------------
+        // Behavioural: the casual prompts (the ones that need no database) really carry it
+        // -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData("kiss", null)]
+        [InlineData("cuddle", null)]
+        [InlineData("handhold", null)]
+        [InlineData("spank", null)]
+        [InlineData("bully", null)]
+        [InlineData("boobhat", null)]
+        [InlineData("lick", null)]
+        [InlineData("pet", null)]
+        [InlineData("lap", "lap")]
+        [InlineData("sit", "sit")]
+        public void CasualConsentPrompts_EndWithTheDeclineHint(string interactionType, string identifier)
+        {
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+            var carol = new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").Build();
+
+            var processor = InteractionProcessorRegistry.GetProcessor(interactionType);
+            Assert.NotNull(processor);
+
+            string single = processor.GetConsentWarning(alice, bob, identifier);
+            Assert.EndsWith(ConsentWarningText.DeclineHint, single);
+
+            // The !sit lap stack closes with its own phrasing rather than the bare hint.
+            string group = processor.GetGroupConsentWarning(alice, new List<Profile> { bob, carol }, identifier);
+            Assert.EndsWith(")", group);
+            Assert.Contains("(or !no", group);
+        }
+
+        [Fact]
+        public void LapStackGroupPrompt_SpellsOutWhatDecliningMeans()
+        {
+            var alice = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").Build();
+            var bob = new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").Build();
+            var carol = new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").Build();
+
+            string sit = InteractionProcessorRegistry.GetProcessor("sit")
+                .GetGroupConsentWarning(alice, new List<Profile> { bob, carol }, "sit");
+
+            Assert.Equal(
+                "Alice wants to start a lap stack with Bob and Carol. The first to !consent "
+                + "gets to be under Alice! (or !no to opt out entirely)",
+                sit);
+        }
+
+        // -------------------------------------------------------------------
+        // Ordering: the reminder stays with the question, trailing notes follow it
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void BreakConsentPrompt_ClampNoteIsSmallPrintAfterTheReminder()
+        {
+            string clamped = FChatDicebot.InteractionProcessors.Consequence.BreakProcessor.ComposeConsentText(
+                "Alice", "Bob", "arm", 1, FChatDicebot.InteractionProcessors.Consequence.BreakProcessor.ClampDirection.Min);
+
+            Assert.Contains("Do you !consent? (or !no) [sub]Duration was adjusted to the minimum of", clamped);
+            Assert.EndsWith("[/sub]", clamped);
+            Assert.DoesNotContain("(Duration was adjusted", clamped);
+        }
+
+        [Fact]
+        public void BreakConsentPrompt_NoClamp_EndsWithTheReminder()
+        {
+            string unclamped = FChatDicebot.InteractionProcessors.Consequence.BreakProcessor.ComposeConsentText(
+                "Alice", "Bob", "arm", 3, FChatDicebot.InteractionProcessors.Consequence.BreakProcessor.ClampDirection.None);
+
+            Assert.EndsWith(ConsentWarningText.DeclineHint, unclamped);
+        }
+
+        private static IEnumerable<IInteractionProcessor> DistinctRegisteredProcessors()
+        {
+            // Lapsit / corruption / climax each register one instance under two verb keys.
+            return InteractionProcessorRegistry.GetAllInteractionTypes()
+                .Select(InteractionProcessorRegistry.GetProcessor)
+                .Where(p => p != null)
+                .GroupBy(p => p.GetType())
+                .Select(g => g.First());
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
+++ b/FChatDicebot.Tests/Unit/Statuseffecthooktests.cs
@@ -224,8 +224,8 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             Assert.Contains("Alice", warning);
             Assert.Contains("Bob", warning);
-            Assert.EndsWith("Do you !consent? [musk lingers]", warning);
-            Assert.DoesNotContain("?  [musk", warning);
+            Assert.EndsWith("Do you !consent? (or !no) [musk lingers]", warning);
+            Assert.DoesNotContain(")  [musk", warning);
         }
 
         [Fact]
@@ -239,7 +239,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string warning = _processor.GetConsentWarning(initiator, recipient, identifier: "");
 
-            Assert.EndsWith("Do you !consent? [scent A] [scent B]", warning);
+            Assert.EndsWith("Do you !consent? (or !no) [scent A] [scent B]", warning);
         }
 
         [Fact]
@@ -253,7 +253,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string warning = _processor.GetConsentWarning(initiator, recipient, identifier: "");
 
-            Assert.EndsWith("Do you !consent? [real]", warning);
+            Assert.EndsWith("Do you !consent? (or !no) [real]", warning);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Trainprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Trainprocessortests.cs
@@ -481,7 +481,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string warning = _processor.GetConsentWarning(alice, bob, "magic");
 
-            Assert.Equal("Alice wants to do some magic training with Bob! Do you !consent to improving your skills together?", warning);
+            Assert.Equal("Alice wants to do some magic training with Bob! Do you !consent to improving your skills together? (or !no)", warning);
         }
 
         [Fact]

--- a/FChatDicebot/BotCommands/ChateauBreak.cs
+++ b/FChatDicebot/BotCommands/ChateauBreak.cs
@@ -130,8 +130,9 @@ namespace FChatDicebot.BotCommands
 
             MonDB.addPendingCommand(pendingBreak);
 
-            // Compose with the actual days (the processor's GetConsentWarning override
-            // can't see extraParameters, so we call the static helper directly).
+            // Compose with the actual days (the processor's consent-warning builder can't see
+            // extraParameters, so we call the static helper directly). That bypasses
+            // GetConsentWarning; ComposeConsentText applies the decline reminder itself.
             string warning = BreakProcessor.ComposeConsentText(
                 initiatorProfile.displayName, recipientProfile.displayName, part, requestedDays, clampDir);
             bot.SendMessageInChannel(warning, channel);

--- a/FChatDicebot/BotCommands/Support/CasualGroupCommandSupport.cs
+++ b/FChatDicebot/BotCommands/Support/CasualGroupCommandSupport.cs
@@ -109,7 +109,8 @@ namespace FChatDicebot.BotCommands.Support
 
                 string single = processor != null
                     ? processor.GetConsentWarning(initiatorProfile, only, identifier)
-                    : initiatorProfile.displayName + " wants to interact with " + only.displayName + ". Do you !consent?";
+                    : ConsentWarningText.WithDeclineHint(
+                        initiatorProfile.displayName + " wants to interact with " + only.displayName + ". Do you !consent?");
                 bot.SendMessageInChannel(single, channel);
                 return;
             }
@@ -130,7 +131,8 @@ namespace FChatDicebot.BotCommands.Support
 
             string announcement = processor != null
                 ? processor.GetGroupConsentWarning(initiatorProfile, recipientProfiles, identifier)
-                : initiatorProfile.displayName + " wants to interact with several residents. Each of you, do you !consent?";
+                : ConsentWarningText.WithDeclineHint(
+                    initiatorProfile.displayName + " wants to interact with several residents. Each of you, do you !consent?");
             bot.SendMessageInChannel(announcement, channel);
         }
 

--- a/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/BoobhatProcessor.cs
@@ -81,7 +81,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{initiatorProfile.displayName} rests their chest atop {names}, one comfy hat at a time. {GetRandomDescriptor(BoobhatDescriptors)}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to rest their chest atop " + recipientProfile.displayName + ". Do you !consent to the temporary headwear?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/BullyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/BullyProcessor.cs
@@ -90,7 +90,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{initiatorProfile.displayName} rounds up {names} and {GetRandomDescriptor(BullyDescriptors)}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " is gearing up to bully " + recipientProfile.displayName + ". Do you !consent to whatever is coming?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/CuddleProcessor.cs
@@ -128,7 +128,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return message;
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to cuddle you, " + recipientProfile.displayName + ". Do you !consent to some cuddles?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/HandholdProcessor.cs
@@ -86,7 +86,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"Ooh, {JoinNamesSerial(names)} hold hands in a chain! {GetRandomDescriptor(HandholdDescriptors)}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to hold your hand (or equivalent appendage) " + recipientProfile.displayName + ". Do you !consent to some handholding?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/KissProcessor.cs
@@ -87,7 +87,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return message;
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to give you a kiss, " + recipientProfile.displayName + ". Do you !consent to a smooch?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitCommandSupport.cs
@@ -59,7 +59,8 @@ namespace FChatDicebot.InteractionProcessors.Casual
             var processor = InteractionProcessorRegistry.GetProcessor(typedVerb);
             string consentMessage = processor != null
                 ? processor.GetConsentWarning(initiatorProfile, recipientProfile, interaction.identifier)
-                : (initiatorProfile.displayName + " wants to share a lap with " + recipientProfile.displayName + ". Do you !consent?");
+                : ConsentWarningText.WithDeclineHint(
+                    initiatorProfile.displayName + " wants to share a lap with " + recipientProfile.displayName + ". Do you !consent?");
             bot.SendMessageInChannel(consentMessage, channel);
         }
     }

--- a/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LapsitProcessor.cs
@@ -147,7 +147,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{opener} {descriptor}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             if (InitiatorIsSitter(identifier))
             {
@@ -156,13 +156,17 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return initiatorProfile.displayName + " wants to pull " + recipientProfile.displayName + " onto their lap. Do you !consent to taking a seat?";
         }
 
-        public override string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
+        protected override string BuildGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
         {
             string names = JoinNamesSerial(recipients.Select(p => p.displayName).ToList());
             if (InitiatorIsSitter(identifier))
             {
-                // !sit: the first to consent becomes the bottom; the rest pile on above.
-                return initiatorProfile.displayName + " wants to start a lap stack with " + names + ". The first to !consent gets to be under " + initiatorProfile.displayName + "!";
+                // !sit: the first to consent becomes the bottom; the rest pile on above. This
+                // announces a race rather than asking a yes/no question, so the bare "(or !no)"
+                // would read as if declining just forfeited the bottom spot — spell it out.
+                return initiatorProfile.displayName + " wants to start a lap stack with " + names
+                    + ". The first to !consent gets to be under " + initiatorProfile.displayName + "! "
+                    + ConsentWarningText.DeclineHintVariant("to opt out entirely");
             }
             return initiatorProfile.displayName + " starts a lap stack, looking to pull " + names + " onto their lap one at a time. Do you each !consent to taking a seat?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/LickProcessor.cs
@@ -98,7 +98,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{initiatorProfile.displayName} licks {names}. {descriptor}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to give " + recipientProfile.displayName + " a lick. Do you !consent to being lapped at?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/PetProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/PetProcessor.cs
@@ -96,7 +96,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{initiatorProfile.displayName} pets {names}. {descriptor}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to pet " + recipientProfile.displayName + ". Do you !consent to some scritches?";
         }

--- a/FChatDicebot/InteractionProcessors/Casual/SpankProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Casual/SpankProcessor.cs
@@ -80,7 +80,7 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return $"{initiatorProfile.displayName} winds up and gives {names} {GetRandomDescriptor(SpankDescriptors)}";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " is about to give " + recipientProfile.displayName + " a spank. Do you !consent to that sting?";
         }

--- a/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BondProcessor.cs
@@ -110,7 +110,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             return initiatorProfile.displayName + " is now " + recipientProfile.displayName + "'s " + Utils.BondToText(identifier, false) + ", and " + recipientProfile.displayName + " is now their " + Utils.BondToText(identifier, true) + "! May you enjoy a bright future together."; ;
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             // A bond puts a global cooldown on BOTH parties (not a per-pair limit), so the
             // recipient-framed clause speaks to the act of declaring a bond at all.

--- a/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/BreedProcessor.cs
@@ -395,7 +395,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             int existingPregnancies = recipientProfile.pregnancies != null ? recipientProfile.pregnancies.Count : 0;
             string pregnancyCountText = existingPregnancies > 0

--- a/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ConsumeProcessor.cs
@@ -79,7 +79,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string bodypartText = Utils.BodypartToText(identifier);
             string seriousness = ConsentWarningText.Block(

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs
@@ -114,7 +114,8 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             var processor = InteractionProcessorRegistry.GetProcessor(effectiveVerb);
             string consentMessage = processor != null
                 ? processor.GetConsentWarning(initiatorProfile, recipientProfile, interaction.identifier)
-                : (initiatorProfile.displayName + " wants to " + effectiveVerb + " " + recipientProfile.displayName + ". Do you !consent?");
+                : ConsentWarningText.WithDeclineHint(
+                    initiatorProfile.displayName + " wants to " + effectiveVerb + " " + recipientProfile.displayName + ". Do you !consent?");
             bot.SendMessageInChannel(consentMessage, channel);
         }
     }

--- a/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/CorruptionProcessor.cs
@@ -264,7 +264,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             QuotaMagnitude = DailyMagnitudeLimit
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string verb = ParseVerbFromIdentifier(identifier);
             int requestedMagnitude = ParseMagnitudeFromIdentifier(identifier);

--- a/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/EmployProcessor.cs
@@ -100,7 +100,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("employed", Cooldown.PeriodDays));

--- a/FChatDicebot/InteractionProcessors/Commitment/EntitleProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/EntitleProcessor.cs
@@ -134,7 +134,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return $"{initiatorProfile.displayName} wants to grant you the title \"{identifier}\". [b]Custom titles cannot be received frequently, so be sure this is an important title for you.[/b] Do you !consent to receiving this title?";
         }

--- a/FChatDicebot/InteractionProcessors/Commitment/MarkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/MarkProcessor.cs
@@ -135,7 +135,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string bodypartText = Utils.BodypartToText(identifier);
             string seriousness = ConsentWarningText.Block(

--- a/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/ObjectifyProcessor.cs
@@ -117,7 +117,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("objectified", Cooldown.PeriodDays));

--- a/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PetrifyProcessor.cs
@@ -93,7 +93,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 7
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("petrified", Cooldown.PeriodDays));

--- a/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/PlantProcessor.cs
@@ -80,7 +80,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 1
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("planted", Cooldown.PeriodDays));

--- a/FChatDicebot/InteractionProcessors/Commitment/TrainProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Commitment/TrainProcessor.cs
@@ -224,7 +224,7 @@ namespace FChatDicebot.InteractionProcessors.Commitment
                 + student + " benefitted from the time spent.";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " wants to do some " + identifier
                 + " training with " + recipientProfile.displayName

--- a/FChatDicebot/InteractionProcessors/ConsentWarningText.cs
+++ b/FChatDicebot/InteractionProcessors/ConsentWarningText.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace FChatDicebot.InteractionProcessors
@@ -17,6 +18,46 @@ namespace FChatDicebot.InteractionProcessors
     {
         /// <summary>The fixed opening sentence of every seriousness block.</summary>
         public const string Opener = "This should not be taken lightly.";
+
+        /// <summary>
+        /// The reminder that declining is always an option, which every consent prompt carries
+        /// directly after its own question. Saying no is as much a part of the consent flow as
+        /// saying yes, so the prompt names both.
+        /// </summary>
+        public const string DeclineHint = "(or !no)";
+
+        /// <summary>
+        /// What counts as "this prompt already names <c>!no</c>". Matching on the stem rather
+        /// than the whole hint is what lets <see cref="DeclineHintVariant"/> stand in for the
+        /// default without <see cref="WithDeclineHint"/> adding a second reminder.
+        /// </summary>
+        private const string DeclineHintStem = "(or !no";
+
+        /// <summary>
+        /// Give a prompt its <see cref="DeclineHint"/>. Applied centrally by
+        /// <see cref="InteractionProcessorBase.GetConsentWarning"/> /
+        /// <see cref="InteractionProcessorBase.GetGroupConsentWarning"/>, so processors never
+        /// write the hint themselves and can't drift. A prompt that already names <c>!no</c>
+        /// anywhere — because it placed the hint mid-string ahead of trailing fragments, or
+        /// used a <see cref="DeclineHintVariant"/> — is returned untouched.
+        /// </summary>
+        public static string WithDeclineHint(string prompt)
+        {
+            if (string.IsNullOrWhiteSpace(prompt)) return prompt;
+            if (prompt.IndexOf(DeclineHintStem, StringComparison.Ordinal) >= 0) return prompt;
+            return prompt.TrimEnd() + " " + DeclineHint;
+        }
+
+        /// <summary>
+        /// A bespoke phrasing of the decline reminder, for the rare prompt whose shape doesn't
+        /// take the bare <see cref="DeclineHint"/> — e.g. the lap stack, which announces a
+        /// race to consent rather than asking a yes/no question, so its reminder reads
+        /// "(or !no to opt out entirely)". Suppresses the default hint.
+        /// </summary>
+        public static string DeclineHintVariant(string tail)
+        {
+            return "(or !no " + tail + ")";
+        }
 
         /// <summary>
         /// Wrap the opener followed by the supplied clauses (in order, empties skipped) in a

--- a/FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/BreakProcessor.cs
@@ -201,17 +201,21 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Scope = "bodypart"
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string baseWarning = ComposeConsentText(initiatorProfile.displayName, recipientProfile.displayName, identifier, DefaultDays, ClampDirection.None);
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent);
-            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+            return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
         }
 
         /// <summary>
         /// Build the consent-warning body with the actual requested days. Callable from the
         /// command so the warning reflects the user's typed duration instead of always
         /// reading <see cref="DefaultDays"/>.
+        ///
+        /// Applies the decline reminder itself, because the clamp note is bookkeeping about
+        /// the initiator's input rather than part of the question — it belongs after the
+        /// reminder, in small print, not between the question and its answer.
         /// </summary>
         public static string ComposeConsentText(string initiatorName, string recipientName, string part, int days, ClampDirection clamp)
         {
@@ -221,16 +225,17 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 ConsentWarningText.FrequencyPerAxis(initiatorName, "break a given part of you", Cooldown.PeriodDays),
                 "While broken, your sore " + part + " will keep you from " + blockedVerbs
                     + ", and might be noticed during other interactions as well.");
-            string warning = initiatorName + " is going to break " + recipientName + "'s " + part
-                + " for " + days + " " + daysWord + "! " + seriousness + " Do you !consent?";
+            string warning = ConsentWarningText.WithDeclineHint(
+                initiatorName + " is going to break " + recipientName + "'s " + part
+                    + " for " + days + " " + daysWord + "! " + seriousness + " Do you !consent?");
 
             if (clamp == ClampDirection.Min)
             {
-                warning += " (Duration was adjusted to the minimum of " + MinDays + " day.)";
+                warning += " [sub]Duration was adjusted to the minimum of " + MinDays + " day.[/sub]";
             }
             else if (clamp == ClampDirection.Max)
             {
-                warning += " (Duration was adjusted to the maximum of " + MaxDays + " days.)";
+                warning += " [sub]Duration was adjusted to the maximum of " + MaxDays + " days.[/sub]";
             }
             return warning;
         }

--- a/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/CurseProcessor.cs
@@ -432,7 +432,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Scope = "curse"
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string casterName = string.IsNullOrEmpty(initiatorProfile?.displayName)
                 ? initiatorProfile?.userName
@@ -466,7 +466,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + "Do you !consent to this curse?";
 
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
-            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+            return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/DoseProcessor.cs
@@ -215,7 +215,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Scope = "vice"
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string vicePhrase = ViceText.ViceName(Database?.GetIdentifier(identifier), identifier, initiatorProfile?.displayName);
             string seriousness = ConsentWarningText.Block(
@@ -226,7 +226,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + " with " + vicePhrase + "! " + seriousness + " "
                 + "Do you !consent?";
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
-            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+            return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/InfestProcessor.cs
@@ -253,7 +253,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Scope = "parasite"
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string costPhrase = CostPhrase(PurgeCostFor(identifier));
             int graceHours = (int)SpreadGracePeriod.TotalHours;
@@ -269,7 +269,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
                 + recipientProfile.displayName + " with " + parasiteWithArticle + "! " + seriousness + " "
                 + "Do you !consent to being made into a new host?";
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
-            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+            return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
         }
     }
 }

--- a/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/MonsterizeProcessor.cs
@@ -105,7 +105,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 7
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string seriousness = ConsentWarningText.Block(
                 ConsentWarningText.FrequencyRecipient("monsterized", Cooldown.PeriodDays),

--- a/FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/OdorizeProcessor.cs
@@ -150,7 +150,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             Scope = "scent"
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string phrase = ScentText.ScentPhrase(Database.GetIdentifier(identifier), identifier, initiatorProfile.displayName);
             string seriousness = ConsentWarningText.Block(

--- a/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Consequence/RenameProcessor.cs
@@ -98,7 +98,7 @@ namespace FChatDicebot.InteractionProcessors.Consequence
             PeriodDays = 7
         };
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string newName = identifier;
             string seriousness = ConsentWarningText.Block(

--- a/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/IInteractionProcessor.cs
@@ -48,7 +48,10 @@ namespace FChatDicebot.InteractionProcessors
         ValidationResult ValidateInteraction(string initiator, string recipient, string identifier);
 
         /// <summary>
-        /// Get the consent warning text shown to the recipient before they consent.
+        /// Get the consent warning text shown to the recipient before they consent, closing
+        /// with the <c>(or !no)</c> reminder that declining is equally an option. Processors
+        /// supply the body by overriding <c>BuildConsentWarning</c>; the reminder is appended
+        /// centrally so it can't drift between interactions.
         /// </summary>
         /// <param name="initiatorProfile">Profile of the initiator</param>
         /// <param name="recipientProfile">Profile of the recipient</param>
@@ -131,7 +134,11 @@ namespace FChatDicebot.InteractionProcessors
         /// <summary>Combined completion message for a resolved group moment.</summary>
         string GetGroupCompletionMessage(Profile initiatorProfile, IReadOnlyList<Profile> consentersInOrder, string identifier);
 
-        /// <summary>Channel announcement shown when a multi-target casual command is invoked.</summary>
+        /// <summary>
+        /// Channel announcement shown when a multi-target casual command is invoked, closing
+        /// with the same <c>(or !no)</c> reminder as the 1:1 prompt. Processors override
+        /// <c>BuildGroupConsentWarning</c> for the body.
+        /// </summary>
         string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier);
     }
 

--- a/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/InteractionProcessorBase.cs
@@ -488,18 +488,45 @@ namespace FChatDicebot.InteractionProcessors
         }
 
         /// <summary>
-        /// Default consent warning. Appends any active status-effect consent fragments for the
-        /// recipient, prefixing each with a single space (contributors should not include
+        /// Channel-bound entry point for a 1:1 consent prompt: the processor's own
+        /// <see cref="BuildConsentWarning"/> with <see cref="ConsentWarningText.DeclineHint"/>
+        /// appended. Deliberately not virtual — every consent prompt must close by naming
+        /// <c>!no</c>, so processors override the builder and the reminder is added here once.
+        /// </summary>
+        public string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        {
+            return ConsentWarningText.WithDeclineHint(
+                BuildConsentWarning(initiatorProfile, recipientProfile, identifier));
+        }
+
+        /// <summary>
+        /// Default consent warning body. Appends any active status-effect consent fragments for
+        /// the recipient, prefixing each with a single space (contributors should not include
         /// their own leading whitespace). Override to provide interaction-specific warnings;
         /// overrides that still want status-effect text should call
         /// <see cref="GetActiveStatusEffects"/> with <see cref="StatusEffectCallSite.Consent"/>
         /// and use <see cref="AppendStatusFragments"/> to apply the same spacing convention.
+        /// Do not write the <c>(or !no)</c> reminder here — <see cref="GetConsentWarning"/>
+        /// adds it for every interaction. Builders that append status-effect fragments should
+        /// use <see cref="ComposeConsentWarning"/> so the reminder still lands directly after
+        /// the question rather than trailing the fragments.
         /// </summary>
-        public virtual string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected virtual string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string baseWarning = $"{initiatorProfile.displayName} wants to {InteractionType} with {recipientProfile.displayName}. Do you !consent?";
             var effects = GetActiveStatusEffects(recipientProfile, StatusEffectCallSite.Consent, identifier, isInitiator: false);
-            return AppendStatusFragments(baseWarning, effects.ConsentWarnings);
+            return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
+        }
+
+        /// <summary>
+        /// Finish a consent-warning body that carries status-effect fragments: the decline
+        /// reminder goes in first, directly after the prompt's own question, and the fragments
+        /// trail it. Without this the reminder would end up after the fragments, separating it
+        /// from the question it belongs to.
+        /// </summary>
+        protected static string ComposeConsentWarning(string baseWarning, IEnumerable<string> fragments)
+        {
+            return AppendStatusFragments(ConsentWarningText.WithDeclineHint(baseWarning), fragments);
         }
 
         /// <summary>
@@ -882,15 +909,27 @@ namespace FChatDicebot.InteractionProcessors
         }
 
         /// <summary>
-        /// Group consent announcement shown when a multi-target casual command is invoked.
-        /// Default reads "{initiator} wants to {verb} A, B, and C. Each of you, do you
-        /// !consent?". Processors with awkward infinitives (lapsit) override.
+        /// Channel-bound entry point for a group consent announcement: the processor's own
+        /// <see cref="BuildGroupConsentWarning"/> with
+        /// <see cref="ConsentWarningText.DeclineHint"/> appended. Not virtual, for the same
+        /// reason as <see cref="GetConsentWarning"/>.
         /// </summary>
-        public virtual string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
+        public string GetGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
+        {
+            return ConsentWarningText.WithDeclineHint(
+                BuildGroupConsentWarning(initiatorProfile, recipients, identifier));
+        }
+
+        /// <summary>
+        /// Group consent announcement body shown when a multi-target casual command is invoked.
+        /// Default reads "{initiator} wants to {verb} A, B, and C. Do you each !consent?".
+        /// Processors with awkward infinitives (lapsit) override.
+        /// </summary>
+        protected virtual string BuildGroupConsentWarning(Profile initiatorProfile, IReadOnlyList<Profile> recipients, string identifier)
         {
             string names = JoinNamesSerial(recipients.Select(p => p.displayName).ToList());
             string verb = GetInteractionVerb(VerbTense.Infinitive);
-            return $"{initiatorProfile.displayName} wants to {verb} {names}. Do you each !consent? (or !no)";
+            return $"{initiatorProfile.displayName} wants to {verb} {names}. Do you each !consent?";
         }
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/ClimaxforProcessor.cs
@@ -439,7 +439,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 : recipientProfile;
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             // Consent warnings are only emitted for non-self-target paths, so we can
             // safely assume initiator != recipient here. The interaction's typeKey is
@@ -447,15 +447,22 @@ namespace FChatDicebot.InteractionProcessors.Involved
             // created), so callers must pass the typeKey via a wrapped identifier OR
             // we infer from the bot command layer. We default to ClimaxforType wording
             // and let the command layer override by calling a typed helper.
-            return GetConsentWarning(initiatorProfile, recipientProfile, identifier, ClimaxforType);
+            return BuildConsentWarning(initiatorProfile, recipientProfile, identifier, ClimaxforType);
         }
 
         /// <summary>
-        /// Typed overload of <see cref="GetConsentWarning"/> — the command layer knows
-        /// the verb the user actually typed and passes it through so the wording matches
-        /// (<c>climax for</c> vs <c>make you climax</c>).
+        /// Typed overload of <see cref="InteractionProcessorBase.GetConsentWarning"/> — the
+        /// command layer knows the verb the user actually typed and passes it through so the
+        /// wording matches (<c>climax for</c> vs <c>make you climax</c>). Applies the same
+        /// <c>(or !no)</c> reminder the untyped entry point does.
         /// </summary>
         public string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier, string typeKey)
+        {
+            return ConsentWarningText.WithDeclineHint(
+                BuildConsentWarning(initiatorProfile, recipientProfile, identifier, typeKey));
+        }
+
+        private string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier, string typeKey)
         {
             string initName = initiatorProfile?.displayName ?? "Someone";
             string recName = recipientProfile?.displayName ?? "you";

--- a/FChatDicebot/InteractionProcessors/Involved/DressupProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/DressupProcessor.cs
@@ -90,7 +90,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             return $"{initiatorProfile.displayName} has dressed up {recipientProfile.displayName} in {Utils.AttireToText(identifier)}! Do a spin for everyone, let them admire your new garb!";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " is going to dress up " + recipientProfile.displayName + " in " + Utils.AttireToText(identifier) + "! Do you !consent to the change of attire?";
         }

--- a/FChatDicebot/InteractionProcessors/Involved/FeedProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/FeedProcessor.cs
@@ -88,7 +88,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             return $"{initiatorProfile.displayName} has fed {recipientProfile.displayName} some {Utils.SubstanceToText(identifier)}! Was it yummy? I bet it was.";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " is going to feed " + recipientProfile.displayName + " some " + Utils.SubstanceToText(identifier) + "! Do you !consent to consuming that?";
         }

--- a/FChatDicebot/InteractionProcessors/Involved/GoldenProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/GoldenProcessor.cs
@@ -102,7 +102,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             return $"{initiatorProfile.displayName} breathes a sigh of relief as a golden fluid pours over {recipientProfile.displayName}'s {Utils.BodypartToText(identifier)}.";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             return initiatorProfile.displayName + " is going to relieve themselves using " + recipientProfile.displayName + "'s " + Utils.BodypartToText(identifier) + "! Do you !consent to being used like that?";
         }

--- a/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
@@ -303,7 +303,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 + ". Bottled, sealed, and tagged." + flavorAppendix;
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             string substance = ParseSubstanceFromIdentifier(identifier);
             string substanceText = Utils.SubstanceToText(substance);

--- a/FChatDicebot/InteractionProcessors/Involved/PaymentGiveProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/PaymentGiveProcessor.cs
@@ -41,7 +41,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             return $"{initiatorProfile.displayName} hands over some {identifier} to {recipientProfile.displayName}. Transaction complete!";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             // identifier is "{amount} {currency}" (e.g. "100 gold") — see ChateauPay.Run.
             return $"{initiatorProfile.displayName} is going to pay {recipientProfile.displayName} {identifier}! Do you !consent to this transaction?";

--- a/FChatDicebot/InteractionProcessors/Involved/PaymentReceiveProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/PaymentReceiveProcessor.cs
@@ -41,7 +41,7 @@ namespace FChatDicebot.InteractionProcessors.Involved
             return $"{recipientProfile.displayName} pays {identifier} to {initiatorProfile.displayName}. Transaction complete!";
         }
 
-        public override string GetConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
+        protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
             // identifier is "{amount} {currency}" (e.g. "100 gold") — see ChateauPay.Run.
             return $"{initiatorProfile.displayName} is requesting {recipientProfile.displayName} pay them {identifier}! Do you !consent to this transaction?";

--- a/wiki-docs/Development-Guide.md
+++ b/wiki-docs/Development-Guide.md
@@ -222,7 +222,9 @@ namespace FChatDicebot.InteractionProcessors.Casual
             return new ValidationResult { IsValid = true };
         }
 
-        public override string GetConsentWarning(
+        // Override the builder, not GetConsentWarning — the base entry point appends the
+        // "(or !no)" decline reminder to whatever you return here.
+        protected override string BuildConsentWarning(
             Profile initiatorProfile,
             Profile recipientProfile,
             string identifier)

--- a/wiki-docs/Interaction-System.md
+++ b/wiki-docs/Interaction-System.md
@@ -515,7 +515,7 @@ Some interactions warn the recipient:
 **Rename Processor:**
 
 ```csharp
-public override string GetConsentWarning(
+protected override string BuildConsentWarning(
     Profile initiatorProfile,
     Profile recipientProfile,
     string identifier)
@@ -525,6 +525,37 @@ public override string GetConsentWarning(
            $"interactions until you are renamed again. Do you !consent?";
 }
 ```
+
+Override `BuildConsentWarning` (and, for group-capable casuals, `BuildGroupConsentWarning`) —
+never `GetConsentWarning` itself. `GetConsentWarning` is the non-virtual channel-bound entry
+point: it takes your body and applies `ConsentWarningText.DeclineHint` — `(or !no)` — so every
+consent prompt in the Chateau names the decline command as well as the accept one. Don't write
+that reminder into the body yourself.
+
+The reminder sits directly after the prompt's own question, and anything that trails the prompt
+follows it. If your builder appends status-effect fragments, return
+`ComposeConsentWarning(baseWarning, effects.ConsentWarnings)` rather than
+`AppendStatusFragments(...)` — otherwise the reminder ends up stranded behind the fragments:
+
+```csharp
+protected override string BuildConsentWarning(Profile init, Profile rec, string identifier)
+{
+    string baseWarning = /* ... */ " Do you !consent to this curse?";
+    var effects = GetActiveStatusEffects(rec, StatusEffectCallSite.Consent, identifier, isInitiator: false);
+    return ComposeConsentWarning(baseWarning, effects.ConsentWarnings);
+}
+```
+
+Two escape hatches:
+
+- Prompts composed outside a processor (e.g. `!break`, which needs the typed duration the
+  processor can't see) apply `ConsentWarningText.WithDeclineHint` themselves. It's idempotent,
+  keyed on the prompt naming `!no` anywhere, so double-wrapping is safe.
+- A prompt that announces something other than a yes/no question can substitute
+  `ConsentWarningText.DeclineHintVariant("to opt out entirely")`, which suppresses the default.
+  `!sit`'s lap stack is the one user of this.
+
+`ConsentDeclineHintTests` fails the build if a processor shadows the entry point.
 
 ## Title System
 

--- a/wiki-docs/Style-Guide.md
+++ b/wiki-docs/Style-Guide.md
@@ -18,9 +18,9 @@ A first-draft style guide for any string a resident will see — consent prompts
 
 ## 3. The consent-prompt template
 
-Every prompt ends `Do you !consent to ___?` and follows this shape:
+Every prompt asks `Do you !consent to ___?` and closes with `(or !no)`:
 
-> `{initiator} <intent verb> {recipient} <detail>! [b]<seriousness warning>[/b] Do you !consent to <recipient-framed action>?`
+> `{initiator} <intent verb> {recipient} <detail>! [b]<seriousness warning>[/b] Do you !consent to <recipient-framed action>? (or !no)`
 
 - **Intent verb phrases** vary by tier flavor: "wants to" (casual, friendly), "is going to" (most involved/consequence), "is about to", "intends for", "is gearing up to", "would like to declare", "graciously offers to". Match the tone of the act.
 - **The `to ___` blank rephrases the action from the recipient's perspective:** "to a smooch", "to that sting", "to becoming an object", "to being bred", "to this life-changing occasion", "to receiving this payment". It should read as something the recipient experiences, not what the initiator does.
@@ -28,6 +28,10 @@ Every prompt ends `Do you !consent to ___?` and follows this shape:
   > `[b]This should not be taken lightly, and can not be done frequently.[/b]`
 
   Casual prompts skip it. Custom warnings exist (e.g. `EntitleProcessor`, `RenameProcessor`) when there's something specific the recipient needs to know — keep them bold.
+- **Never write the `(or !no)` reminder yourself.** It's applied by `InteractionProcessorBase.GetConsentWarning` from `ConsentWarningText.DeclineHint`, so it stays identical everywhere and reaches group announcements too. It's there because a consent flow that only names the yes command isn't offering a real choice.
+- **The reminder belongs with the question, not at the very end.** Anything that trails the prompt — status-effect fragments, small-print notes — goes *after* it: `Do you !consent to some cuddles? (or !no) Bob is carrying a heavy musk.` A builder that appends status fragments must use `ComposeConsentWarning(baseWarning, fragments)` to get this ordering.
+- **Bookkeeping notes are `[sub]`, not parentheticals.** When a prompt has to report something about the initiator's input rather than the act itself, put it in small print after the reminder — see `!break`'s `[sub]Duration was adjusted to the minimum of 1 day.[/sub]`. Two parentheticals in a row read as a stutter.
+- **A prompt that doesn't ask a yes/no question needs a spelled-out reminder.** `ConsentWarningText.DeclineHintVariant("to opt out entirely")` yields `(or !no to opt out entirely)` and suppresses the default. The `!sit` lap stack uses it: it announces a race to consent, so a bare `(or !no)` would read as if declining only forfeited the bottom spot.
 
 ## 4. Completion-message template
 


### PR DESCRIPTION
Every consent prompt now closes by naming the decline command, not just the accept one. Previously only the group announcement did.

## Why this shape

Writing `(or !no)` into ~45 strings would drift the moment someone adds an interaction. Instead `GetConsentWarning` / `GetGroupConsentWarning` became non-virtual entry points that apply `ConsentWarningText.DeclineHint` to whatever the processor built; the 34 overrides moved to `protected BuildConsentWarning` / `BuildGroupConsentWarning`. New interactions get the reminder for free, and `ConsentDeclineHintTests` fails the build if a processor shadows the entry point.

## Placement

The reminder stays with the question it belongs to; anything trailing the prompt follows it:

> …Do you !consent to some cuddles? **(or !no)** Bob is carrying a heavy musk.

Builders that append status-effect fragments go through `ComposeConsentWarning` to get that ordering. This is a visible change rather than a hypothetical one — `OdorizeStatusContributor` emits consent fragments today.

## Two prompts that don't take the bare hint

- **`!break`** reported a clamped duration as a parenthetical, which stuttered against `(or !no)`. Now `[sub]Duration was adjusted to the minimum of 1 day.[/sub]`, after the reminder.
- **`!sit`'s lap stack** announces a race to consent rather than asking a question, so `(or !no)` would read as if declining merely forfeited the bottom spot. It uses `DeclineHintVariant("to opt out entirely")` → `(or !no to opt out entirely)`.

## Docs

`Style-Guide.md` §3 gains the placement rules; `Interaction-System.md` and `Development-Guide.md` now show the builder signature instead of the old override.

## Testing

1690 tests pass (22 new). Four pre-existing exact-string assertions updated for the new tails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)