### PR TITLE
Acknowledge group consent and decline privately

### DIFF
--- a/FChatDicebot.Tests/Unit/Groupinteractionresolvertests.cs
+++ b/FChatDicebot.Tests/Unit/Groupinteractionresolvertests.cs
@@ -320,6 +320,42 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             Assert.Empty(_database.GetPendingCommandsByGroupId(seats[0].groupId));
         }
 
+        // ---- Seat acknowledgements ----
+
+        [Fact]
+        public void SeatConsentedWait_QuotesTimeUntilTheLastUnconsentedSeatExpires()
+        {
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentSeat(seats[0]); // Bob is in; Carol's seat is what the group now waits on
+
+            // Carol has been sitting on her seat for 4 of the 10 minutes.
+            seats[1].startTime = DateTime.UtcNow.AddMinutes(-4);
+            _database.UpdatePendingCommand(seats[1]);
+
+            string message = GroupInteractionResolver.BuildSeatConsentedWaitMessage(
+                _database.GetPendingCommandsByGroupId(seats[0].groupId), DateTime.UtcNow);
+
+            Assert.StartsWith("You're in!", message);
+            Assert.Contains("resolve automatically in 5 minutes.", message);
+            Assert.DoesNotContain("{time}", message);
+        }
+
+        [Fact]
+        public void SeatConsentedWait_AllSeatsConsented_DoesNotQuoteAFreshWindow()
+        {
+            // Degenerate case: the group is resolving this instant, so quoting the full ten
+            // minutes would be a lie.
+            SeedProfiles("Alice", "Bob", "Carol");
+            var seats = CreateGroup("Alice", "cuddle", null, "Bob", "Carol");
+            ConsentInOrder(seats);
+
+            string message = GroupInteractionResolver.BuildSeatConsentedWaitMessage(
+                _database.GetPendingCommandsByGroupId(seats[0].groupId), DateTime.UtcNow);
+
+            Assert.Contains("resolve automatically in less than a minute.", message);
+        }
+
         // ---- Helpers ----
 
         private void SeedProfiles(params string[] names)

--- a/FChatDicebot/BotCommands/ChateauConsent.cs
+++ b/FChatDicebot/BotCommands/ChateauConsent.cs
@@ -116,12 +116,14 @@ namespace FChatDicebot.BotCommands
 
             // Group seats defer (mark consented; resolve when the last seat clears); 1:1 seats
             // process immediately as before.
+            var consentedGroupIds = new List<string>();
             foreach (PendingCommand seat in toActOn)
             {
                 if (seat.IsGroupSeat)
                 {
                     InteractionProcessors.GroupInteractionResolver.MarkSeatConsented(database, seat);
                     touchedGroups.Add(seat.groupId);
+                    consentedGroupIds.Add(seat.groupId);
                 }
                 else
                 {
@@ -139,6 +141,22 @@ namespace FChatDicebot.BotCommands
                     if (!string.IsNullOrEmpty(channelMessage)) channelMessage += "\n\n";
                     channelMessage += groupMessage;
                 }
+            }
+
+            // Consenting into a group is the one path where saying yes produces nothing visible
+            // — the moment is still waiting on someone else — so acknowledge it privately with
+            // how long the group can still take to fire on its own. Skipped for a group that
+            // just resolved above (its seats are gone), which announced itself in-channel.
+            foreach (string groupId in consentedGroupIds.Distinct())
+            {
+                var remainingSeats = database.GetPendingCommandsByGroupId(groupId);
+                if (remainingSeats.Count == 0) continue;
+
+                string waitMessage = InteractionProcessors.GroupInteractionResolver
+                    .BuildSeatConsentedWaitMessage(remainingSeats, DateTime.UtcNow);
+                if (privateMessage.Contains(waitMessage)) continue; // '!consent all' across groups
+                if (privateMessage != string.Empty) privateMessage += "\n\n";
+                privateMessage += waitMessage;
             }
 
             if (channelMessage.Length > maxNoSpoilerLength)

--- a/FChatDicebot/BotCommands/ChateauNo.cs
+++ b/FChatDicebot/BotCommands/ChateauNo.cs
@@ -117,9 +117,14 @@ namespace FChatDicebot.BotCommands
             }
 
             // Clear the caller's own seat(s). For a group seat this leaves the rest intact.
+            bool declinedAGroupSeat = false;
             foreach (PendingCommand seat in toRefuse)
             {
-                if (seat.IsGroupSeat) touchedGroups.Add(seat.groupId);
+                if (seat.IsGroupSeat)
+                {
+                    touchedGroups.Add(seat.groupId);
+                    declinedAGroupSeat = true;
+                }
                 MonDB.removePendingInteraction(seat.Id);
             }
 
@@ -128,6 +133,15 @@ namespace FChatDicebot.BotCommands
                 Profile caller = MonDB.getProfile(characterName);
                 string callerName = caller != null ? caller.displayName : characterName;
                 channelMessage = RefuseAnnouncement.Replace("{recipient}", callerName);
+            }
+
+            // That announcement speaks to the initiator; declining a group seat also gets a
+            // private acknowledgement, since the group carries on without you and there's
+            // otherwise nothing telling you your own seat is gone.
+            if (declinedAGroupSeat)
+            {
+                if (privateMessage != string.Empty) privateMessage += "\n\n";
+                privateMessage += InteractionProcessors.GroupInteractionResolver.SeatDeclinedMessage;
             }
 
             // A declined group seat may complete the group for whoever else already consented.

--- a/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
+++ b/FChatDicebot/InteractionProcessors/GroupInteractionResolver.cs
@@ -23,6 +23,44 @@ namespace FChatDicebot.InteractionProcessors
         // Mirrors the 10-minute window ChateauConsent sweeps with.
         public const int PendingMinutesKeep = 10;
 
+        // ==================== Seat-acknowledgement strings (owner review) ====================
+        // A group seat is the one consent path where answering does nothing visible: the moment
+        // waits on everyone else, so without a reply the resident can't tell their !consent /
+        // !no even registered. Both are PM'd, like the random-event accept reply.
+
+        /// <summary>
+        /// PM'd to a resident whose group seat just consented while the group is still waiting
+        /// on someone. <c>{time}</c> is the wall-clock wait until the timeout sweep fires the
+        /// moment without the remaining seats — filled in by
+        /// <see cref="BuildSeatConsentedWaitMessage"/>.
+        /// </summary>
+        public const string SeatConsentedWaitMessage =
+            "You're in! Wait for the other members of the group to respond, or for the interaction to resolve automatically in {time}.";
+
+        /// <summary>PM'd to a resident who declined a group seat with <c>!no</c>.</summary>
+        public const string SeatDeclinedMessage =
+            "Understood and respected! The group interaction will not include you this time.";
+
+        /// <summary>
+        /// Fill <see cref="SeatConsentedWaitMessage"/>'s <c>{time}</c> from the seats a group
+        /// still holds. Consented seats never expire, so the group fires on its own once the
+        /// last un-consented seat passes the 10-minute mark — that's the deadline quoted.
+        /// Pure so it can be unit-tested.
+        /// </summary>
+        public static string BuildSeatConsentedWaitMessage(IEnumerable<PendingCommand> groupSeats, DateTime utcNow)
+        {
+            DateTime deadline = (groupSeats ?? Enumerable.Empty<PendingCommand>())
+                .Where(s => s != null && !s.HasConsented)
+                .Select(s => s.startTime)
+                // No un-consented seat left means the group is resolving right now; quoting a
+                // fresh 10 minutes would be a lie, so fall back to an already-elapsed deadline.
+                .DefaultIfEmpty(utcNow.AddMinutes(-PendingMinutesKeep))
+                .Max()
+                .AddMinutes(PendingMinutesKeep);
+
+            return SeatConsentedWaitMessage.Replace("{time}", Utils.TimeDifferenceText(utcNow, deadline));
+        }
+
         /// <summary>
         /// Stamp a group seat as consented: assign the next consent-order number for its group
         /// and flip its state. Caller is expected to follow up with


### PR DESCRIPTION
## What

Group interactions now PM the resident who answers a group consent prompt:

| Trigger | PM |
|---|---|
| `!consent` on a group seat, group still waiting | *You're in! Wait for the other members of the group to respond, or for the interaction to resolve automatically in **5 minutes**.* |
| `!no` on a group seat | *Understood and respected! The group interaction will not include you this time.* |

1:1 pendings are untouched — they resolve on the spot and already announce themselves in-channel.

## Why

A group seat was the one consent path where answering produced nothing visible. The shared moment waits on everyone else, so someone who typed `!consent` had no way to tell it registered, and someone who typed `!no` had nothing confirming their seat was gone. Random events already reply to `!random` this way; this brings group interactions in line.

## Notes for review

- **The quoted time is the real one.** `BuildSeatConsentedWaitMessage` derives the deadline from the *last un-consented seat's* expiry, not from a flat 10 minutes. Consented seats never time out, so that instant is exactly when `HandleGroupTimeoutsTick` fires the moment without the remaining seats. Rendered through the existing `Utils.TimeDifferenceText` ("5 minutes" / "1 minute" / "less than a minute").
- **No wait message when your consent completed the group.** The PM only goes out for groups that still hold seats after the resolve pass, so the last consenter gets the in-channel moment instead of being told to keep waiting.
- **`!consent all` spanning two groups** dedupes identical rendered text rather than sending the same line twice.
- Both strings live as consts on `GroupInteractionResolver` next to `PendingMinutesKeep`, following the `RandomEventEngine` "framework user-facing strings" convention, so wording can't drift between call sites.
- The public `!no` announcement ("Looks like {recipient} isn't in the mood…") addresses the *initiator* and is unchanged; this is the private counterpart.
- **Not included:** `!oops` (initiator withdraw) still has no private acknowledgement — it was out of the requested scope. Easy follow-up if wanted.

## Testing

`dotnet test` — 1692 passed, 0 failed. Two new cases in `GroupInteractionResolverTests` cover the quoted-time math and the degenerate all-seats-consented case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
