### PR TITLE
Bottle serials, !bottles, !drink, and bottle transfer via !pay

### DIFF
--- a/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
+++ b/FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs
@@ -65,6 +65,9 @@ namespace FChatDicebot.Tests.Fixtures
             Database.ClearCollection("Feedback");
             Database.ClearCollection("SlotsJackpots");
             Database.ClearCollection("RandomEvents");
+            // Bottle serials come from a counter document here. Resetting it keeps serial
+            // assertions stable rather than dependent on how many bottles earlier tests milked.
+            Database.ClearCollection("Counters");
         }
 
         /// <summary>

--- a/FChatDicebot.Tests/Unit/Bottleinventorytests.cs
+++ b/FChatDicebot.Tests/Unit/Bottleinventorytests.cs
@@ -1,0 +1,216 @@
+using FChatDicebot;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for BottleInventory — the shared selection and grouping that !sell, !drink,
+    /// !bottles and bottle transfer all read from. Pure functions over a Profile, so no
+    /// database fixture is needed.
+    ///
+    /// The two contracts under test: newest-first ordering (so what !bottles shows at the top
+    /// is what !sell and !drink act on next), and empties never appearing in an implicit
+    /// selection.
+    /// </summary>
+    public class BottleInventoryTests
+    {
+        // -------------------------------------------------------------------
+        // Selection
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void SelectFull_NullProfile_ReturnsEmptyList()
+        {
+            Assert.Empty(BottleInventory.SelectFull(null, null, null));
+        }
+
+        [Fact]
+        public void SelectFull_OrdersNewestFirst()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(1, "cum", "Bob", hour: 1))
+                .WithMilkBottle(NewBottle(2, "cum", "Bob", hour: 5))
+                .WithMilkBottle(NewBottle(3, "cum", "Bob", hour: 3))
+                .Build();
+
+            var ordered = BottleInventory.SelectFull(profile, null, null);
+
+            Assert.Equal(new[] { 2, 3, 1 }, ordered.Select(b => b.serial).ToArray());
+        }
+
+        [Fact]
+        public void SelectFull_ExcludesEmpties()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(1, "cum", "Bob", hour: 1))
+                .WithMilkBottle(Emptied(NewBottle(2, "cum", "Bob", hour: 9)))
+                .Build();
+
+            var full = BottleInventory.SelectFull(profile, null, null);
+
+            Assert.Single(full);
+            Assert.Equal(1, full[0].serial);
+        }
+
+        [Fact]
+        public void SelectEmpty_ReturnsOnlyEmpties()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(1, "cum", "Bob", hour: 1))
+                .WithMilkBottle(Emptied(NewBottle(2, "cum", "Bob", hour: 2)))
+                .WithMilkBottle(Emptied(NewBottle(3, "milk", "Alice", hour: 3)))
+                .Build();
+
+            var empties = BottleInventory.SelectEmpty(profile, null, null);
+
+            Assert.Equal(2, empties.Count);
+            Assert.DoesNotContain(empties, b => b.serial == 1);
+        }
+
+        [Fact]
+        public void SelectFull_AppliesSubstanceAndSourceFilters()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(1, "milk", "Alice", hour: 5))
+                .WithMilkBottle(NewBottle(2, "cum", "Alice", hour: 4))
+                .WithMilkBottle(NewBottle(3, "cum", "Bob", hour: 3))
+                .Build();
+
+            var bySubstance = BottleInventory.SelectFull(profile, "cum", null);
+            Assert.Equal(new[] { 2, 3 }, bySubstance.Select(b => b.serial).ToArray());
+
+            var bySource = BottleInventory.SelectFull(profile, "cum", "Bob");
+            Assert.Single(bySource);
+            Assert.Equal(3, bySource[0].serial);
+        }
+
+        // -------------------------------------------------------------------
+        // Serial lookup
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void FindBySerial_FindsFullAndEmptyAlike()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(11, "cum", "Bob", hour: 1))
+                .WithMilkBottle(Emptied(NewBottle(12, "cum", "Bob", hour: 2)))
+                .Build();
+
+            Assert.Equal(11, BottleInventory.FindBySerial(profile, 11).serial);
+            Assert.Equal(12, BottleInventory.FindBySerial(profile, 12).serial);
+            Assert.Null(BottleInventory.FindBySerial(profile, 99));
+        }
+
+        [Fact]
+        public void FindBySerial_ZeroNeverMatches()
+        {
+            // Serial 0 is the "predates the backfill" sentinel, not a referenceable number.
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(NewBottle(0, "cum", "Bob", hour: 1))
+                .Build();
+
+            Assert.Null(BottleInventory.FindBySerial(profile, 0));
+        }
+
+        // -------------------------------------------------------------------
+        // Grouping and display
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Group_CollapsesMatchingSubstanceSourceAndTag()
+        {
+            var bottles = new[]
+            {
+                NewBottle(1, "milk", "Alice", hour: 3),
+                NewBottle(2, "milk", "Alice", hour: 2),
+                NewBottle(3, "milk", "Bob", hour: 1),
+            };
+
+            var groups = BottleInventory.Group(bottles);
+
+            Assert.Equal(2, groups.Count);
+            Assert.Equal(2, groups[0].Count);
+            Assert.Equal(new[] { 1, 2 }, groups[0].Serials.ToArray());
+            Assert.Single(groups[1].Serials);
+        }
+
+        [Fact]
+        public void Group_SeparatesByCorruptionTag()
+        {
+            var bottles = new[]
+            {
+                NewBottle(1, "milk", "Alice", hour: 3, tag: ChateauCurrency.CorruptTag),
+                NewBottle(2, "milk", "Alice", hour: 2),
+            };
+
+            Assert.Equal(2, BottleInventory.Group(bottles).Count);
+        }
+
+        [Fact]
+        public void FormatSerials_CapsWithMoreTail()
+        {
+            string text = BottleInventory.FormatSerials(new[] { 1, 2, 3, 4, 5 }, cap: 3);
+
+            Assert.Equal("#1, #2, #3, and 2 more", text);
+        }
+
+        [Fact]
+        public void FormatSerials_UnderCapHasNoTail()
+        {
+            Assert.Equal("#1, #2", BottleInventory.FormatSerials(new[] { 1, 2 }, cap: 8));
+        }
+
+        [Fact]
+        public void FormatSerials_UnnumberedRendersAsQuestionMark()
+        {
+            // A pre-backfill bottle shouldn't claim to be "#0".
+            Assert.Equal("#?", BottleInventory.FormatSerials(new[] { 0 }, cap: 8));
+        }
+
+        [Fact]
+        public void CountsBySubstance_OrdersByCountThenName()
+        {
+            var bottles = new[]
+            {
+                NewBottle(1, "cum", "Bob", hour: 1),
+                NewBottle(2, "milk", "Alice", hour: 2),
+                NewBottle(3, "milk", "Alice", hour: 3),
+                NewBottle(4, "milk", "Bob", hour: 4),
+            };
+
+            var counts = BottleInventory.CountsBySubstance(bottles);
+
+            Assert.Equal("milk", counts[0].Key);
+            Assert.Equal(3, counts[0].Value);
+            Assert.Equal("cum", counts[1].Key);
+            Assert.Equal(1, counts[1].Value);
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        internal static MilkBottle NewBottle(int serial, string substance, string source, int hour, string tag = null)
+        {
+            return new MilkBottle
+            {
+                serial = serial,
+                substance = substance,
+                sourceName = source,
+                quantity = 1,
+                corruptionTag = tag,
+                milkedAt = DateTime.UtcNow.Date.AddHours(hour),
+            };
+        }
+
+        internal static MilkBottle Emptied(MilkBottle bottle)
+        {
+            bottle.emptiedAt = bottle.milkedAt.AddMinutes(30);
+            return bottle;
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Bottlepaymenttests.cs
+++ b/FChatDicebot.Tests/Unit/Bottlepaymenttests.cs
@@ -1,0 +1,285 @@
+using FChatDicebot;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for bottle transfer through !pay.
+    ///
+    /// The property worth defending here is exactness across the consent gap. A currency payment
+    /// can settle with an atomic debit; a bottle payment can't, so it promises specific serial
+    /// numbers and refuses to settle for anything else — including the same bottle after it has
+    /// been drunk.
+    /// </summary>
+    [Collection("Database")]
+    public class BottlePaymentTests
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public BottlePaymentTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            new ProfileBuilder().WithUserName("Carol").WithDisplayName("Carol").BuildAndSave(_database);
+        }
+
+        // -------------------------------------------------------------------
+        // Parsing
+        // -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(new[] { "bottles" }, true)]
+        [InlineData(new[] { "bottle" }, true)]
+        [InlineData(new[] { "BOTTLES" }, true)]
+        [InlineData(new[] { "gold" }, false)]
+        [InlineData(new string[0], false)]
+        public void MentionsBottles_RecognisesTheKeyword(string[] terms, bool expected)
+        {
+            Assert.Equal(expected, BottlePayment.MentionsBottles(terms));
+        }
+
+        [Fact]
+        public void ParseSerials_TakesHashPrefixedNumbersInOrderWithoutDuplicates()
+        {
+            var serials = BottlePayment.ParseSerials(new[] { "bottles", "#12", "#7", "#12", "3" });
+
+            Assert.Equal(new[] { 12, 7 }, serials.ToArray());
+        }
+
+        // -------------------------------------------------------------------
+        // Selection
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Select_AmountForm_TakesNewestFullBottlesOnly()
+        {
+            var empty = Bottle(3, "cum", "Carol", hour: 9);
+            empty.emptiedAt = DateTime.UtcNow;
+            var payer = new ProfileBuilder()
+                .WithMilkBottle(Bottle(1, "cum", "Carol", hour: 1))
+                .WithMilkBottle(Bottle(2, "cum", "Carol", hour: 5))
+                .WithMilkBottle(empty)
+                .Build();
+
+            var selection = BottlePayment.Select(payer, new List<int>(), null, 2);
+
+            Assert.True(selection.IsValid);
+            // Newest-first among the full bottles; the newer empty is never swept in.
+            Assert.Equal(new[] { 2, 1 }, selection.Bottles.Select(b => b.serial).ToArray());
+        }
+
+        [Fact]
+        public void Select_AmountForm_ShortCollectionFails()
+        {
+            var payer = new ProfileBuilder()
+                .WithMilkBottle(Bottle(1, "cum", "Carol", hour: 1))
+                .Build();
+
+            var selection = BottlePayment.Select(payer, new List<int>(), null, 3);
+
+            Assert.False(selection.IsValid);
+            Assert.Equal(BottlePayment.NotEnoughText, selection.PayerFacingError);
+        }
+
+        [Fact]
+        public void Select_NamedSerial_CanMoveAnEmpty()
+        {
+            // A numbered empty is a keepsake worth handing over; naming it is the friction.
+            var empty = Bottle(3, "cum", "Carol", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            var payer = new ProfileBuilder().WithMilkBottle(empty).Build();
+
+            var selection = BottlePayment.Select(payer, new List<int> { 3 }, null, 1);
+
+            Assert.True(selection.IsValid);
+            Assert.True(selection.Bottles[0].IsEmpty);
+        }
+
+        [Fact]
+        public void Select_NamedSerial_NotHeldFails()
+        {
+            var payer = new ProfileBuilder()
+                .WithMilkBottle(Bottle(1, "cum", "Carol", hour: 1))
+                .Build();
+
+            var selection = BottlePayment.Select(payer, new List<int> { 99 }, null, 1);
+
+            Assert.False(selection.IsValid);
+            Assert.Contains("#99", selection.PayerFacingError);
+        }
+
+        [Fact]
+        public void Select_SubstanceFilterNarrowsTheAmountForm()
+        {
+            var payer = new ProfileBuilder()
+                .WithMilkBottle(Bottle(1, "milk", "Carol", hour: 5))
+                .WithMilkBottle(Bottle(2, "cum", "Carol", hour: 1))
+                .Build();
+
+            var selection = BottlePayment.Select(payer, new List<int>(), "cum", 1);
+
+            Assert.True(selection.IsValid);
+            Assert.Equal(2, selection.Bottles[0].serial);
+        }
+
+        // -------------------------------------------------------------------
+        // Transfer and the consent gap
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void TryTransfer_MovesBottlesIntactBetweenCollections()
+        {
+            SeedPair(Bottle(5, "cum", "Carol", hour: 1, tag: ChateauCurrency.CorruptTag));
+
+            bool moved = BottlePayment.TryTransfer(_database, "Alice", "Bob", Promise(5, false), out string failure);
+
+            Assert.True(moved, failure);
+            Assert.Empty(_database.GetProfile("Alice").milkInventory);
+            var received = Assert.Single(_database.GetProfile("Bob").milkInventory);
+            Assert.Equal(5, received.serial);
+            Assert.Equal("Carol", received.sourceName);
+            Assert.Equal(ChateauCurrency.CorruptTag, received.corruptionTag);
+        }
+
+        [Fact]
+        public void TryTransfer_BottleSoldDuringConsentGap_Aborts()
+        {
+            SeedPair(Bottle(5, "cum", "Carol", hour: 1));
+            // Alice sells it out from under the promise.
+            _database.SetMilkInventory("Alice", new List<MilkBottle>());
+
+            bool moved = BottlePayment.TryTransfer(_database, "Alice", "Bob", Promise(5, false), out string failure);
+
+            Assert.False(moved);
+            Assert.Contains("nothing changed hands", failure);
+            Assert.Empty(_database.GetProfile("Bob").milkInventory);
+        }
+
+        [Fact]
+        public void TryTransfer_BottleDrunkDuringConsentGap_AbortsRatherThanDeliveringAnEmpty()
+        {
+            // The bottle is still there under the same number, but the recipient consented to a
+            // full one. That's a mismatch, not a substitution.
+            SeedPair(Bottle(5, "cum", "Carol", hour: 1));
+            var alice = _database.GetProfile("Alice");
+            alice.milkInventory[0].emptiedAt = DateTime.UtcNow;
+            _database.SetMilkInventory("Alice", alice.milkInventory);
+
+            bool moved = BottlePayment.TryTransfer(_database, "Alice", "Bob", Promise(5, false), out string failure);
+
+            Assert.False(moved);
+            Assert.Contains("nothing changed hands", failure);
+            Assert.Empty(_database.GetProfile("Bob").milkInventory);
+            Assert.Single(_database.GetProfile("Alice").milkInventory);
+        }
+
+        [Fact]
+        public void TryTransfer_PartialMismatch_MovesNothingAtAll()
+        {
+            SeedPair(Bottle(5, "cum", "Carol", hour: 1), Bottle(6, "cum", "Carol", hour: 2));
+            var alice = _database.GetProfile("Alice");
+            alice.milkInventory.RemoveAll(b => b.serial == 6);
+            _database.SetMilkInventory("Alice", alice.milkInventory);
+
+            var promises = new List<KeyValuePair<int, bool>>
+            {
+                new KeyValuePair<int, bool>(5, false),
+                new KeyValuePair<int, bool>(6, false),
+            };
+            bool moved = BottlePayment.TryTransfer(_database, "Alice", "Bob", promises, out _);
+
+            Assert.False(moved);
+            // #5 was still available, but a partial delivery isn't what anyone agreed to.
+            Assert.Empty(_database.GetProfile("Bob").milkInventory);
+            Assert.Single(_database.GetProfile("Alice").milkInventory);
+        }
+
+        [Fact]
+        public void EncodePromise_CarriesEmptyStateAlongsideTheSerial()
+        {
+            var full = Bottle(9, "cum", "Carol", hour: 1);
+            var empty = Bottle(9, "cum", "Carol", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+
+            Assert.Equal(9, BottlePayment.EncodePromise(full));
+            Assert.Equal(-9, BottlePayment.EncodePromise(empty));
+        }
+
+        // -------------------------------------------------------------------
+        // Wording
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Describe_NamesCountSubstanceDonorAndTag()
+        {
+            var bottles = new List<MilkBottle>
+            {
+                Bottle(1, "cum", "Carol", hour: 2, tag: ChateauCurrency.CorruptTag),
+                Bottle(2, "cum", "Carol", hour: 1, tag: ChateauCurrency.CorruptTag),
+            };
+
+            string described = BottlePayment.Describe(_database, bottles);
+
+            Assert.Contains("[b]2 bottles[/b]", described);
+            Assert.Contains("Carol", described);
+            Assert.Contains("[b]corrupt[/b]", described);
+            Assert.DoesNotContain("emptied", described);
+        }
+
+        [Fact]
+        public void Describe_FlagsEmptiesSoNobodyConsentsToOneUnknowingly()
+        {
+            var empty = Bottle(1, "cum", "Carol", hour: 2);
+            empty.emptiedAt = DateTime.UtcNow;
+
+            Assert.Contains("(already emptied)",
+                BottlePayment.Describe(_database, new List<MilkBottle> { empty }));
+
+            // A mixed parcel says exactly how many rather than implying either.
+            var mixed = new List<MilkBottle> { empty, Bottle(2, "cum", "Carol", hour: 1) };
+            Assert.Contains("1 of them already emptied", BottlePayment.Describe(_database, mixed));
+        }
+
+        [Fact]
+        public void DescribesBottles_DistinguishesBottleSummariesFromCurrencyAmounts()
+        {
+            var bottles = new List<MilkBottle> { Bottle(1, "cum", "Carol", hour: 1) };
+
+            Assert.True(BottlePayment.DescribesBottles(BottlePayment.Describe(_database, bottles)));
+            // The currency path passes bare "{amount} {currency}" with no markup at all.
+            Assert.False(BottlePayment.DescribesBottles("100 gold"));
+            Assert.False(BottlePayment.DescribesBottles(null));
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private void SeedPair(params MilkBottle[] aliceBottles)
+        {
+            var builder = new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice");
+            foreach (var bottle in aliceBottles) builder.WithMilkBottle(bottle);
+            builder.BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+        }
+
+        private static List<KeyValuePair<int, bool>> Promise(int serial, bool wasEmpty)
+        {
+            return new List<KeyValuePair<int, bool>> { new KeyValuePair<int, bool>(serial, wasEmpty) };
+        }
+
+        private static MilkBottle Bottle(int serial, string substance, string source, int hour, string tag = null)
+        {
+            return BottleInventoryTests.NewBottle(serial, substance, source, hour, tag);
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Bottleserialtests.cs
+++ b/FChatDicebot.Tests/Unit/Bottleserialtests.cs
@@ -1,0 +1,131 @@
+using FChatDicebot;
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Involved;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for bottle serial issuance — the counter behind every bottle's permanent number.
+    ///
+    /// The properties that matter: numbers are never handed out twice (a duplicate would make
+    /// !drink #142 and !pay bottle #142 ambiguous), a milking claims its whole block in one
+    /// reservation, and a number is retired rather than recycled when its bottle leaves.
+    /// </summary>
+    [Collection("Database")]
+    public class BottleSerialTests
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public BottleSerialTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        [Fact]
+        public void ClaimBottleSerials_ReturnsFirstOfBlock()
+        {
+            int first = _database.ClaimBottleSerials(3);
+
+            // The block is [first, first+2]; the next claim must start past it.
+            int next = _database.ClaimBottleSerials(1);
+            Assert.Equal(first + 3, next);
+        }
+
+        [Fact]
+        public void ClaimBottleSerials_StartsAtOneOnFreshDatabase()
+        {
+            Assert.Equal(1, _database.ClaimBottleSerials(1));
+        }
+
+        [Fact]
+        public void ClaimBottleSerials_NeverRepeatsAcrossManyClaims()
+        {
+            var seen = new HashSet<int>();
+            for (int i = 0; i < 50; i++)
+            {
+                int count = (i % 3) + 1;
+                int first = _database.ClaimBottleSerials(count);
+                for (int offset = 0; offset < count; offset++)
+                {
+                    Assert.True(seen.Add(first + offset), "serial " + (first + offset) + " was issued twice");
+                }
+            }
+        }
+
+        [Fact]
+        public void ClaimBottleSerials_NonPositiveCountIsNoOp()
+        {
+            int before = _database.ClaimBottleSerials(1);
+            Assert.Equal(0, _database.ClaimBottleSerials(0));
+            Assert.Equal(before + 1, _database.ClaimBottleSerials(1));
+        }
+
+        [Fact]
+        public void SoldSerials_AreRetiredNotReissued()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(BottleInventoryTests.NewBottle(1, "cum", "Bob", hour: 1))
+                .Build();
+
+            ChateauSell.SellBottles(profile, null, null, 1);
+
+            // The bottle went to the Chateau, so its number leaves the collection entirely.
+            Assert.Empty(profile.milkInventory);
+            // And the counter keeps climbing rather than handing #1 back out.
+            _database.ClaimBottleSerials(1);
+            Assert.True(_database.ClaimBottleSerials(1) > 1);
+        }
+
+        [Fact]
+        public void DrunkSerials_StayInTheCollection()
+        {
+            // The counterpart to the sell case: drinking keeps the number, selling loses it.
+            var bottle = BottleInventoryTests.NewBottle(7, "cum", "Bob", hour: 1);
+            var profile = new ProfileBuilder().WithMilkBottle(bottle).Build();
+
+            bottle.emptiedAt = DateTime.UtcNow;
+
+            Assert.Single(profile.milkInventory);
+            Assert.Equal(7, profile.milkInventory[0].serial);
+            Assert.True(profile.milkInventory[0].IsEmpty);
+        }
+
+        [Fact]
+        public void MilkedSerialsSurviveTransferUnchanged()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            var alice = _database.GetProfile("Alice");
+            var bottle = BottleInventoryTests.NewBottle(0, "cum", "Carol", hour: 1);
+            bottle.serial = _database.ClaimBottleSerials(1);
+            bottle.corruptionTag = ChateauCurrency.CorruptTag;
+            alice.milkInventory.Add(bottle);
+            _database.SetMilkInventory("Alice", alice.milkInventory);
+
+            var promises = new List<KeyValuePair<int, bool>>
+            {
+                new KeyValuePair<int, bool>(bottle.serial, false),
+            };
+            bool moved = BottlePayment.TryTransfer(_database, "Alice", "Bob", promises, out string failure);
+
+            Assert.True(moved, failure);
+            var bobBottle = Assert.Single(_database.GetProfile("Bob").milkInventory);
+            Assert.Equal(bottle.serial, bobBottle.serial);
+            Assert.Equal("Carol", bobBottle.sourceName);
+            Assert.Equal(ChateauCurrency.CorruptTag, bobBottle.corruptionTag);
+            Assert.Empty(_database.GetProfile("Alice").milkInventory);
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Chateaubottlestests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubottlestests.cs
@@ -1,0 +1,198 @@
+using FChatDicebot;
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for the !bottles rendering. Uses the database fixture only to resolve donor
+    /// userNames into displayNames, which is the one thing the view can't do from the profile
+    /// alone and the one thing it must never skip.
+    /// </summary>
+    [Collection("Database")]
+    public class ChateauBottlesTests
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public ChateauBottlesTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bobby").BuildAndSave(_database);
+        }
+
+        [Fact]
+        public void BuildCollectionText_EmptyCollection_PointsAtMilk()
+        {
+            var profile = new ProfileBuilder().Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Equal(ChateauBottles.EmptyCollectionText, text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_ShowsCountSerialsAndPrice()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 2))
+                .WithMilkBottle(Bottle(12, "cum", "Bob", hour: 1))
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Contains("[b]2 bottles[/b]", text);
+            Assert.Contains("#11, #12", text);
+            Assert.Contains(ChateauCurrency.StandardBottlePrice + " " + ChateauCurrency.SellPayoutCurrency + " each", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_RendersDonorDisplayNameNotUserName()
+        {
+            // sourceName is a stored userName; a resident should never see the raw handle.
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 1))
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Contains("Bobby", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_TotalValueCountsFullBottlesOnly()
+        {
+            var empty = Bottle(12, "cum", "Bob", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 2))
+                .WithMilkBottle(empty)
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Contains("[b]1 bottle[/b]", text);
+            Assert.Contains("[b]" + ChateauCurrency.StandardBottlePrice + " "
+                + ChateauCurrency.SellPayoutCurrency + "[/b] if you choose to !sell", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_OnlyEmpties_DoesNotOpenWithZeroBottles()
+        {
+            var empty = Bottle(12, "cum", "Bob", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            var profile = new ProfileBuilder().WithMilkBottle(empty).Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.DoesNotContain("0 bottles", text);
+            Assert.Contains("[b]1 empty[/b]", text);
+            Assert.Contains("#12", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_ListsEmptiesSeparately()
+        {
+            var empty = Bottle(12, "cum", "Bob", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 2))
+                .WithMilkBottle(empty)
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Contains("Empties: #12", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_NoEmpties_OmitsTheEmptiesLine()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 1))
+                .Build();
+
+            Assert.DoesNotContain("Empties:", ChateauBottles.BuildCollectionText(_database, profile, null, null));
+        }
+
+        [Fact]
+        public void BuildCollectionText_TagsAreLabelled()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 2, tag: ChateauCurrency.CorruptTag))
+                .WithMilkBottle(Bottle(12, "milk", "Bob", hour: 1, tag: ChateauCurrency.PurifiedTag))
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            Assert.Contains("[b]corrupt[/b]", text);
+            Assert.Contains("[b]pure[/b]", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_FilterMiss_DistinguishedFromEmptyCollection()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 1))
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, "milk", null);
+
+            Assert.NotEqual(ChateauBottles.EmptyCollectionText, text);
+            Assert.Contains("!bottles on its own", text);
+        }
+
+        [Fact]
+        public void BuildCollectionText_GroupsSameSubstanceSourceAndTag()
+        {
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 3))
+                .WithMilkBottle(Bottle(12, "cum", "Bob", hour: 2))
+                .WithMilkBottle(Bottle(13, "cum", "Bob", hour: 1))
+                .Build();
+
+            string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
+
+            // Three separate milkings collapse into one readable line.
+            Assert.Contains("#11, #12, #13", text);
+            Assert.Equal(3, text.Split('\n').Length);
+        }
+
+        [Fact]
+        public void BuildCollectionLine_ZeroBottles_IsOmittedFromBank()
+        {
+            var profile = new ProfileBuilder().Build();
+
+            Assert.Equal(string.Empty, ChateauBank.BuildCollectionLine(profile, ownAccount: true));
+        }
+
+        [Fact]
+        public void BuildCollectionLine_CountsFullAndEmptySeparately()
+        {
+            var empty = Bottle(12, "cum", "Bob", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            var profile = new ProfileBuilder()
+                .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 2))
+                .WithMilkBottle(empty)
+                .Build();
+
+            string line = ChateauBank.BuildCollectionLine(profile, ownAccount: true);
+
+            Assert.Contains("[b]1 bottle[/b]", line);
+            Assert.Contains("[b]1 empty[/b]", line);
+            Assert.Contains("!bottles", line);
+        }
+
+        private static MilkBottle Bottle(int serial, string substance, string source, int hour, string tag = null)
+        {
+            return BottleInventoryTests.NewBottle(serial, substance, source, hour, tag);
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Chateaudrinktests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaudrinktests.cs
@@ -1,0 +1,349 @@
+using FChatDicebot;
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Tests for ChateauDrink.Execute — the pure drink logic behind !drink.
+    ///
+    /// The behaviour that distinguishes drinking from selling: the bottle is emptied rather than
+    /// removed, so its serial stays in the collection as proof of what was drunk, and no bottle
+    /// currency is credited because the physical empty is the keepsake instead.
+    /// </summary>
+    [Collection("Database")]
+    public class ChateauDrinkTests
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public ChateauDrinkTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+
+            _fixture.SeedIdentifier(new Identifier
+            {
+                type = "cum",
+                description = "cum",
+                categories = new[] { "substance", "vice" }
+            });
+        }
+
+        // -------------------------------------------------------------------
+        // Consumption
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Execute_EmptiesBottleButKeepsItAndItsSerial()
+        {
+            SeedDrinker("Alice", Bottle(42, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.NotNull(result.Bottle);
+            var stored = Assert.Single(_database.GetProfile("Alice").milkInventory);
+            Assert.Equal(42, stored.serial);
+            Assert.True(stored.IsEmpty);
+        }
+
+        [Fact]
+        public void Execute_CreditsNoBottleCurrency()
+        {
+            // Selling hands the empty to the Chateau for a bottle currency; drinking keeps it,
+            // so the tally must not move.
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+
+            ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            var currencies = _database.GetProfile("Alice").currencies;
+            Assert.False(currencies != null
+                && currencies.TryGetValue(ChateauCurrency.BottleCurrency, out int bottles)
+                && bottles > 0);
+        }
+
+        [Fact]
+        public void Execute_ImplicitSelectionTakesNewestFull()
+        {
+            SeedDrinker("Alice",
+                Bottle(1, "cum", "Bob", hour: 1),
+                Bottle(2, "cum", "Bob", hour: 9));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Equal(2, result.Bottle.serial);
+        }
+
+        [Fact]
+        public void Execute_ImplicitSelectionSkipsEmpties()
+        {
+            // The empty is newest, but an empty is never picked up implicitly.
+            var empty = Bottle(2, "cum", "Bob", hour: 9);
+            empty.emptiedAt = DateTime.UtcNow;
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1), empty);
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Equal(1, result.Bottle.serial);
+        }
+
+        [Fact]
+        public void Execute_SerialSelectsThatExactBottle()
+        {
+            SeedDrinker("Alice",
+                Bottle(11, "cum", "Bob", hour: 9),
+                Bottle(12, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 12, NeverRolls());
+
+            Assert.Equal(12, result.Bottle.serial);
+        }
+
+        [Fact]
+        public void Execute_UnknownSerial_ChangesNothing()
+        {
+            SeedDrinker("Alice", Bottle(11, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 99, NeverRolls());
+
+            Assert.Null(result.Bottle);
+            Assert.Contains("#99", result.PrivateMessage);
+            Assert.False(_database.GetProfile("Alice").milkInventory[0].IsEmpty);
+        }
+
+        [Fact]
+        public void Execute_AlreadyEmptySerial_GetsItsOwnMessage()
+        {
+            // Distinct from "not in your collection": the resident does hold #11, they just
+            // already drank it, and the useful remedy is different.
+            var empty = Bottle(11, "cum", "Bob", hour: 1);
+            empty.emptiedAt = DateTime.UtcNow;
+            SeedDrinker("Alice", empty);
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 11, NeverRolls());
+
+            Assert.Null(result.Bottle);
+            Assert.Contains("already empty", result.PrivateMessage);
+        }
+
+        [Fact]
+        public void Execute_EmptyCollection_ExplainsWhereBottlesComeFrom()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Null(result.Bottle);
+            Assert.Equal(ChateauBottles.EmptyCollectionText, result.PrivateMessage);
+            Assert.Empty(result.ChannelMessage);
+        }
+
+        [Fact]
+        public void Execute_SubstanceFilterMiss_ChangesNothing()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", "milk", 0, NeverRolls());
+
+            Assert.Null(result.Bottle);
+            Assert.False(_database.GetProfile("Alice").milkInventory[0].IsEmpty);
+        }
+
+        // -------------------------------------------------------------------
+        // Corruption transfer
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Execute_CorruptBottle_ShiftsDrinkerTowardCorruption()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1, tag: ChateauCurrency.CorruptTag));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Equal(-1, result.CorruptionApplied);
+            Assert.Equal(-1, CorruptionProcessor.ReadCorruption(_database.GetProfile("Alice")));
+        }
+
+        [Fact]
+        public void Execute_PurifiedBottle_ShiftsDrinkerTowardPurity()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1, tag: ChateauCurrency.PurifiedTag));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Equal(1, result.CorruptionApplied);
+            Assert.Equal(1, CorruptionProcessor.ReadCorruption(_database.GetProfile("Alice")));
+        }
+
+        [Fact]
+        public void Execute_UntaggedBottle_MovesNothing()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            Assert.Equal(0, result.CorruptionApplied);
+            Assert.False(result.BudgetSpent);
+            Assert.Equal(0, CorruptionProcessor.ReadCorruption(_database.GetProfile("Alice")));
+        }
+
+        [Fact]
+        public void Execute_PastDailyBudget_StillDrinksButMovesNothing()
+        {
+            var bottles = Enumerable.Range(1, ChateauCurrency.DrinkCorruptionDailyLimit + 1)
+                .Select(i => Bottle(i, "cum", "Bob", hour: i, tag: ChateauCurrency.CorruptTag))
+                .ToArray();
+            SeedDrinker("Alice", bottles);
+
+            for (int i = 0; i < ChateauCurrency.DrinkCorruptionDailyLimit; i++)
+            {
+                ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+            }
+            int atBudget = CorruptionProcessor.ReadCorruption(_database.GetProfile("Alice"));
+
+            var overBudget = ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            // The bottle is still drunk and still narrated, it just stops moving the needle.
+            Assert.NotNull(overBudget.Bottle);
+            Assert.True(overBudget.BudgetSpent);
+            Assert.Equal(0, overBudget.CorruptionApplied);
+            Assert.Equal(atBudget, CorruptionProcessor.ReadCorruption(_database.GetProfile("Alice")));
+            Assert.Contains("metabolize", overBudget.ChannelMessage);
+        }
+
+        [Fact]
+        public void Execute_DrinkBudget_DoesNotTouchCorruptQuota()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1, tag: ChateauCurrency.CorruptTag));
+
+            ChateauDrink.Execute(_database, "Alice", null, 0, NeverRolls());
+
+            var magnitudes = _database.GetProfile("Alice").dailyMagnitudes;
+            Assert.Contains(magnitudes, kv => kv.Key.StartsWith("drinkshift_"));
+            Assert.DoesNotContain(magnitudes, kv => kv.Key.StartsWith("corruption_"));
+        }
+
+        [Fact]
+        public void RecordUsedDrinkShift_PrunesStaleDays()
+        {
+            var profile = new ProfileBuilder().Build();
+            profile.dailyMagnitudes = new System.Collections.Generic.Dictionary<string, int>
+            {
+                { ChateauDrink.DrinkShiftQuotaKey(DateTime.UtcNow.Date.AddDays(-3)), 3 },
+            };
+
+            ChateauDrink.RecordUsedDrinkShift(profile, DateTime.UtcNow.Date, 1);
+
+            Assert.Single(profile.dailyMagnitudes);
+            Assert.Equal(1, ChateauDrink.GetUsedDrinkShift(profile, DateTime.UtcNow.Date));
+        }
+
+        // -------------------------------------------------------------------
+        // Addiction
+        // -------------------------------------------------------------------
+
+        [Fact]
+        public void Execute_AddictionRoll_IntensifiesAnExistingVice()
+        {
+            var profile = SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+            ViceInstance.SaveAll(profile, new System.Collections.Generic.List<ViceInstance>
+            {
+                new ViceInstance { Vice = "cum", AddictionLevel = 2, DosedBy = "Bob", FirstDosedAt = DateTime.UtcNow },
+            });
+            _database.SetProfile("Alice", profile);
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, AlwaysRolls());
+
+            Assert.True(result.AddictionIntensified);
+            var vice = ViceInstance.LoadAll(_database.GetProfile("Alice")).Single();
+            Assert.Equal(3, vice.AddictionLevel);
+        }
+
+        [Fact]
+        public void Execute_AddictionRoll_NeverCreatesANewVice()
+        {
+            SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, AlwaysRolls());
+
+            Assert.False(result.AddictionIntensified);
+            Assert.Empty(ViceInstance.LoadAll(_database.GetProfile("Alice")));
+        }
+
+        [Fact]
+        public void Execute_SatisfyingACravingStillTightensTheHook()
+        {
+            // Drinking what you're addicted to both quiets the craving and deepens it. The two
+            // are not exclusive: restricting the roll to unsatisfied drinks would make it
+            // unreachable, since only an existing vice can intensify and an existing vice is
+            // exactly what satisfaction requires.
+            var profile = SeedDrinker("Alice", Bottle(1, "cum", "Bob", hour: 1));
+            ViceInstance.SaveAll(profile, new System.Collections.Generic.List<ViceInstance>
+            {
+                new ViceInstance { Vice = "cum", AddictionLevel = 1, DosedBy = "Bob", FirstDosedAt = DateTime.UtcNow },
+            });
+            _database.SetProfile("Alice", profile);
+
+            var result = ChateauDrink.Execute(_database, "Alice", null, 0, AlwaysRolls());
+
+            Assert.True(result.AddictionIntensified);
+            Assert.Equal(2, ViceInstance.LoadAll(_database.GetProfile("Alice")).Single().AddictionLevel);
+        }
+
+        // -------------------------------------------------------------------
+        // Serial parsing
+        // -------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(new[] { "#142" }, 142)]
+        [InlineData(new[] { "cum", "#7" }, 7)]
+        [InlineData(new[] { "142" }, 0)]      // bare numbers are counts elsewhere, never serials
+        [InlineData(new[] { "#0" }, 0)]
+        [InlineData(new[] { "#abc" }, 0)]
+        [InlineData(new string[0], 0)]
+        public void ParseSerial_RequiresTheHashPrefix(string[] terms, int expected)
+        {
+            Assert.Equal(expected, ChateauDrink.ParseSerial(terms));
+        }
+
+        // -------------------------------------------------------------------
+        // Helpers
+        // -------------------------------------------------------------------
+
+        private Profile SeedDrinker(string userName, params MilkBottle[] bottles)
+        {
+            var builder = new ProfileBuilder().WithUserName(userName).WithDisplayName(userName);
+            foreach (var bottle in bottles) builder.WithMilkBottle(bottle);
+            builder.BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+            return _database.GetProfile(userName);
+        }
+
+        private static MilkBottle Bottle(int serial, string substance, string source, int hour, string tag = null)
+        {
+            return BottleInventoryTests.NewBottle(serial, substance, source, hour, tag);
+        }
+
+        /// <summary>Rng whose NextDouble always clears the addiction threshold (no intensify).</summary>
+        private static Random NeverRolls() => new FixedSampleRandom(0.999);
+
+        /// <summary>Rng whose NextDouble always lands under the addiction threshold.</summary>
+        private static Random AlwaysRolls() => new FixedSampleRandom(0.0);
+
+        private class FixedSampleRandom : Random
+        {
+            private readonly double _sample;
+            public FixedSampleRandom(double sample) { _sample = sample; }
+            protected override double Sample() => _sample;
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Milkprocessortests.cs
+++ b/FChatDicebot.Tests/Unit/Milkprocessortests.cs
@@ -204,7 +204,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
         // -------------------------------------------------------------------
 
         [Fact]
-        public void ProcessInteraction_AppendsBottleToInitiator()
+        public void ProcessInteraction_AppendsOneEntryPerBottleToInitiator()
         {
             new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
             new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
@@ -215,13 +215,33 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
             _processor.ProcessInteraction(pending);
 
             var alice = _database.GetProfile("Alice");
-            Assert.Single(alice.milkInventory);
-            var bottle = alice.milkInventory[0];
-            Assert.Equal("cum", bottle.substance);
-            Assert.Equal("Bob", bottle.sourceName);
-            // 0.5 sample over [1, 4) → 2 bottles
-            Assert.Equal(2, bottle.quantity);
-            Assert.Null(bottle.corruptionTag); // Bob has neutral corruption
+            // 0.5 sample over [1, 4) → 2 bottles, and a serial names one bottle, so a
+            // 2-bottle milking writes two entries rather than one entry of quantity 2.
+            Assert.Equal(2, alice.milkInventory.Count);
+            foreach (var entry in alice.milkInventory)
+            {
+                Assert.Equal("cum", entry.substance);
+                Assert.Equal("Bob", entry.sourceName);
+                Assert.Equal(1, entry.quantity);
+                Assert.Null(entry.corruptionTag); // Bob has neutral corruption
+                Assert.False(entry.IsEmpty);
+                Assert.True(entry.serial > 0);
+            }
+        }
+
+        [Fact]
+        public void ProcessInteraction_ClaimsConsecutiveSerials()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            new ProfileBuilder().WithUserName("Bob").WithDisplayName("Bob").BuildAndSave(_database);
+
+            _processor.ProcessInteraction(SaveAndReturn(BuildPendingCommand("Alice", "Bob", "cum")));
+
+            var serials = _database.GetProfile("Alice").milkInventory
+                .Select(b => b.serial).OrderBy(s => s).ToList();
+            Assert.Equal(2, serials.Count);
+            // Reserved as one contiguous block so a concurrent milking can't interleave.
+            Assert.Equal(serials[0] + 1, serials[1]);
         }
 
         [Fact]

--- a/FChatDicebot/BotCommands/ChateauBank.cs
+++ b/FChatDicebot/BotCommands/ChateauBank.cs
@@ -128,8 +128,36 @@ namespace FChatDicebot.BotCommands
                     bankText = bankText.TrimEnd(' ', '|');
                 }
 
+                // Bottles live outside the vault, so they hang off both branches: a resident with
+                // no currency but a full collection was previously told they owned nothing.
+                string collectionLine = BuildCollectionLine(profile, ownAccount);
+                if (!string.IsNullOrEmpty(collectionLine))
+                {
+                    bankText += "\n" + collectionLine;
+                }
             }
             bot.SendPrivateMessage(bankText, characterName);
+        }
+
+        /// <summary>
+        /// One-line summary of the resident's bottle collection, pointing at !bottles for the
+        /// detail. Empty string when they hold nothing, so an untouched collection adds no noise.
+        /// </summary>
+        public static string BuildCollectionLine(Profile profile, bool ownAccount)
+        {
+            if (profile == null || profile.milkInventory == null) return string.Empty;
+            int full = profile.milkInventory.Count(b => b != null && !b.IsEmpty);
+            int empty = profile.milkInventory.Count(b => b != null && b.IsEmpty);
+            if (full == 0 && empty == 0) return string.Empty;
+
+            var pieces = new List<string>();
+            if (full > 0) pieces.Add("[b]" + full + " bottle" + (full == 1 ? "" : "s") + "[/b]");
+            if (empty > 0) pieces.Add("[b]" + empty + " empt" + (empty == 1 ? "y" : "ies") + "[/b]");
+            string held = string.Join(" and ", pieces);
+
+            return ownAccount
+                ? $"You're also holding {held} of your own. Use !bottles to look them over."
+                : $"{profile.displayName} is also holding {held}.";
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauBottles.cs
+++ b/FChatDicebot/BotCommands/ChateauBottles.cs
@@ -1,0 +1,161 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// Private read-only view of the caller's bottle collection: full bottles with their
+    /// serials, donors, corruption tags and sell values, then the numbered empties.
+    ///
+    /// Argument shape deliberately mirrors <see cref="ChateauSell"/> so the two read as a pair,
+    /// and the ordering is the same newest-first contract, meaning the top line of this output
+    /// is exactly what an unfiltered <c>!sell</c> or <c>!drink</c> will act on next.
+    ///
+    /// Self-only. Another resident's collection shows up in summary form on their public
+    /// <c>!dossier</c> with counts but no donor names, which is the privacy line: how many
+    /// bottles someone has is public, who they milked for them is not.
+    /// </summary>
+    public class ChateauBottles : ChatBotCommand
+    {
+        public ChateauBottles()
+        {
+            Name = "bottles";
+            Aliases = new string[] { "collection" };
+            Category = "General";
+            ShortDescription = "Look over the bottles you've collected.";
+            LongDescription = "Review the bottled fluid in your personal collection. Each bottle carries its own number, the resident it came from, whether it's corrupt or pure, and what the Chateau would pay for it. Empties keep their number too, so your collection remembers everything you've ever drunk. Filter by substance and by donor to narrow the list.";
+            Usage = "!bottles\nor\n!bottles {substance}\nor\n!bottles {substance} [noparse][user]NameInUserTag[/user][/noparse]";
+            RelatedCommands = new string[] { "milk", "sell", "drink", "pay", "bank" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = "substance";
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = false;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, MessageAddress address, UserGeneratedCommand command)
+        {
+            string characterName = address.character;
+            Profile profile = MonDB.getProfile(characterName);
+            if (profile == null)
+            {
+                bot.SendPrivateMessage(ChateauInteractionHandler.notRegisteredText(), characterName);
+                return;
+            }
+
+            string substanceFilter = commandController.GetIdentifierFromCommandTerms(rawTerms, "substance");
+            string sourceFilter = commandController.GetUserNameFromCommandTerms(rawTerms);
+
+            bot.SendPrivateMessage(
+                BuildCollectionText(MonDB.GetDatabase(), profile, substanceFilter, sourceFilter),
+                characterName);
+        }
+
+        /// <summary>
+        /// Pure renderer, factored out so the layout can be tested without a bot connection.
+        /// Takes the database only to resolve donor userNames into displayNames.
+        /// </summary>
+        public static string BuildCollectionText(
+            IChateauDatabase database, Profile profile, string substanceFilter, string sourceFilter)
+        {
+            bool filtered = !string.IsNullOrEmpty(substanceFilter) || !string.IsNullOrEmpty(sourceFilter);
+
+            if (BottleInventory.IsCollectionEmpty(profile))
+            {
+                return EmptyCollectionText;
+            }
+
+            var full = BottleInventory.SelectFull(profile, substanceFilter, sourceFilter);
+            var empties = BottleInventory.SelectEmpty(profile, substanceFilter, sourceFilter);
+
+            if (full.Count == 0 && empties.Count == 0)
+            {
+                return filtered ? FilterMissText : EmptyCollectionText;
+            }
+
+            var lines = new List<string>();
+
+            // A resident who has drunk everything they own still has a collection worth
+            // showing, but "you're holding 0 bottles" would be a strange way to open it.
+            if (full.Count == 0)
+            {
+                string emptyWord = empties.Count == 1 ? "empty" : "empties";
+                lines.Add("Nothing left to drink, but our records show you're keeping [b]"
+                    + empties.Count + " " + emptyWord + "[/b]:");
+                lines.Add(BottleInventory.FormatSerials(
+                    empties.Select(b => b.serial), ChateauCurrency.BottleSerialDisplayCap));
+                lines.Add("Go !milk a willing resident if you'd like something to drink.");
+                return string.Join("\n", lines);
+            }
+
+            string bottleWord = full.Count == 1 ? "bottle" : "bottles";
+            lines.Add("Our records show you're holding [b]" + full.Count + " " + bottleWord + "[/b]:");
+
+            int totalValue = 0;
+            foreach (var group in BottleInventory.Group(full))
+            {
+                int pricePer = ChateauCurrency.GetSellPricePerBottle(group.Substance, group.CorruptionTag);
+                totalValue += pricePer * group.Count;
+                lines.Add(BuildGroupLine(database, group, pricePer));
+            }
+
+            if (empties.Count > 0)
+            {
+                lines.Add("Empties: " + BottleInventory.FormatSerials(
+                    empties.Select(b => b.serial), ChateauCurrency.BottleSerialDisplayCap));
+            }
+
+            lines.Add("That's [b]" + totalValue + " " + ChateauCurrency.SellPayoutCurrency
+                + "[/b] if you choose to !sell the lot to the Chateau on the cheap, but someone might be"
+                + " willing to let you !pay them with a few bottles... or you could always have a !drink.");
+
+            return string.Join("\n", lines);
+        }
+
+        private static string BuildGroupLine(IChateauDatabase database, BottleInventory.BottleGroup group, int pricePer)
+        {
+            string line = "[b]" + Utils.SubstanceToText(group.Substance) + "[/b] from "
+                + DonorText(database, group.SourceName);
+
+            if (group.CorruptionTag == ChateauCurrency.CorruptTag)
+            {
+                line += ", [b]corrupt[/b]";
+            }
+            else if (group.CorruptionTag == ChateauCurrency.PurifiedTag)
+            {
+                line += ", [b]pure[/b]";
+            }
+
+            line += " | " + BottleInventory.FormatSerials(group.Serials, ChateauCurrency.BottleSerialDisplayCap)
+                + " | " + pricePer + " " + ChateauCurrency.SellPayoutCurrency + " each";
+            return line;
+        }
+
+        /// <summary>
+        /// Shared with <c>!drink</c> so the two commands describe an untouched collection the
+        /// same way.
+        /// </summary>
+        public const string EmptyCollectionText =
+            "No bottles to speak of yet. Go !milk a willing resident to start your collection!";
+
+        private const string FilterMissText =
+            "We don't see anything like that in your collection. Use !bottles on its own to see everything you're holding.";
+
+        /// <summary>
+        /// Donor names are stored as userNames and must be resolved before a resident reads
+        /// them. Falls back to the stored name only if the donor has since vanished from the
+        /// roster entirely.
+        /// </summary>
+        public static string DonorText(IChateauDatabase database, string sourceName)
+        {
+            if (string.IsNullOrEmpty(sourceName)) return "an unknown donor";
+            string displayName = database?.GetDisplayName(sourceName);
+            return string.IsNullOrEmpty(displayName) ? sourceName : displayName;
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -664,10 +664,43 @@ namespace FChatDicebot.BotCommands
             List<string> cells = new List<string>();
             string titles = BuildTitlesEarnedSection(profile);
             string currency = BuildMostAbundantCurrencySection(profile);
+            string bottled = BuildBottledSection(profile);
             if (!string.IsNullOrEmpty(titles)) cells.Add(titles);
             if (!string.IsNullOrEmpty(currency)) cells.Add(currency);
+            if (!string.IsNullOrEmpty(bottled)) cells.Add(bottled);
             if (cells.Count == 0) return string.Empty;
             return string.Join(InlineSeparator, cells) + "\n";
+        }
+
+        /// <summary>
+        /// Single-line bottle collection tally. Substance counts only, deliberately: the dossier
+        /// is public and a bottle's sourceName amounts to "who has this resident milked", which
+        /// is the donor's business rather than the reader's. Serial numbers are likewise omitted
+        /// so a public page can't be used to shop someone else's collection.
+        /// </summary>
+        private string BuildBottledSection(Profile profile)
+        {
+            if (profile.milkInventory == null || profile.milkInventory.Count == 0) return string.Empty;
+
+            var full = profile.milkInventory.Where(b => b != null && !b.IsEmpty).ToList();
+            int emptyCount = profile.milkInventory.Count(b => b != null && b.IsEmpty);
+            if (full.Count == 0 && emptyCount == 0) return string.Empty;
+
+            List<string> parts = new List<string>();
+            if (full.Count > 0)
+            {
+                var breakdown = BottleInventory.CountsBySubstance(full)
+                    .Select(kv => kv.Value + " " + Utils.SubstanceToText(kv.Key))
+                    .ToList();
+                parts.Add(full.Count + " bottle" + (full.Count == 1 ? "" : "s")
+                    + (breakdown.Count > 0 ? " (" + string.Join(", ", breakdown) + ")" : ""));
+            }
+            if (emptyCount > 0)
+            {
+                parts.Add(emptyCount + " empt" + (emptyCount == 1 ? "y" : "ies"));
+            }
+
+            return "[b]Bottled:[/b] " + string.Join(" and ", parts);
         }
 
         /// <summary>

--- a/FChatDicebot/BotCommands/ChateauDrink.cs
+++ b/FChatDicebot/BotCommands/ChateauDrink.cs
@@ -1,0 +1,378 @@
+using FChatDicebot.BotCommands.Base;
+using FChatDicebot.Database;
+using FChatDicebot.InteractionProcessors;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.InteractionProcessors.StatusEffectContributors;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands
+{
+    /// <summary>
+    /// Uncork and drink one bottle from your own collection. Self-targeted, so there is no
+    /// consent flow, but it is deliberately channel-only: the effects are things the channel is
+    /// meant to witness (<c>!dose</c>'s own consent text promises everyone will know when a
+    /// craving is satisfied), and a private-message run would either swallow that or leak
+    /// public-by-design text into a PM.
+    ///
+    /// Drinking does not destroy the bottle. It stamps <see cref="MilkBottle.emptiedAt"/> and
+    /// the numbered empty stays in the collection as proof of what was drunk. That is what makes
+    /// this different from <c>!sell</c>, where the Chateau keeps the bottle and the serial is
+    /// gone. Because the empty is the keepsake, drinking credits no bottle currency.
+    ///
+    /// Three effects fire, in this order: the corruption the bottle's tag carries (bounded by a
+    /// daily budget), whatever the status-effect contributors have to say (a satisfied craving,
+    /// most of the time), and a roll to deepen an addiction the drinker already has.
+    ///
+    /// Structured like <see cref="ChateauDetox"/>: a thin command over a pure
+    /// <see cref="Execute(IChateauDatabase, string, string, int, Random)"/> so the effect logic
+    /// is testable without a bot connection.
+    /// </summary>
+    public class ChateauDrink : ChatBotCommand
+    {
+        public ChateauDrink()
+        {
+            Name = "drink";
+            Aliases = new string[] { "imbibe", "swig" };
+            Category = "General";
+            ShortDescription = "Drink down one of the bottles you're holding.";
+            LongDescription = "Uncork and drink a bottle from your collection, keeping the empty. Whatever was inside affects you: a corrupt or pure bottle shifts you the same way, up to 3 bottles per day, and a substance you're addicted to will quiet the craving. There's always a small chance you find yourself wanting more. Name a bottle by its number, or leave it off to drink your newest.";
+            Usage = "!drink\nor\n!drink {substance}\nor\n!drink #{number}";
+            RelatedCommands = new string[] { "bottles", "milk", "sell", "dose", "detox" };
+            CooldownDuration = null;
+            CooldownAppliesTo = null;
+            IdentifierCategory = "substance";
+            RequireBotAdmin = false;
+            RequireChannelAdmin = false;
+            RequireChannel = true;
+            LockCategory = CommandLockCategory.NONE;
+        }
+
+        public override void Run(BotMain bot, BotCommandController commandController, string[] rawTerms, string[] terms, MessageAddress address, UserGeneratedCommand command)
+        {
+            string characterName = address.character;
+            string channel = address.channel;
+
+            string substanceFilter = commandController.GetIdentifierFromCommandTerms(rawTerms, "substance");
+            int serial = ParseSerial(rawTerms);
+
+            DrinkResult result = Execute(MonDB.GetDatabase(), characterName, substanceFilter, serial, new Random());
+
+            if (!string.IsNullOrEmpty(result.ChannelMessage))
+            {
+                bot.SendMessageInChannel(result.ChannelMessage, channel);
+            }
+            if (!string.IsNullOrEmpty(result.PrivateMessage))
+            {
+                bot.SendPrivateMessage(result.PrivateMessage, characterName);
+            }
+        }
+
+        /// <summary>
+        /// Pulls a <c>#142</c>-style bottle number out of the raw terms. The <c>#</c> is required
+        /// so a bare number can never be mistaken for a count, which matters because the sibling
+        /// <c>!pay</c> syntax does take a bare amount. Returns 0 when no serial was named.
+        /// </summary>
+        public static int ParseSerial(string[] rawTerms)
+        {
+            if (rawTerms == null) return 0;
+            foreach (string term in rawTerms)
+            {
+                if (string.IsNullOrEmpty(term) || term[0] != '#') continue;
+                if (int.TryParse(term.Substring(1), out int parsed) && parsed > 0) return parsed;
+            }
+            return 0;
+        }
+
+        public class DrinkResult
+        {
+            public string ChannelMessage { get; set; } = string.Empty;
+            public string PrivateMessage { get; set; } = string.Empty;
+            /// <summary>The bottle that was drunk, or null when nothing was consumed.</summary>
+            public MilkBottle Bottle { get; set; }
+            /// <summary>Corruption actually applied: -1, +1, or 0 when untagged or over budget.</summary>
+            public int CorruptionApplied { get; set; }
+            /// <summary>True when the bottle was tagged but the daily budget was already spent.</summary>
+            public bool BudgetSpent { get; set; }
+            /// <summary>True when the drink deepened an addiction the drinker already carried.</summary>
+            public bool AddictionIntensified { get; set; }
+        }
+
+        /// <summary>
+        /// Drink one bottle and apply its effects. <paramref name="serial"/> of 0 means "no
+        /// specific bottle", falling back to the newest full bottle matching
+        /// <paramref name="substanceFilter"/>.
+        /// </summary>
+        public static DrinkResult Execute(
+            IChateauDatabase database, string characterName, string substanceFilter, int serial, Random rng)
+        {
+            var result = new DrinkResult();
+            rng = rng ?? new Random();
+
+            Profile profile = database.GetProfile(characterName);
+            if (profile == null)
+            {
+                result.PrivateMessage = ChateauInteractionHandler.notRegisteredText();
+                return result;
+            }
+
+            MilkBottle bottle = SelectBottle(profile, substanceFilter, serial, result);
+            if (bottle == null) return result;
+
+            // The bottle stays put. Only its contents are gone.
+            bottle.emptiedAt = DateTime.UtcNow;
+            result.Bottle = bottle;
+
+            string substanceText = Utils.SubstanceToText(bottle.substance, database.GetIdentifier(bottle.substance));
+            string drinkerName = string.IsNullOrEmpty(profile.displayName) ? profile.userName : profile.displayName;
+
+            ApplyCorruption(profile, bottle, result);
+
+            // Status effects run before the addiction roll so the satisfaction fragment (if the
+            // drinker is hooked on this substance) reads ahead of the "wanting another already"
+            // line that follows from it.
+            var fragments = SelfCommandStatusEffects.GetCompletionFragments(
+                profile, DoseStatusContributor.DrinkType, bottle.substance);
+
+            int addictionLevel = ApplyAddictionRoll(profile, bottle, rng, result);
+
+            // One write for the whole command. Everything touched (the emptied bottle, the
+            // corruption characteristic, the daily budget, the vice list) lives on this one
+            // profile, matching how !detox persists its own multi-field change.
+            database.SetProfile(characterName, profile);
+
+            result.ChannelMessage = BuildChannelMessage(
+                database, drinkerName, bottle, substanceText, result, addictionLevel, fragments.CompletionAppendix, rng);
+            return result;
+        }
+
+        /// <summary>
+        /// Resolve which bottle is being drunk, or record the refusal message and return null.
+        /// Empties are never selected implicitly, and an explicitly named empty gets its own
+        /// message — "you already drank that" is a different situation from "you don't have it".
+        /// </summary>
+        private static MilkBottle SelectBottle(
+            Profile profile, string substanceFilter, int serial, DrinkResult result)
+        {
+            if (serial > 0)
+            {
+                MilkBottle named = BottleInventory.FindBySerial(profile, serial);
+                if (named == null)
+                {
+                    result.PrivateMessage = "Bottle [b]#" + serial + "[/b] isn't in your collection."
+                        + " Perhaps you sold it off... use !bottles to check your numbers.";
+                    return null;
+                }
+                if (named.IsEmpty)
+                {
+                    result.PrivateMessage = "Bottle [b]#" + serial + "[/b] is already empty!"
+                        + " Use !bottles to see which of yours still have something in them.";
+                    return null;
+                }
+                return named;
+            }
+
+            var candidates = BottleInventory.SelectFull(profile, substanceFilter, null);
+            if (candidates.Count > 0) return candidates[0];
+
+            // Nothing to drink. Distinguish "you own nothing" from "your filter matched nothing"
+            // so the remedy we point at is the useful one.
+            if (BottleInventory.IsCollectionEmpty(profile))
+            {
+                result.PrivateMessage = ChateauBottles.EmptyCollectionText;
+            }
+            else if (!string.IsNullOrEmpty(substanceFilter))
+            {
+                result.PrivateMessage = "We don't see any of that in your collection."
+                    + " Use !bottles to check what you're actually holding.";
+            }
+            else
+            {
+                result.PrivateMessage = "Every bottle you're holding is already empty."
+                    + " Go !milk a willing resident if you'd like something to drink.";
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Move the drinker's corruption by the bottle's tag, within the day's budget. The budget
+        /// lives under its own key so it never draws from the per-pair <c>!corrupt</c> quota, and
+        /// it is what bounds the drift now that bottles can be pooled through <c>!pay</c>.
+        /// </summary>
+        private static void ApplyCorruption(Profile profile, MilkBottle bottle, DrinkResult result)
+        {
+            int shift = ShiftForTag(bottle.corruptionTag);
+            if (shift == 0) return;
+
+            DateTime utcDay = DateTime.UtcNow.Date;
+            int used = GetUsedDrinkShift(profile, utcDay);
+            if (used >= ChateauCurrency.DrinkCorruptionDailyLimit)
+            {
+                result.BudgetSpent = true;
+                return;
+            }
+
+            int current = CorruptionProcessor.ReadCorruption(profile);
+            if (profile.characteristics == null)
+            {
+                profile.characteristics = new Dictionary<string, string>();
+            }
+            profile.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = (current + shift).ToString();
+            RecordUsedDrinkShift(profile, utcDay, used + Math.Abs(shift));
+            result.CorruptionApplied = shift;
+        }
+
+        /// <summary>
+        /// Corrupt bottles pull toward corruption (negative), purified ones toward purity
+        /// (positive), matching the sign convention in <see cref="ChateauCurrency"/>.
+        /// </summary>
+        public static int ShiftForTag(string corruptionTag)
+        {
+            if (string.Equals(corruptionTag, ChateauCurrency.CorruptTag, StringComparison.OrdinalIgnoreCase))
+            {
+                return -ChateauCurrency.DrinkCorruptionShiftPerBottle;
+            }
+            if (string.Equals(corruptionTag, ChateauCurrency.PurifiedTag, StringComparison.OrdinalIgnoreCase))
+            {
+                return ChateauCurrency.DrinkCorruptionShiftPerBottle;
+            }
+            return 0;
+        }
+
+        public static string DrinkShiftQuotaKey(DateTime utcDay) => "drinkshift_" + utcDay.ToString("yyyy-MM-dd");
+
+        public static int GetUsedDrinkShift(Profile profile, DateTime utcDay)
+        {
+            if (profile?.dailyMagnitudes == null) return 0;
+            return profile.dailyMagnitudes.TryGetValue(DrinkShiftQuotaKey(utcDay), out int used) ? used : 0;
+        }
+
+        /// <summary>
+        /// Record today's spend and drop stale-dated drink keys, mirroring
+        /// <see cref="CorruptionProcessor.RecordUsedQuota"/> so old days don't accumulate on the
+        /// profile forever.
+        /// </summary>
+        public static void RecordUsedDrinkShift(Profile profile, DateTime utcDay, int newTotal)
+        {
+            if (profile == null) return;
+            if (profile.dailyMagnitudes == null)
+            {
+                profile.dailyMagnitudes = new Dictionary<string, int>();
+            }
+            string todayKey = DrinkShiftQuotaKey(utcDay);
+            var stale = profile.dailyMagnitudes.Keys
+                .Where(k => k.StartsWith("drinkshift_", StringComparison.Ordinal)
+                            && !string.Equals(k, todayKey, StringComparison.Ordinal))
+                .ToList();
+            foreach (var key in stale)
+            {
+                profile.dailyMagnitudes.Remove(key);
+            }
+            profile.dailyMagnitudes[todayKey] = newTotal;
+        }
+
+        /// <summary>
+        /// Roll to deepen an addiction the drinker already carries for this substance. Returns
+        /// the resulting addiction level, or 0 when nothing intensified.
+        ///
+        /// Note this deliberately fires even when the same drink satisfied the craving: the
+        /// bottle quiets the want now and tightens the hook at the same time, which is the whole
+        /// dynamic the vice system is modelling. Restricting it to unsatisfied drinks would make
+        /// the roll unreachable, since only an existing vice can intensify and an existing vice
+        /// is exactly what satisfaction requires.
+        /// </summary>
+        private static int ApplyAddictionRoll(Profile profile, MilkBottle bottle, Random rng, DrinkResult result)
+        {
+            if (string.IsNullOrEmpty(bottle.substance)) return 0;
+            if (rng.NextDouble() >= ChateauCurrency.DrinkAddictionChance) return 0;
+
+            var intensified = DoseProcessor.IntensifyExistingVices(profile, new[] { bottle.substance });
+            if (intensified.Count == 0) return 0;
+
+            result.AddictionIntensified = true;
+            var vice = ViceInstance.LoadAll(profile)
+                .FirstOrDefault(v => string.Equals(v.Vice, bottle.substance, StringComparison.OrdinalIgnoreCase));
+            return vice?.AddictionLevel ?? 0;
+        }
+
+        // -------------------------------------------------------------------
+        // Channel message
+        // -------------------------------------------------------------------
+
+        private static readonly string[] ClosingFlourishes = new[]
+        {
+            "Unbottled, unsealed, and thoroughly enjoyed.",
+            "Not a drop wasted!",
+            "The empty goes in the collection.",
+            "Rumors say green clad adventurers will pay a lot for an empty bottle...",
+            "Got {substance}?",
+        };
+
+        private static string BuildChannelMessage(
+            IChateauDatabase database,
+            string drinkerName,
+            MilkBottle bottle,
+            string substanceText,
+            DrinkResult result,
+            int addictionLevel,
+            List<string> statusFragments,
+            Random rng)
+        {
+            var parts = new List<string>();
+
+            string serialText = bottle.serial > 0 ? " [b]#" + bottle.serial + "[/b]" : string.Empty;
+            parts.Add(drinkerName + " uncorks bottle" + serialText + " and drinks down the tasty "
+                + substanceText + " from " + ChateauBottles.DonorText(database, bottle.sourceName) + ".");
+
+            parts.Add(ClosingFlourishes[rng.Next(ClosingFlourishes.Length)].Replace("{substance}", substanceText));
+
+            string corruptionFragment = BuildCorruptionFragment(drinkerName, bottle, result);
+            if (!string.IsNullOrEmpty(corruptionFragment)) parts.Add(corruptionFragment);
+
+            if (statusFragments != null)
+            {
+                parts.AddRange(statusFragments.Where(f => !string.IsNullOrEmpty(f)));
+            }
+
+            if (result.AddictionIntensified)
+            {
+                string levelNote = addictionLevel > 0
+                    ? " [sub](addiction " + addictionLevel + "/" + DoseProcessor.MaxAddictionLevel + ")[/sub]"
+                    : string.Empty;
+                parts.Add("...and " + drinkerName + " finds themself wanting another already." + levelNote);
+            }
+
+            return string.Join(" ", parts);
+        }
+
+        /// <summary>
+        /// Two halves: the taste always lands, and the mechanical half is what the daily budget
+        /// can take away. An over-budget drink still reads as the thing it is, it just stops
+        /// moving the needle.
+        /// </summary>
+        private static string BuildCorruptionFragment(string drinkerName, MilkBottle bottle, DrinkResult result)
+        {
+            bool corrupt = string.Equals(bottle.corruptionTag, ChateauCurrency.CorruptTag, StringComparison.OrdinalIgnoreCase);
+            bool pure = string.Equals(bottle.corruptionTag, ChateauCurrency.PurifiedTag, StringComparison.OrdinalIgnoreCase);
+            if (!corrupt && !pure) return string.Empty;
+
+            string taste = corrupt ? "How delightfully dark and rich~" : "So light and invigorating!";
+
+            string effect;
+            if (result.BudgetSpent)
+            {
+                effect = "No effect though... maybe tomorrow they'll be able to metabolize a bit more.";
+            }
+            else
+            {
+                effect = drinkerName + " gains " + Math.Abs(result.CorruptionApplied)
+                    + (corrupt ? " corruption." : " purity.");
+            }
+
+            return taste + " " + effect;
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauMilk.cs
+++ b/FChatDicebot/BotCommands/ChateauMilk.cs
@@ -26,7 +26,7 @@ namespace FChatDicebot.BotCommands
             ShortDescription = "Milk a substance from another resident.";
             LongDescription = "Milk a specified substance from another resident, gaining 1 to 3 bottles. The bottles might be pure or corrupted based on who was milked. You can only milk a specified resident once per day.";
             Usage = "!milk [noparse][user]NameInUserTag[/user][/noparse] {substance}";
-            RelatedCommands = new string[] { "sell", "feed", "golden", "consent", "dossier" };
+            RelatedCommands = new string[] { "bottles", "sell", "drink", "feed", "golden", "consent", "dossier" };
             CooldownDuration = "1 day, per-direction";
             CooldownAppliesTo = "initiator (per recipient)";
             IdentifierCategory = "substance";

--- a/FChatDicebot/BotCommands/ChateauPay.cs
+++ b/FChatDicebot/BotCommands/ChateauPay.cs
@@ -20,9 +20,9 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "Involved Interaction";
             ShortDescription = "Transfer currency to/from another resident.";
-            LongDescription = "Pay an amount of currency to another character (defaulting to 1 if no amount is specified). Pay a negative amount to instead 'bill' someone else and ask them to pay you. Currency isn't inherently valuable in the Chateau where everyone is cared for one way or another, but people still like to exchange it for goods and services.";
-            Usage = "!pay [noparse][user]NameInUserTag[/user][/noparse] {amount} {currency}\nor\n!pay {currency}";
-            RelatedCommands = new string[] { "bank", "work", "volunteer" };
+            LongDescription = "Pay an amount of currency to another character (defaulting to 1 if no amount is specified). Pay a negative amount to instead 'bill' someone else and ask them to pay you. Currency isn't inherently valuable in the Chateau where everyone is cared for one way or another, but people still like to exchange it for goods and services. You can also pass along bottles from your collection, full or empty, either by number or by naming a substance and an amount.";
+            Usage = "!pay [noparse][user]NameInUserTag[/user][/noparse] {amount} {currency}\nor\n!pay {currency}\nor\n!pay [noparse][user]NameInUserTag[/user][/noparse] {amount} bottles {substance}\nor\n!pay [noparse][user]NameInUserTag[/user][/noparse] bottles #12 #13";
+            RelatedCommands = new string[] { "bank", "work", "volunteer", "bottles" };
             CooldownDuration = null;
             CooldownAppliesTo = null;
             IdentifierCategory = "currency";
@@ -53,6 +53,14 @@ namespace FChatDicebot.BotCommands
             {
                 bot.SendPrivateMessage("You can't pay yourself. You can !volunteer and even !employ yourself or others, then !work for money.", characterName);
                 valid = false;
+            }
+            // Bottles are not a currency bucket, so they branch off before the currency-identifier
+            // lookup that would reject the keyword. Checked after the not-found/self-pay guards so
+            // those messages stay the same for both kinds of payment.
+            else if (BottlePayment.MentionsBottles(rawTerms))
+            {
+                RunBottlePayment(bot, commandController, rawTerms, address, characterName, recipient, initiatorProfile, recipientProfile, channel);
+                return;
             }
             else if (currency == null)
             {
@@ -145,6 +153,83 @@ namespace FChatDicebot.BotCommands
                     bot.SendMessageInChannel(message, channel);
                 }
             }
+        }
+
+        /// <summary>
+        /// Bottle-transfer variant of a payment. Resolves the request down to concrete serial
+        /// numbers up front and stores those on the pending command, so the consent-time recheck
+        /// asks an exact question ("does the payer still hold #142?") rather than re-running a
+        /// filter that could quietly select different bottles than the recipient agreed to.
+        /// </summary>
+        private void RunBottlePayment(
+            BotMain bot, BotCommandController commandController, string[] rawTerms, MessageAddress address,
+            string characterName, string recipient, Profile initiatorProfile, Profile recipientProfile, string channel)
+        {
+            string substanceFilter = commandController.GetIdentifierFromCommandTerms(rawTerms, "substance");
+            List<int> requestedSerials = BottlePayment.ParseSerials(rawTerms);
+
+            int amount = 1;
+            string[] rawInts = commandController.GetIntsFromCommandTermsAsStrings(rawTerms);
+            if (rawInts != null && rawInts.Length > 0)
+            {
+                if (!int.TryParse(rawInts[0], out amount))
+                {
+                    bot.SendPrivateMessage("The payment amount must be a valid whole number.", characterName);
+                    return;
+                }
+            }
+            else if (requestedSerials.Count > 0)
+            {
+                // Naming bottles by number states the count implicitly.
+                amount = requestedSerials.Count;
+            }
+
+            if (amount == 0)
+            {
+                bot.SendPrivateMessage("We won't waste our time with empty transfers. Name at least one bottle!", characterName);
+                return;
+            }
+
+            bool isGive = amount > 0;
+            Profile payerProfile = isGive ? initiatorProfile : recipientProfile;
+
+            var selection = BottlePayment.Select(payerProfile, requestedSerials, substanceFilter, Math.Abs(amount));
+            if (!selection.IsValid)
+            {
+                bot.SendPrivateMessage(
+                    isGive ? selection.PayerFacingError : selection.ThirdPartyError(recipientProfile.displayName),
+                    characterName);
+                return;
+            }
+
+            var processor = InteractionProcessors.InteractionProcessorRegistry.GetProcessor(
+                isGive ? "paymentGive" : "paymentReceive");
+
+            string describedGoods = BottlePayment.Describe(MonDB.GetDatabase(), selection.Bottles);
+            string message = processor.GetConsentWarning(initiatorProfile, recipientProfile, describedGoods);
+
+            Interaction payInteraction = new Interaction();
+            payInteraction.initiator = characterName;
+            payInteraction.recipient = recipient;
+            payInteraction.identifier = BottlePayment.BottleIdentifier;
+            payInteraction.type = isGive ? "paymentGive" : "paymentReceive";
+            payInteraction.investmentLevel = "involved";
+            payInteraction.interactionTime = DateTime.UtcNow;
+            payInteraction.extraParameters = new MongoDB.Bson.BsonArray { amount };
+            // The exact bottles promised, each carrying whether it was full at promise time.
+            // Everything after this point works from these, not from the filter that found them.
+            foreach (var bottle in selection.Bottles)
+            {
+                payInteraction.extraParameters.Add(BottlePayment.EncodePromise(bottle));
+            }
+
+            PendingCommand pendingPay = new PendingCommand();
+            pendingPay.pendingInteraction = payInteraction;
+            pendingPay.awaitingConsentFrom = recipient;
+
+            MonDB.addPendingCommand(pendingPay);
+
+            bot.SendMessageInChannel(message, channel);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauSell.cs
+++ b/FChatDicebot/BotCommands/ChateauSell.cs
@@ -31,9 +31,9 @@ namespace FChatDicebot.BotCommands
             Aliases = new string[] { };
             Category = "General";
             ShortDescription = "Sell bottled substances, obtained when you !milk others.";
-            LongDescription = "Sell bottled fluid from your personal inventory to the Chateau. Pricing depends on the substance's rarity and whether it is corrupt or pure. One empty bottle is returned per bottle sold. With no arguments, sells most recent bottle. With an amount, sells that many bottles in reverse of the order acquired, optionally filtered by substance and/or original source.";
+            LongDescription = "Sell bottled fluid from your personal collection to the Chateau. Pricing depends on the substance's rarity and whether it is corrupt or pure. The Chateau keeps the bottle, so its number leaves your collection for good, and one empty bottle is returned per bottle sold. With no arguments, sells your most recent bottle. With an amount, sells that many bottles in reverse of the order acquired, optionally filtered by substance and/or original source. Bottles you've already drunk stay with you and can't be sold.";
             Usage = "!sell\nor\n!sell {amount}\nor\n!sell {amount} {substance}\nor\n!sell {amount} {substance} [noparse][user]NameInUserTag[/user][/noparse]";
-            RelatedCommands = new string[] { "milk", "bank" };
+            RelatedCommands = new string[] { "milk", "bottles", "drink", "bank" };
             CooldownDuration = null;
             CooldownAppliesTo = null;
             IdentifierCategory = "substance";
@@ -53,9 +53,9 @@ namespace FChatDicebot.BotCommands
                 bot.SendPrivateMessage(ChateauInteractionHandler.notRegisteredText(), characterName);
                 return;
             }
-            if (profile.milkInventory == null || profile.milkInventory.Count == 0)
+            if (BottleInventory.SelectFull(profile, null, null).Count == 0)
             {
-                bot.SendPrivateMessage("You don't have any bottles in your inventory to sell.", characterName);
+                bot.SendPrivateMessage("You don't have any bottles in your collection to sell.", characterName);
                 return;
             }
 
@@ -87,7 +87,7 @@ namespace FChatDicebot.BotCommands
             if (sellResult.BottlesSold == 0)
             {
                 bot.SendPrivateMessage(
-                    "No bottles in your inventory matched that filter. Use !bank or your !dossier to review what you've got bottled up.",
+                    "No bottles in your collection matched that filter. Use !bottles to review what you've got bottled up.",
                     characterName);
                 return;
             }
@@ -122,6 +122,11 @@ namespace FChatDicebot.BotCommands
             // Distinct (substance, source) pairs touched, in sell order (newest first).
             // Used to build a readable summary line for the channel message.
             public List<SellLineItem> LineItems = new List<SellLineItem>();
+            /// <summary>
+            /// Serial numbers that left the collection, in sell order. Sold bottles go to the
+            /// Chateau outright, so these numbers are retired rather than kept as empties.
+            /// </summary>
+            public List<int> SoldSerials = new List<int>();
         }
 
         public class SellLineItem
@@ -148,12 +153,10 @@ namespace FChatDicebot.BotCommands
                 return result;
             }
 
-            // LIFO: newest first. We pull from the front of this ordering; entries are
-            // looked at one at a time and either consumed whole or partially.
-            var ordered = profile.milkInventory
-                .Where(b => MatchesFilters(b, substanceFilter, sourceFilter))
-                .OrderByDescending(b => b.milkedAt)
-                .ToList();
+            // Newest first, full bottles only — an empty has nothing the Chateau would pay for,
+            // and it's the resident's keepsake now. Shared with !drink/!bottles/!pay so the
+            // four commands can never disagree about what a filter means.
+            var ordered = BottleInventory.SelectFull(profile, substanceFilter, sourceFilter);
 
             // Index payout summary by (substance, source) so the result message can
             // collapse multiple sessions of the same kind into one line.
@@ -176,6 +179,7 @@ namespace FChatDicebot.BotCommands
                 result.BottlesSold += take;
                 result.PayoutCopper += payout;
                 result.BottlesReturned += take;
+                if (bottle.serial > 0) result.SoldSerials.Add(bottle.serial);
 
                 string key = (bottle.substance ?? "") + "|" + (bottle.sourceName ?? "");
                 if (!lineItems.TryGetValue(key, out var line))
@@ -209,21 +213,6 @@ namespace FChatDicebot.BotCommands
             return result;
         }
 
-        private static bool MatchesFilters(MilkBottle bottle, string substanceFilter, string sourceFilter)
-        {
-            if (!string.IsNullOrEmpty(substanceFilter)
-                && !string.Equals(bottle.substance, substanceFilter, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            if (!string.IsNullOrEmpty(sourceFilter)
-                && !string.Equals(bottle.sourceName, sourceFilter, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-            return true;
-        }
-
         private static string BuildResultMessage(string sellerDisplayName, SellResult result)
         {
             string lineSummary;
@@ -232,7 +221,7 @@ namespace FChatDicebot.BotCommands
                 var line = result.LineItems[0];
                 lineSummary = result.BottlesSold + " bottle" + (result.BottlesSold == 1 ? "" : "s")
                     + " of " + Utils.SubstanceToText(line.Substance)
-                    + " (sourced from " + (line.SourceName ?? "an unknown donor") + ")";
+                    + " (sourced from " + DonorText(line.SourceName) + ")";
             }
             else
             {
@@ -240,15 +229,29 @@ namespace FChatDicebot.BotCommands
                 foreach (var line in result.LineItems)
                 {
                     pieces.Add(line.Bottles + " of " + Utils.SubstanceToText(line.Substance)
-                        + " from " + (line.SourceName ?? "an unknown donor"));
+                        + " from " + DonorText(line.SourceName));
                 }
                 lineSummary = result.BottlesSold + " bottles ("
                     + string.Join(", ", pieces) + ")";
             }
 
-            return sellerDisplayName + " sold " + lineSummary + " for [b]" + result.PayoutCopper
+            string serials = BottleInventory.FormatSerials(result.SoldSerials, ChateauCurrency.BottleSerialDisplayCap);
+            string serialText = string.IsNullOrEmpty(serials) ? string.Empty : " (" + serials + ")";
+
+            return sellerDisplayName + " sold " + lineSummary + serialText + " for [b]" + result.PayoutCopper
                 + " " + ChateauCurrency.SellPayoutCurrency + "[/b]. Empty bottles returned: "
                 + result.BottlesReturned + ".";
+        }
+
+        /// <summary>
+        /// Donor names are stored as userNames and must be resolved before a resident reads them:
+        /// a userName survives renames as the raw handle, which is not what anyone should see.
+        /// </summary>
+        private static string DonorText(string sourceName)
+        {
+            if (string.IsNullOrEmpty(sourceName)) return "an unknown donor";
+            string displayName = MonDB.getDisplayName(sourceName);
+            return string.IsNullOrEmpty(displayName) ? sourceName : displayName;
         }
     }
 }

--- a/FChatDicebot/BottleInventory.cs
+++ b/FChatDicebot/BottleInventory.cs
@@ -1,0 +1,175 @@
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot
+{
+    /// <summary>
+    /// Shared selection and grouping over a Profile's <see cref="Profile.milkInventory"/>.
+    ///
+    /// <c>!sell</c>, <c>!drink</c>, <c>!bottles</c>, and bottle transfer through <c>!pay</c> all
+    /// need identical answers to "which bottles does this filter mean, and in what order", so
+    /// the rules live here once. The ordering contract is <b>newest first</b>: what the top of
+    /// <c>!bottles</c> shows is what an unfiltered <c>!sell</c> or <c>!drink</c> acts on next.
+    ///
+    /// Empties are excluded from every implicit selection. They are still in the collection and
+    /// still carry their serial, but they cannot be sold, cannot be drunk again, and only move
+    /// between residents when named by serial.
+    /// </summary>
+    public static class BottleInventory
+    {
+        /// <summary>
+        /// Full bottles matching the optional filters, newest first. Null/empty filters mean
+        /// "any". Never returns empties. Returns an empty list for a null profile or inventory
+        /// so callers can enumerate without null checks.
+        /// </summary>
+        public static List<MilkBottle> SelectFull(Profile profile, string substanceFilter, string sourceFilter)
+        {
+            if (profile?.milkInventory == null) return new List<MilkBottle>();
+            return profile.milkInventory
+                .Where(b => b != null && !b.IsEmpty && MatchesFilters(b, substanceFilter, sourceFilter))
+                .OrderByDescending(b => b.milkedAt)
+                .ThenByDescending(b => b.serial)
+                .ToList();
+        }
+
+        /// <summary>Emptied bottles matching the optional filters, newest-emptied first.</summary>
+        public static List<MilkBottle> SelectEmpty(Profile profile, string substanceFilter, string sourceFilter)
+        {
+            if (profile?.milkInventory == null) return new List<MilkBottle>();
+            return profile.milkInventory
+                .Where(b => b != null && b.IsEmpty && MatchesFilters(b, substanceFilter, sourceFilter))
+                .OrderByDescending(b => b.emptiedAt ?? b.milkedAt)
+                .ThenByDescending(b => b.serial)
+                .ToList();
+        }
+
+        /// <summary>
+        /// The bottle carrying this serial, full or empty, or null if the resident doesn't hold
+        /// it. Serial 0 never matches — it is the "predates the backfill" sentinel, not a
+        /// referenceable number.
+        /// </summary>
+        public static MilkBottle FindBySerial(Profile profile, int serial)
+        {
+            if (profile?.milkInventory == null || serial <= 0) return null;
+            return profile.milkInventory.FirstOrDefault(b => b != null && b.serial == serial);
+        }
+
+        /// <summary>True when the resident holds no bottles at all, full or empty.</summary>
+        public static bool IsCollectionEmpty(Profile profile)
+        {
+            return profile?.milkInventory == null || profile.milkInventory.Count == 0;
+        }
+
+        public static bool MatchesFilters(MilkBottle bottle, string substanceFilter, string sourceFilter)
+        {
+            if (bottle == null) return false;
+            if (!string.IsNullOrEmpty(substanceFilter)
+                && !string.Equals(bottle.substance, substanceFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            if (!string.IsNullOrEmpty(sourceFilter)
+                && !string.Equals(bottle.sourceName, sourceFilter, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// One display row: bottles sharing a substance, a donor, and a corruption tag, collapsed
+        /// together with their serials listed. Separate milkings of the same kind read as one
+        /// line, which is what keeps a large collection legible.
+        /// </summary>
+        public class BottleGroup
+        {
+            public string Substance;
+            public string SourceName;
+            public string CorruptionTag;
+            public List<int> Serials = new List<int>();
+            /// <summary>Newest milkedAt in the group, carrying the group's sort position.</summary>
+            public DateTime NewestAt;
+            public int Count => Serials.Count;
+        }
+
+        /// <summary>
+        /// Collapse an already-ordered bottle list into display groups, preserving the order the
+        /// bottles arrived in (so a newest-first input yields newest-first groups). Serials within
+        /// a group keep that same order.
+        /// </summary>
+        public static List<BottleGroup> Group(IEnumerable<MilkBottle> bottles)
+        {
+            var groups = new List<BottleGroup>();
+            var index = new Dictionary<string, BottleGroup>(StringComparer.Ordinal);
+            if (bottles == null) return groups;
+
+            foreach (var bottle in bottles)
+            {
+                if (bottle == null) continue;
+                string key = (bottle.substance ?? "") + "|" + (bottle.sourceName ?? "") + "|" + (bottle.corruptionTag ?? "");
+                if (!index.TryGetValue(key, out var group))
+                {
+                    group = new BottleGroup
+                    {
+                        Substance = bottle.substance,
+                        SourceName = bottle.sourceName,
+                        CorruptionTag = bottle.corruptionTag,
+                        NewestAt = bottle.milkedAt,
+                    };
+                    index[key] = group;
+                    groups.Add(group);
+                }
+                group.Serials.Add(bottle.serial);
+                if (bottle.milkedAt > group.NewestAt) group.NewestAt = bottle.milkedAt;
+            }
+            return groups;
+        }
+
+        /// <summary>
+        /// Render a group's serials as "#12, #40, #41", capped at
+        /// <see cref="ChateauCurrency.BottleSerialDisplayCap"/> with an "and N more" tail so one
+        /// prolific donor can't push the rest of the collection out of the message.
+        /// Serial 0 (pre-backfill) renders as "#?" rather than a misleading "#0".
+        /// </summary>
+        public static string FormatSerials(IEnumerable<int> serials, int cap)
+        {
+            if (serials == null) return string.Empty;
+            var all = serials.ToList();
+            if (all.Count == 0) return string.Empty;
+
+            var shown = all.Take(cap).Select(s => s > 0 ? "#" + s : "#?");
+            string text = string.Join(", ", shown);
+            int remaining = all.Count - cap;
+            if (remaining > 0)
+            {
+                text += ", and " + remaining + " more";
+            }
+            return text;
+        }
+
+        /// <summary>
+        /// Per-substance totals for the public dossier line, highest count first. Deliberately
+        /// drops donor names: the dossier is read by everyone, and who a resident has milked is
+        /// the donor's business.
+        /// </summary>
+        public static List<KeyValuePair<string, int>> CountsBySubstance(IEnumerable<MilkBottle> bottles)
+        {
+            var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            if (bottles != null)
+            {
+                foreach (var bottle in bottles)
+                {
+                    if (bottle == null || string.IsNullOrEmpty(bottle.substance)) continue;
+                    counts.TryGetValue(bottle.substance, out int current);
+                    counts[bottle.substance] = current + 1;
+                }
+            }
+            return counts
+                .OrderByDescending(kv => kv.Value)
+                .ThenBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+    }
+}

--- a/FChatDicebot/BottlePayment.cs
+++ b/FChatDicebot/BottlePayment.cs
@@ -1,0 +1,305 @@
+using FChatDicebot.BotCommands;
+using FChatDicebot.Database;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot
+{
+    /// <summary>
+    /// Parsing, selection, and wording shared by the bottle-transfer path of <c>!pay</c> and the
+    /// payment processors that complete it.
+    ///
+    /// Bottles are not a currency bucket, so they can't ride the atomic <c>$inc</c> the currency
+    /// path uses. What they get instead is exactness: a transfer is resolved to concrete serial
+    /// numbers when the command is typed, and those numbers are what the consent-time recheck
+    /// asks about. That closes the gap where a payer could promise three corrupt bottles, drink
+    /// them, and deliver three plain ones under the same filter.
+    /// </summary>
+    public static class BottlePayment
+    {
+        /// <summary>
+        /// Identifier stored on the interaction so the processors know a payment is bottles
+        /// rather than a currency name. Not a currency-category identifier, which is exactly why
+        /// the keyword was free to take.
+        /// </summary>
+        public const string BottleIdentifier = "bottles";
+
+        /// <summary>True when the terms name bottles rather than a currency.</summary>
+        public static bool MentionsBottles(string[] rawTerms)
+        {
+            if (rawTerms == null) return false;
+            return rawTerms.Any(t => !string.IsNullOrEmpty(t)
+                && (string.Equals(t, "bottles", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(t, "bottle", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        /// <summary>
+        /// Every <c>#142</c>-style bottle number in the terms, in the order given. The <c>#</c>
+        /// keeps serials distinguishable from the bare amount this command also accepts.
+        /// </summary>
+        public static List<int> ParseSerials(string[] rawTerms)
+        {
+            var serials = new List<int>();
+            if (rawTerms == null) return serials;
+            foreach (string term in rawTerms)
+            {
+                if (string.IsNullOrEmpty(term) || term[0] != '#') continue;
+                if (int.TryParse(term.Substring(1), out int parsed) && parsed > 0 && !serials.Contains(parsed))
+                {
+                    serials.Add(parsed);
+                }
+            }
+            return serials;
+        }
+
+        public class Selection
+        {
+            public List<MilkBottle> Bottles = new List<MilkBottle>();
+            public bool IsValid => Bottles.Count > 0 && string.IsNullOrEmpty(_error);
+            private string _error;
+
+            /// <summary>Message for the resident who typed the command, when they are the payer.</summary>
+            public string PayerFacingError => _error;
+
+            /// <summary>
+            /// Same refusal, reworded for a bill: the person typing isn't the one whose collection
+            /// came up short.
+            /// </summary>
+            public string ThirdPartyError(string payerDisplayName)
+            {
+                if (string.IsNullOrEmpty(_error)) return string.Empty;
+                return payerDisplayName + " doesn't have the bottles for that. They can use !bottles to see what they're holding.";
+            }
+
+            public static Selection Failed(string error)
+            {
+                return new Selection { _error = error };
+            }
+
+            public static Selection Of(List<MilkBottle> bottles)
+            {
+                return new Selection { Bottles = bottles };
+            }
+        }
+
+        /// <summary>
+        /// Resolve a request into the exact bottles that will move.
+        ///
+        /// Named serials transfer whatever they name, full or empty — a numbered empty is a
+        /// keepsake worth handing over. An amount with no serials means full bottles only:
+        /// someone asking for "3 bottles" means three with something in them, and the friction of
+        /// naming a number is the right price for moving a collectible.
+        /// </summary>
+        public static Selection Select(Profile payerProfile, List<int> requestedSerials, string substanceFilter, int amount)
+        {
+            if (payerProfile == null) return Selection.Failed(NotEnoughText);
+
+            if (requestedSerials != null && requestedSerials.Count > 0)
+            {
+                var named = new List<MilkBottle>();
+                foreach (int serial in requestedSerials)
+                {
+                    MilkBottle bottle = BottleInventory.FindBySerial(payerProfile, serial);
+                    if (bottle == null)
+                    {
+                        return Selection.Failed("Bottle [b]#" + serial + "[/b] isn't in your collection."
+                            + " Use !bottles to check your numbers.");
+                    }
+                    named.Add(bottle);
+                }
+                return Selection.Of(named);
+            }
+
+            var candidates = BottleInventory.SelectFull(payerProfile, substanceFilter, null);
+            if (candidates.Count < amount)
+            {
+                return Selection.Failed(NotEnoughText);
+            }
+            return Selection.Of(candidates.Take(amount).ToList());
+        }
+
+        public const string NotEnoughText =
+            "You don't have that many bottles to hand over. Use !bottles to see what you're holding.";
+
+        /// <summary>
+        /// How a promised bottle is written into the pending command's extra parameters: the
+        /// serial, negated if the bottle was empty when promised. Carrying the state alongside
+        /// the number is what lets the consent-time recheck notice that a promised-full bottle
+        /// has since been drunk, rather than handing over an empty nobody agreed to.
+        /// </summary>
+        public static int EncodePromise(MilkBottle bottle)
+        {
+            return bottle.IsEmpty ? -bottle.serial : bottle.serial;
+        }
+
+        /// <summary>
+        /// Bottles promised by a pending payment, as (serial, wasEmpty) pairs. The first extra
+        /// parameter is the signed amount (shared with the currency path); everything after it is
+        /// an encoded promise.
+        /// </summary>
+        public static List<KeyValuePair<int, bool>> ReadPromises(Interaction interaction)
+        {
+            var promises = new List<KeyValuePair<int, bool>>();
+            if (interaction?.extraParameters == null) return promises;
+            for (int i = 1; i < interaction.extraParameters.Count; i++)
+            {
+                int encoded = interaction.extraParameters[i].ToInt32();
+                promises.Add(new KeyValuePair<int, bool>(Math.Abs(encoded), encoded < 0));
+            }
+            return promises;
+        }
+
+        public static bool IsBottlePayment(Interaction interaction)
+        {
+            return interaction != null && IsBottlePayment(interaction.identifier);
+        }
+
+        /// <summary>
+        /// True when a payment's stored identifier is the bottle keyword rather than a currency
+        /// name. This is what the completion messages branch on.
+        /// </summary>
+        public static bool IsBottlePayment(string identifier)
+        {
+            return string.Equals(identifier, BottleIdentifier, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// True when the string handed to a consent warning is a rendered bottle summary from
+        /// <see cref="Describe"/> rather than the currency path's "{amount} {currency}".
+        ///
+        /// The consent slot carries one string and the two paths put different things in it, so
+        /// this has to read the shape. It's unambiguous in practice: <see cref="Describe"/> always
+        /// opens with a bolded bottle count, and a currency description is bare text with no
+        /// BBCode at all (see ChateauPay.Run's <c>amountAndCurrency</c>).
+        /// </summary>
+        public static bool DescribesBottles(string described)
+        {
+            return !string.IsNullOrEmpty(described)
+                && described.StartsWith("[b]", StringComparison.Ordinal)
+                && described.IndexOf(" bottle", StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        /// <summary>
+        /// Move the promised bottles from payer to payee, or report why not.
+        ///
+        /// Every promised serial must still be in the payer's collection <i>in the state the
+        /// recipient agreed to</i>. A bottle drunk during the consent gap is still there under the
+        /// same number, but it's an empty now, and nobody consented to an empty — that's a
+        /// mismatch, not a substitution, so the whole transfer aborts rather than silently
+        /// downgrading.
+        /// </summary>
+        public static bool TryTransfer(
+            IChateauDatabase database, string payerUserName, string payeeUserName,
+            List<KeyValuePair<int, bool>> promises, out string failureMessage)
+        {
+            failureMessage = null;
+            Profile payer = database.GetProfile(payerUserName);
+            Profile payee = database.GetProfile(payeeUserName);
+            if (payer == null || payee == null)
+            {
+                failureMessage = "We couldn't find both parties in our records, so nothing changed hands.";
+                return false;
+            }
+            if (promises == null || promises.Count == 0)
+            {
+                failureMessage = GoneMessage(database, payerUserName);
+                return false;
+            }
+
+            var moving = new List<MilkBottle>();
+            foreach (var promise in promises)
+            {
+                MilkBottle bottle = BottleInventory.FindBySerial(payer, promise.Key);
+                if (bottle == null || bottle.IsEmpty != promise.Value)
+                {
+                    failureMessage = GoneMessage(database, payerUserName);
+                    return false;
+                }
+                moving.Add(bottle);
+            }
+
+            if (payee.milkInventory == null) payee.milkInventory = new List<MilkBottle>();
+            foreach (var bottle in moving)
+            {
+                payer.milkInventory.Remove(bottle);
+                // Serial, donor, timestamp, tag and empty-state all travel untouched. Provenance
+                // surviving the handoff is the point: a bottle from a corrupt donor still corrupts
+                // whoever drinks it three owners later, and still answers to the same number.
+                payee.milkInventory.Add(bottle);
+            }
+
+            database.SetMilkInventory(payerUserName, payer.milkInventory);
+            database.SetMilkInventory(payeeUserName, payee.milkInventory);
+            return true;
+        }
+
+        private static string GoneMessage(IChateauDatabase database, string payerUserName)
+        {
+            string payerName = database?.GetDisplayName(payerUserName);
+            if (string.IsNullOrEmpty(payerName)) payerName = payerUserName;
+            return payerName + " doesn't have those bottles anymore. It seems they were sold or enjoyed"
+                + " while we waited on an answer... nothing changed hands.";
+        }
+
+        /// <summary>
+        /// Player-facing summary of what is changing hands, for the consent prompt. Names the
+        /// substance, the donor, and any corruption tag, because a recipient deserves to know
+        /// they're being handed corrupt goods before they agree to take them.
+        /// </summary>
+        public static string Describe(IChateauDatabase database, List<MilkBottle> bottles)
+        {
+            if (bottles == null || bottles.Count == 0) return "nothing at all";
+
+            var pieces = new List<string>();
+            foreach (var group in BottleInventory.Group(bottles))
+            {
+                string piece = CountWord(group.Count) + " of the "
+                    + Utils.SubstanceToText(group.Substance)
+                    + " from " + ChateauBottles.DonorText(database, group.SourceName);
+
+                if (group.CorruptionTag == ChateauCurrency.CorruptTag) piece += " ([b]corrupt[/b])";
+                else if (group.CorruptionTag == ChateauCurrency.PurifiedTag) piece += " ([b]pure[/b])";
+
+                pieces.Add(piece);
+            }
+
+            string bottleWord = bottles.Count == 1 ? "bottle" : "bottles";
+            string described = "[b]" + bottles.Count + " " + bottleWord + "[/b]: " + JoinWithAnd(pieces);
+
+            // Whether the contents are still in there is the single most important thing the
+            // recipient needs to know before agreeing, so it goes on the whole parcel rather than
+            // per line. Mixed parcels say so instead of implying either.
+            int emptyCount = bottles.Count(b => b.IsEmpty);
+            if (emptyCount == bottles.Count)
+            {
+                described += " [sub](already emptied)[/sub]";
+            }
+            else if (emptyCount > 0)
+            {
+                described += " [sub](" + emptyCount + " of them already emptied)[/sub]";
+            }
+            return described;
+        }
+
+        private static string CountWord(int count)
+        {
+            switch (count)
+            {
+                case 1: return "one";
+                case 2: return "two";
+                case 3: return "three";
+                default: return count.ToString();
+            }
+        }
+
+        private static string JoinWithAnd(List<string> pieces)
+        {
+            if (pieces.Count == 0) return string.Empty;
+            if (pieces.Count == 1) return pieces[0];
+            if (pieces.Count == 2) return pieces[0] + " and " + pieces[1];
+            return string.Join(", ", pieces.Take(pieces.Count - 1)) + ", and " + pieces[pieces.Count - 1];
+        }
+    }
+}

--- a/FChatDicebot/ChateauCurrency.cs
+++ b/FChatDicebot/ChateauCurrency.cs
@@ -43,6 +43,34 @@ namespace FChatDicebot
         public const int MilkRollMax = 3;
 
         // -----------------------------------------------------------------------
+        // !drink
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Corruption moved onto the drinker per tagged bottle: a "corrupt" bottle shifts them
+        /// this far toward corruption, a "purified" one this far toward purity. Untagged
+        /// bottles move nothing.
+        /// </summary>
+        public const int DrinkCorruptionShiftPerBottle = 1;
+
+        /// <summary>
+        /// How much corruption a resident can absorb by drinking in one Chateau day. Tracked
+        /// under its own <c>drinkshift_</c> key so it never draws from the per-pair
+        /// <c>!corrupt</c> quota. This is the load-bearing balance lever: bottles can be pooled
+        /// through <c>!pay</c>, so supply scarcity alone would not bound the drift.
+        /// </summary>
+        public const int DrinkCorruptionDailyLimit = 3;
+
+        /// <summary>
+        /// Chance that drinking a substance deepens an addiction the drinker already carries.
+        /// Intensify-only — a first bottle can never hook a clean resident.
+        /// </summary>
+        public const double DrinkAddictionChance = 0.10;
+
+        /// <summary>Serial numbers listed per group in <c>!bottles</c> before the "and N more" tail.</summary>
+        public const int BottleSerialDisplayCap = 8;
+
+        // -----------------------------------------------------------------------
         // Corruption tag thresholds (applied at milking time)
         // -----------------------------------------------------------------------
 

--- a/FChatDicebot/Database/Chateaudatabase.cs
+++ b/FChatDicebot/Database/Chateaudatabase.cs
@@ -332,6 +332,32 @@ namespace FChatDicebot.Database
             collection.ReplaceOne(filter, document);
         }
 
+        /// <summary>
+        /// Server-side atomic $inc against a single counter document, returning the post-increment
+        /// value. Reserving the whole block in one round-trip (rather than N single increments) is
+        /// what makes a 3-bottle milking cheap and keeps the claimed serials contiguous. IsUpsert
+        /// seeds the counter on first use, so no migration step is needed to create it.
+        /// </summary>
+        public int ClaimBottleSerials(int count)
+        {
+            if (count <= 0) return 0;
+            var collection = Database.GetCollection<BsonDocument>("Counters");
+            var filter = Builders<BsonDocument>.Filter.Eq("_id", BottleSerialCounterId);
+            var update = Builders<BsonDocument>.Update.Inc("value", count);
+            var options = new FindOneAndUpdateOptions<BsonDocument>
+            {
+                IsUpsert = true,
+                ReturnDocument = ReturnDocument.After,
+            };
+            var result = collection.FindOneAndUpdate(filter, update, options);
+            int lastClaimed = result["value"].ToInt32();
+            // $inc returns the LAST number in the block; callers want the first.
+            return lastClaimed - count + 1;
+        }
+
+        /// <summary>Counter document key backing <see cref="ClaimBottleSerials"/>.</summary>
+        public const string BottleSerialCounterId = "bottleSerial";
+
         public void ChangeCurrency(string userName, string currencyLabel, int changeAmount)
         {
             // Server-side atomic $inc (not a read-modify-write ReplaceOne). This matters for the

--- a/FChatDicebot/Database/Ichateaudatabase.cs
+++ b/FChatDicebot/Database/Ichateaudatabase.cs
@@ -35,6 +35,15 @@ namespace FChatDicebot.Database
         /// caller's own GetProfile.
         /// </summary>
         void SetMilkInventory(string userName, List<MilkBottle> inventory);
+
+        /// <summary>
+        /// Atomically reserve a block of <paramref name="count"/> consecutive bottle serial
+        /// numbers and return the first one. A milking that produces three bottles makes one
+        /// call and takes the returned value, +1, +2. Serials are globally unique and never
+        /// reused, so two simultaneous milkings can never collide on a number.
+        /// </summary>
+        int ClaimBottleSerials(int count);
+
         void ChangeCurrency(string userName, string currencyLabel, int changeAmount);
 
         /// <summary>

--- a/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs
@@ -7,8 +7,9 @@ using System.Linq;
 namespace FChatDicebot.InteractionProcessors.Involved
 {
     /// <summary>
-    /// Processor for <c>!milk</c>. Produces 1–3 tagged bottles (rolled at process time)
-    /// in the initiator's <see cref="Profile.milkInventory"/> and applies a 24-hour daily
+    /// Processor for <c>!milk</c>. Produces 1–3 tagged bottles (rolled at process time), each a
+    /// separate serial-numbered entry in the initiator's <see cref="Profile.milkInventory"/>,
+    /// and applies a 24-hour daily
     /// per-direction lock so a given milker can only milk a given resident once per
     /// Chateau day, regardless of substance. The lock is directional: it does not stop
     /// the recipient from milking the initiator back the same day. The Chateau provides
@@ -227,19 +228,29 @@ namespace FChatDicebot.InteractionProcessors.Involved
                 string corruptionTag = ChateauCurrency.GetCorruptionTagForValue(
                     Commitment.CorruptionProcessor.ReadCorruption(recipientProfile));
 
-                var bottle = new MilkBottle
-                {
-                    substance = substance,
-                    sourceName = recipient,
-                    milkedAt = DateTime.UtcNow,
-                    quantity = produced,
-                    corruptionTag = corruptionTag,
-                };
                 if (initiatorProfile.milkInventory == null)
                 {
                     initiatorProfile.milkInventory = new List<MilkBottle>();
                 }
-                initiatorProfile.milkInventory.Add(bottle);
+
+                // One entry per physical bottle, each with its own serial, rather than a single
+                // entry carrying a count. A serial names one bottle, so an aggregated entry has
+                // nothing to name. The whole block is reserved in one call so the numbers stay
+                // contiguous and a concurrent milking can't interleave into the middle of them.
+                DateTime milkedAt = DateTime.UtcNow;
+                int firstSerial = Database.ClaimBottleSerials(produced);
+                for (int i = 0; i < produced; i++)
+                {
+                    initiatorProfile.milkInventory.Add(new MilkBottle
+                    {
+                        serial = firstSerial + i,
+                        substance = substance,
+                        sourceName = recipient,
+                        milkedAt = milkedAt,
+                        quantity = 1,
+                        corruptionTag = corruptionTag,
+                    });
+                }
 
                 // Per-direction 24h lock — until the *next* day-boundary regardless of
                 // time-of-day. Stamped on the milker only and scoped to the milked

--- a/FChatDicebot/InteractionProcessors/Involved/PaymentGiveProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/PaymentGiveProcessor.cs
@@ -38,12 +38,22 @@ namespace FChatDicebot.InteractionProcessors.Involved
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
+            if (BottlePayment.IsBottlePayment(identifier))
+            {
+                return $"{initiatorProfile.displayName} hands the bottles over to {recipientProfile.displayName}. Is that a vintage?";
+            }
             return $"{initiatorProfile.displayName} hands over some {identifier} to {recipientProfile.displayName}. Transaction complete!";
         }
 
         protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            // identifier is "{amount} {currency}" (e.g. "100 gold") — see ChateauPay.Run.
+            // identifier is "{amount} {currency}" (e.g. "100 gold") for a currency payment, or the
+            // rendered bottle summary from BottlePayment.Describe for a bottle transfer — see
+            // ChateauPay.Run / ChateauPay.RunBottlePayment.
+            if (BottlePayment.DescribesBottles(identifier))
+            {
+                return $"{initiatorProfile.displayName} is going to pass {recipientProfile.displayName} {identifier}! Do you !consent to receiving them?";
+            }
             return $"{initiatorProfile.displayName} is going to pay {recipientProfile.displayName} {identifier}! Do you !consent to this transaction?";
         }
     }

--- a/FChatDicebot/InteractionProcessors/Involved/PaymentProcessorBase.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/PaymentProcessorBase.cs
@@ -65,6 +65,24 @@ namespace FChatDicebot.InteractionProcessors.Involved
             string payer = IsGive ? initiator : recipient;
             string payee = IsGive ? recipient : initiator;
 
+            // Bottles aren't a currency bucket, so they move as objects rather than through the
+            // atomic $inc below. What they get instead is exactness: the promised serials are
+            // re-checked against the payer's collection, in the state the recipient agreed to.
+            if (BottlePayment.IsBottlePayment(command.pendingInteraction))
+            {
+                var promises = BottlePayment.ReadPromises(command.pendingInteraction);
+                if (!BottlePayment.TryTransfer(Database, payer, payee, promises, out string bottleFailure))
+                {
+                    _lastInitiatorPrivateMessage = bottleFailure;
+                    Database.DeletePendingCommand(command.Id);
+                    return "NoInteraction";
+                }
+
+                Database.AddInteraction(command.pendingInteraction);
+                Database.DeletePendingCommand(command.Id);
+                return InteractionType;
+            }
+
             // Debit is atomic and guarded (>= magnitude unless the currency allows negative
             // balances), so this can never mint currency on self-pay (initiator == recipient
             // nets the same $inc twice back to zero) and never overdraws a currency that

--- a/FChatDicebot/InteractionProcessors/Involved/PaymentReceiveProcessor.cs
+++ b/FChatDicebot/InteractionProcessors/Involved/PaymentReceiveProcessor.cs
@@ -38,12 +38,22 @@ namespace FChatDicebot.InteractionProcessors.Involved
 
         public override string GetCompletionMessage(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
+            if (BottlePayment.IsBottlePayment(identifier))
+            {
+                return $"{initiatorProfile.displayName} accepts the bottles from {recipientProfile.displayName}. Is that a vintage?";
+            }
             return $"{recipientProfile.displayName} pays {identifier} to {initiatorProfile.displayName}. Transaction complete!";
         }
 
         protected override string BuildConsentWarning(Profile initiatorProfile, Profile recipientProfile, string identifier)
         {
-            // identifier is "{amount} {currency}" (e.g. "100 gold") — see ChateauPay.Run.
+            // identifier is "{amount} {currency}" (e.g. "100 gold") for a currency payment, or the
+            // rendered bottle summary from BottlePayment.Describe for a bottle transfer — see
+            // ChateauPay.Run / ChateauPay.RunBottlePayment.
+            if (BottlePayment.DescribesBottles(identifier))
+            {
+                return $"{initiatorProfile.displayName} is asking {recipientProfile.displayName} for {identifier}! Do you !consent to handing them over?";
+            }
             return $"{initiatorProfile.displayName} is requesting {recipientProfile.displayName} pay them {identifier}! Do you !consent to this transaction?";
         }
     }

--- a/FChatDicebot/InteractionProcessors/SelfCommandStatusEffects.cs
+++ b/FChatDicebot/InteractionProcessors/SelfCommandStatusEffects.cs
@@ -1,0 +1,56 @@
+using FChatDicebot.Model;
+using System;
+
+namespace FChatDicebot.InteractionProcessors
+{
+    /// <summary>
+    /// Runs the registered status-effect contributors for a command that has no second party
+    /// and therefore no consent flow to hang them off.
+    ///
+    /// Status effects normally fire from <see cref="InteractionProcessorBase"/> at the
+    /// completion of something a recipient consented to; system commands deliberately skip the
+    /// hook. <c>!drink</c> is the exception the convention allows for: the drinker is consenting
+    /// with themselves, and its effects (a satisfied craving, a corruption drift) are things the
+    /// channel is supposed to witness. This is the public seam that lets such a command invoke
+    /// the same contributors against a single subject.
+    ///
+    /// <c>!detox</c> and <c>!wash</c> are the obvious future callers.
+    /// </summary>
+    public static class SelfCommandStatusEffects
+    {
+        /// <summary>
+        /// Completion-time fragments for <paramref name="subject"/> acting on themselves.
+        /// Contributors are invoked with <c>isInitiator: true</c> — there is only one party, and
+        /// they are the one doing it.
+        ///
+        /// A contributor that throws is skipped rather than allowed to break the command, the
+        /// same contract <see cref="InteractionProcessorBase"/> applies.
+        /// </summary>
+        public static StatusEffectFragments GetCompletionFragments(
+            Profile subject, string interactionType, string parentIdentifier)
+        {
+            var merged = new StatusEffectFragments();
+            if (subject == null) return merged;
+
+            foreach (var contributor in StatusEffectRegistry.GetAllContributors())
+            {
+                StatusEffectFragments contributed;
+                try
+                {
+                    contributed = contributor.Contribute(
+                        subject,
+                        StatusEffectCallSite.Completion,
+                        interactionType,
+                        parentIdentifier ?? string.Empty,
+                        isInitiator: true);
+                }
+                catch (Exception)
+                {
+                    continue;
+                }
+                merged.MergeWith(contributed);
+            }
+            return merged;
+        }
+    }
+}

--- a/FChatDicebot/InteractionProcessors/StatusEffectContributors/DoseStatusContributor.cs
+++ b/FChatDicebot/InteractionProcessors/StatusEffectContributors/DoseStatusContributor.cs
@@ -113,6 +113,8 @@ namespace FChatDicebot.InteractionProcessors.StatusEffectContributors
         /// <item><description><c>!feed</c> where the substance identifier == vice name.</description></item>
         /// <item><description><c>!odorize</c> where the scent identifier == vice name.</description></item>
         /// <item><description><c>!dose</c> where the vice identifier == vice name (the escalating dose itself).</description></item>
+        /// <item><description><c>!drink</c> where the bottle's substance == vice name — the only
+        /// satisfaction route that doesn't need a second consenting resident.</description></item>
         /// </list>
         /// All comparisons are case-insensitive. Climax interactions intentionally don't
         /// match — they dose the partner instead of satisfying anyone.
@@ -125,7 +127,15 @@ namespace FChatDicebot.InteractionProcessors.StatusEffectContributors
             if (string.Equals(parentInteractionType, "feed", StringComparison.OrdinalIgnoreCase)) return true;
             if (string.Equals(parentInteractionType, "odorize", StringComparison.OrdinalIgnoreCase)) return true;
             if (string.Equals(parentInteractionType, DoseProcessor.DoseType, StringComparison.OrdinalIgnoreCase)) return true;
+            if (string.Equals(parentInteractionType, DrinkType, StringComparison.OrdinalIgnoreCase)) return true;
             return false;
         }
+
+        /// <summary>
+        /// Interaction-type key <c>!drink</c> passes when it invokes the contributors through
+        /// <see cref="SelfCommandStatusEffects"/>. Lives here rather than on the command so the
+        /// satisfaction rule and its trigger can't drift apart.
+        /// </summary>
+        public const string DrinkType = "drink";
     }
 }

--- a/FChatDicebot/Model/MilkBottle.cs
+++ b/FChatDicebot/Model/MilkBottle.cs
@@ -4,32 +4,68 @@ using System;
 namespace FChatDicebot.Model
 {
     /// <summary>
-    /// One milking session's worth of bottled fluid sitting in a Profile's milkInventory.
-    /// Stored per-milking (not aggregated) so different sessions of the same
-    /// (substance, sourceName) keep their distinct milkedAt timestamps and corruption tags
-    /// for display and FIFO sell ordering.
+    /// One physical bottle sitting in a Profile's milkInventory, identified for life by its
+    /// <see cref="serial"/>.
+    ///
+    /// Historically one entry represented a whole milking session and could carry
+    /// <c>quantity &gt; 1</c>. Serial numbers identify a single bottle, so a milking that rolls
+    /// 3 now writes three entries with three consecutive serials. <see cref="quantity"/> is
+    /// retained so pre-serial documents still deserialize; nothing written since the serial
+    /// migration ever sets it above 1.
+    ///
+    /// Drinking does not delete the bottle. It stamps <see cref="emptiedAt"/> and the empty
+    /// stays in the collection under the same serial, keeping the substance, donor, and
+    /// corruption tag it always had. Selling to the Chateau is what actually removes a bottle
+    /// (the Chateau keeps it), which is what makes !sell and !drink a real choice rather than
+    /// two spellings of the same thing.
     /// </summary>
     public class MilkBottle
     {
+        /// <summary>
+        /// Globally unique bottle number, issued from the shared counter at milking time and
+        /// never reused. Zero only on documents predating the serial backfill.
+        /// </summary>
+        public int serial { get; set; }
+
         /// <summary>Identifier name from the substance/vice catalog (e.g. "cum", "milk").</summary>
         public string substance { get; set; }
 
-        /// <summary>Recipient's userName at the time of milking. Frozen — does not follow renames.</summary>
+        /// <summary>
+        /// Donor's userName at the time of milking. Frozen — does not follow renames, so it
+        /// must be resolved through <c>GetDisplayName</c> before reaching any player-facing
+        /// string.
+        /// </summary>
         public string sourceName { get; set; }
 
-        /// <summary>When the milking happened. Used for FIFO sell ordering and tiebreakers.</summary>
+        /// <summary>When the milking happened. Used for newest-first ordering and tiebreakers.</summary>
         public DateTime milkedAt { get; set; }
 
-        /// <summary>How many bottles this milking session produced. Always &gt;= 1.</summary>
+        /// <summary>
+        /// Legacy per-session bottle count. Always 1 for anything created since serials landed;
+        /// kept so a pre-migration document with an aggregated count still deserializes.
+        /// </summary>
         public int quantity { get; set; }
 
         /// <summary>
-        /// Optional flavor tag derived from the recipient's corruption value at milking time:
+        /// Optional flavor tag derived from the donor's corruption value at milking time:
         /// "corrupt" (corruption &lt;= -CorruptionTagThreshold), "purified" (&gt;= +threshold),
         /// or null in the neutral band. Drives sell-price multipliers in
-        /// <see cref="ChateauCurrency"/>.
+        /// <see cref="ChateauCurrency"/> and the corruption shift applied by <c>!drink</c>.
         /// </summary>
         [BsonIgnoreIfNull]
         public string corruptionTag { get; set; }
+
+        /// <summary>
+        /// Null while the bottle still has something in it; stamped when it is drunk. The
+        /// bottle stays in the collection either way, so this doubles as the full/empty flag
+        /// and as a record of when the contents were enjoyed.
+        /// </summary>
+        [BsonIgnoreIfNull]
+        public DateTime? emptiedAt { get; set; }
+
+        /// <summary>True once the contents have been drunk. Empties are never sellable, never
+        /// implicitly selected by !drink, and only transfer by explicit serial.</summary>
+        [BsonIgnore]
+        public bool IsEmpty => emptiedAt.HasValue;
     }
 }

--- a/scripts/backfill-bottle-serials.js
+++ b/scripts/backfill-bottle-serials.js
@@ -1,0 +1,191 @@
+/*
+ * Backfill bottle serial numbers onto every existing MilkBottle, and split the pre-serial
+ * aggregated entries into one entry per physical bottle.
+ *
+ * Run with mongosh from the repo root:
+ *   mongosh "mongodb://localhost:27017" scripts/backfill-bottle-serials.js
+ *
+ * On Windows cmd.exe, single quotes are not string delimiters — quote paths with DOUBLE
+ * quotes or leave an unspaced path bare, or mongosh will look for a file named with the
+ * quotes included.
+ *
+ * (Review the DRY RUN output before setting DRY_RUN = false.)
+ *
+ * ── Why this is needed ────────────────────────────────────────────────────────
+ *   A serial identifies ONE bottle, so an entry with quantity > 1 has nothing to name.
+ *   Before serials, a milking that rolled 3 wrote a single entry with quantity: 3. This
+ *   splits those into three entries and numbers each one.
+ *
+ *   Bottles left un-numbered would render as "#?" and be unreachable by "!drink #142"
+ *   and "!pay ... bottle #142", so this MUST run before or with the deploy that ships
+ *   those commands.
+ *
+ * ── Assignment order ─────────────────────────────────────────────────────────
+ *   All bottles across ALL profiles are sorted by milkedAt ascending and numbered from 1.
+ *   Chronological across the whole Chateau is deliberate: it makes a low serial genuinely
+ *   mean "one of the oldest bottles in the building", which is the property that makes
+ *   the number worth showing to players at all.
+ *
+ *   Ties on milkedAt break by userName then substance, purely so a re-run is deterministic.
+ *
+ * ── emptiedAt ────────────────────────────────────────────────────────────────
+ *   Left unset on everything. Bottles drunk or sold before this ships weren't recorded,
+ *   and inventing empties for them would be fiction.
+ *
+ * ── Safety ───────────────────────────────────────────────────────────────────
+ *   - DRY_RUN = true by default: prints what it would do and writes NOTHING.
+ *   - Refuses to run if any bottle already carries a serial, because a second run would
+ *     renumber bottles residents have already seen and referred to. Delete the counter
+ *     and clear the serials first if you genuinely need to redo it.
+ *   - Sets the Counters/bottleSerial document to the highest number assigned, so live
+ *     milkings continue from there rather than colliding with backfilled numbers.
+ */
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+// Matches MonDB.Initialize in BotMain.cs. Change only if the bot is pointed elsewhere.
+const DB_NAME = "ChateauDb";
+// Applied to the live ChateauDb on 2026-07-29 (35 bottles, serials #1-#35). Left at true so
+// a stray re-run reports rather than writes; the already-numbered guard below would stop it
+// regardless.
+const DRY_RUN = true;        // <-- set to false to actually write
+// ──────────────────────────────────────────────────────────────────────────────
+
+const targetDb = db.getSiblingDB(DB_NAME);
+const PROFILES = "RegisteredProfiles";
+const COUNTERS = "Counters";
+const COUNTER_ID = "bottleSerial";
+
+print("");
+print("=== Bottle serial backfill" + (DRY_RUN ? " (DRY RUN)" : "") + " ===");
+print("database: " + DB_NAME);
+print("");
+
+// ── Sanity-check the target ───────────────────────────────────────────────────
+// A wrong DB_NAME would otherwise look exactly like success: mongo happily reads from a
+// database that doesn't exist, finds no bottles, and reports "nothing to do" while the
+// real data sits untouched somewhere else.
+const totalProfiles = targetDb.getCollection(PROFILES).countDocuments({});
+if (totalProfiles === 0) {
+    print("ABORTING: database '" + DB_NAME + "' has no " + PROFILES + " documents.");
+    print("That almost certainly means DB_NAME is wrong. Databases on this server:");
+    db.adminCommand({ listDatabases: 1 }).databases.forEach(function (d) {
+        print("  " + d.name);
+    });
+    quit(1);
+}
+print("residents on file: " + totalProfiles);
+
+// ── Collect every bottle in the Chateau ───────────────────────────────────────
+const profiles = targetDb
+    .getCollection(PROFILES)
+    .find({ milkInventory: { $exists: true, $ne: [] } })
+    .toArray();
+
+let alreadyNumbered = 0;
+const flattened = [];
+
+profiles.forEach(function (profile) {
+    (profile.milkInventory || []).forEach(function (bottle, index) {
+        if (bottle.serial && bottle.serial > 0) {
+            alreadyNumbered++;
+        }
+        // An entry of quantity N becomes N bottles. Anything missing or below 1 counts
+        // as a single bottle rather than vanishing.
+        const count = bottle.quantity && bottle.quantity > 1 ? bottle.quantity : 1;
+        for (let i = 0; i < count; i++) {
+            flattened.push({
+                userName: profile.userName,
+                entryIndex: index,
+                milkedAt: bottle.milkedAt,
+                substance: bottle.substance,
+                sourceName: bottle.sourceName,
+                corruptionTag: bottle.corruptionTag,
+            });
+        }
+    });
+});
+
+if (alreadyNumbered > 0) {
+    print("ABORTING: " + alreadyNumbered + " bottle(s) already carry a serial.");
+    print("Re-running would renumber bottles residents have already seen and referred to.");
+    print("If you really mean to redo this, clear the serials and the Counters/" + COUNTER_ID + " document first.");
+    quit(1);
+}
+
+if (flattened.length === 0) {
+    print("No bottles found. Nothing to do.");
+    print("Seeding the counter at 0 so live milkings start from #1.");
+    if (!DRY_RUN) {
+        targetDb.getCollection(COUNTERS).updateOne(
+            { _id: COUNTER_ID },
+            { $set: { value: 0 } },
+            { upsert: true }
+        );
+    }
+    quit(0);
+}
+
+// ── Number them oldest first, Chateau-wide ────────────────────────────────────
+flattened.sort(function (a, b) {
+    const aTime = a.milkedAt ? a.milkedAt.getTime() : 0;
+    const bTime = b.milkedAt ? b.milkedAt.getTime() : 0;
+    if (aTime !== bTime) return aTime - bTime;
+    if (a.userName !== b.userName) return a.userName < b.userName ? -1 : 1;
+    if (a.substance !== b.substance) return (a.substance || "") < (b.substance || "") ? -1 : 1;
+    return a.entryIndex - b.entryIndex;
+});
+
+const rebuilt = {};
+flattened.forEach(function (bottle, i) {
+    if (!rebuilt[bottle.userName]) rebuilt[bottle.userName] = [];
+    const entry = {
+        serial: i + 1,
+        substance: bottle.substance,
+        sourceName: bottle.sourceName,
+        milkedAt: bottle.milkedAt,
+        quantity: 1,
+    };
+    // Match the C# model's [BsonIgnoreIfNull]: an absent tag is absent, not null.
+    if (bottle.corruptionTag) entry.corruptionTag = bottle.corruptionTag;
+    rebuilt[bottle.userName].push(entry);
+});
+
+const highestSerial = flattened.length;
+
+// ── Report ────────────────────────────────────────────────────────────────────
+const owners = Object.keys(rebuilt).sort();
+print("residents with bottles: " + owners.length);
+print("bottles after splitting: " + highestSerial);
+print("");
+owners.forEach(function (userName) {
+    const bottles = rebuilt[userName];
+    const first = bottles[0].serial;
+    const last = bottles[bottles.length - 1].serial;
+    print("  " + userName + ": " + bottles.length + " bottle(s), serials #" + first + " ... #" + last);
+});
+print("");
+
+if (DRY_RUN) {
+    print("DRY RUN: nothing written. Set DRY_RUN = false to apply.");
+    quit(0);
+}
+
+// ── Apply ─────────────────────────────────────────────────────────────────────
+let written = 0;
+owners.forEach(function (userName) {
+    targetDb.getCollection(PROFILES).updateOne(
+        { userName: userName },
+        { $set: { milkInventory: rebuilt[userName] } }
+    );
+    written++;
+});
+
+targetDb.getCollection(COUNTERS).updateOne(
+    { _id: COUNTER_ID },
+    { $set: { value: highestSerial } },
+    { upsert: true }
+);
+
+print("Wrote " + written + " profile(s).");
+print("Counter " + COUNTER_ID + " set to " + highestSerial + "; the next bottle milked will be #" + (highestSerial + 1) + ".");
+print("");

--- a/wiki-docs/Command-Reference.md
+++ b/wiki-docs/Command-Reference.md
@@ -562,6 +562,19 @@ Give/receive payment.
 → Alice wants to pay Bob 50 tokens! Do you !consent?
 ```
 
+#### !pay
+Transfer currency, or pass along bottles from your collection. A negative amount bills the other resident instead.
+
+**Usage:** `!pay [user]Name[/user] {amount} {currency}` or `!pay [user]Name[/user] {amount} bottles {substance}` or `!pay [user]Name[/user] bottles #12 #13`
+
+Bottles keep their number, their donor and their corrupt/pure tag when they change hands. Naming bottles by number is the only way to pass along an empty; an amount always means full bottles.
+
+**Example:**
+```
+!pay [user]Bob[/user] bottles #142 #143
+→ Alice is going to pass Bob 2 bottles: two of the milk from Carol (corrupt)! Do you !consent to receiving them? (or !no)
+```
+
 ### Commitment Interactions (24 hour cooldown)
 
 #### !mark
@@ -711,6 +724,42 @@ Try other jobs without being employed.
 ```
 
 **Note:** Volunteers earn less than employees
+
+### Bottle Collection
+
+Bottles come from `!milk`. Every bottle carries a permanent number, the resident it came from, and a corrupt/pure tag if the donor was far enough one way or the other.
+
+#### !bottles
+Look over the bottles you're holding. Private reply.
+
+**Usage:** `!bottles` or `!bottles {substance}` or `!bottles {substance} [user]Name[/user]`
+
+**Example:**
+```
+!bottles
+→ Our records show you're holding 2 bottles:
+  milk from Carol, corrupt | #142, #143 | 7 copper each
+  Empties: #12, #40
+  That's 14 copper if you choose to !sell the lot to the Chateau on the cheap...
+```
+
+#### !drink
+Drink one bottle from your collection. Channel-only, since everyone gets to see what it does to you.
+
+**Usage:** `!drink` or `!drink {substance}` or `!drink #{number}`
+
+Drinking empties the bottle but you keep it: the number stays in your collection as a record of what you drank. A corrupt or pure bottle shifts you the same way (up to 3 per day), a substance you're addicted to quiets the craving, and there's a small chance you find yourself wanting more.
+
+**Example:**
+```
+!drink #142
+→ Alice uncorks bottle #142 and drinks down the tasty milk from Carol. Not a drop wasted! How delightfully dark and rich~ Alice gains 1 corruption.
+```
+
+#### !sell
+Sell full bottles to the Chateau. The Chateau keeps the bottle, so its number leaves your collection for good. Empties can't be sold.
+
+**Usage:** `!sell` or `!sell {amount}` or `!sell {amount} {substance}` or `!sell {amount} {substance} [user]Name[/user]`
 
 ### Statistics & Profiles
 
@@ -917,6 +966,8 @@ Many commands have shorter aliases:
 | `!coinflip` | `!flip` |
 | `!consent` | `!accept` |
 | `!reject` | `!deny` |
+| `!bottles` | `!collection` |
+| `!drink` | `!imbibe`, `!swig` |
 
 ## Tips
 

--- a/wiki-docs/specs/Bottle-Consumption-And-Transfer.md
+++ b/wiki-docs/specs/Bottle-Consumption-And-Transfer.md
@@ -1,0 +1,473 @@
+# Bottle Consumption & Transfer — `!bottles`, `!drink`, `!pay … bottles`
+
+Closes the loop on the milk-bottle economy. Today `!milk` fills `Profile.milkInventory` and `!sell` is the only thing that ever reads it — residents cannot see what they own and cannot do anything with it but cash it out. This spec adds serial numbers, persistent empties, a view surface, a consumption path with real mechanical effects, and player-to-player transfer.
+
+**Status:** Implemented (2026-07-29).
+**Investment level:** `!bottles` is a private self-command. `!drink` is a channel self-command (no consent flow). Bottle transfer rides the existing Involved-tier `!pay` consent flow.
+**Depends on:** [Currency-and-Milk-Inventory](Infrastructure/Currency-and-Milk-Inventory.md) (`MilkBottle`, `milkInventory`, `ChateauCurrency`), [Dose-and-Detox](Dose-and-Detox.md) (`ViceInstance`, `DoseStatusContributor`, `DoseProcessor.IntensifyExistingVices`), [Corrupt-and-Purify](Corrupt-and-Purify.md) (`CorruptionProcessor.ReadCorruption`, daily-quota pattern), [Status-Effect-Hook](Infrastructure/Status-Effect-Hook.md).
+
+> **This is a deliberate extension, not a correction.** [Currency-and-Milk-Inventory.md](Infrastructure/Currency-and-Milk-Inventory.md) originally stated that bottles cannot be transferred between residents and that the `bottle` side-currency is a pure tally. Both were accurate as-shipped decisions; this feature supersedes them by owner direction (2026-07-29), and that doc now carries a pointer here.
+
+> **Deploy note:** [`scripts/backfill-bottle-serials.js`](../../scripts/backfill-bottle-serials.js) must run before or with the deploy. Bottles left un-numbered render as `#?` and cannot be named by `!drink` or `!pay`.
+
+## Motivating gaps
+
+1. **No view surface.** `!bank` reads `profile.currencies` only ([`ChateauBank.cs:123`](../../FChatDicebot/BotCommands/ChateauBank.cs)); `!dossier` has no bottle section. A resident who forgets what they milked has no way to find out short of guessing filters at `!sell`.
+2. **`!sell` points at commands that don't show bottles.** Its filter-miss message reads *"Use !bank or your !dossier to review what you've got bottled up"* ([`ChateauSell.cs:90`](../../FChatDicebot/BotCommands/ChateauSell.cs)). Neither does. A shipped-text bug regardless of the rest of this spec.
+3. **No consumption path.** `!sell` is the only exit. `!feed` takes a substance identifier but has no inventory precondition, so bottles are never actually required for any downstream fiction.
+4. **`corruptionTag` only moves price.** A bottle milked from a deeply corrupt resident is worth 1.5×, and that is its entire consequence.
+5. **Bottles have no handle**, which is what makes precise transfer and precise consumption impossible to express.
+
+---
+
+## 1. Bottle serial numbers
+
+`!milk`'s completion already says *"Bottled, sealed, and tagged."* This makes the tag real: **every physical bottle gets a globally unique serial number**, issued at milking time and carried for the life of the bottle — including after it's been emptied.
+
+### Why global, not a per-cellar index
+
+A per-cellar index (bottles numbered 1..N in display order, computed at read time) needs no storage and no backfill, and was the cheaper option on the table. It loses on one point that turns out to be decisive: **`!pay` has a consent gap.** Between the payer typing the command and the recipient answering, the payer can `!drink` or `!sell`, and every index after the affected bottle shifts. The handle the payer typed would then name a different bottle at consent time. A deferred-consent command needs a stable handle, and per-cellar indices are not stable. They also renumber on transfer, which destroys the provenance story that makes transfer interesting in the first place.
+
+Global serials are stable forever, in anyone's collection, and give the collection a collectible dimension for free: a low serial is demonstrably old.
+
+### Empties keep their serial
+
+Drinking does not destroy a bottle. It **empties** it, and the empty stays in the resident's collection carrying the same serial, donor, substance, and corruption tag it always had. Bottle #142 is permanent proof that you once held a bottle of Alice's corrupt milk, and drank it.
+
+This changes the meaning of `!sell` versus `!drink` into a real decision rather than a formality:
+
+| | Copper | `bottle` currency | Serial |
+|---|---|---|---|
+| `!sell` | substance value | +1 (the Chateau takes the empty back) | leaves your collection with the bottle |
+| `!drink` | none | none | **stays, as an empty** |
+
+**This depreciates the `bottle` side-currency**, deliberately. It is no longer the only record that a bottle passed through your hands; the empty itself is, and it is far more specific. `!sell` and the self-milk shortcut keep crediting it so existing balances stay meaningful, but `!drink` does not, and nothing new is built on it.
+
+### Shape
+
+One collection with a nullable emptied-timestamp, rather than two parallel lists. A bottle's *state* changes; its identity does not, so it should not move between containers. Filters, transfer, and display all work off one list with a predicate.
+
+```csharp
+public class MilkBottle
+{
+    public int serial;              // NEW. Globally unique, never reused.
+    public string substance;
+    public string sourceName;
+    public DateTime milkedAt;
+    public int quantity;            // now always 1 for newly created bottles
+
+    [BsonIgnoreIfNull]
+    public string corruptionTag;
+
+    /// NEW. Null while full. Set when drunk; the bottle stays in the
+    /// collection as a numbered empty from that point on.
+    [BsonIgnoreIfNull]
+    public DateTime? emptiedAt;
+
+    public bool IsEmpty => emptiedAt.HasValue;
+}
+```
+
+`emptiedAt` satisfies the full/empty boolean and carries *when* for free, following the `[BsonIgnoreIfNull]` pattern `corruptionTag` already uses.
+
+**One entry per physical bottle.** Today a milking that rolls 3 stores a single entry with `quantity = 3`. A serial identifies one bottle, so aggregated entries must be split: a milking that rolls 3 writes three entries with three consecutive serials. `quantity` is retained on the model so legacy documents still deserialize (see `Profiledeserializationtests.cs`), but nothing new ever writes a value above 1.
+
+This is a net simplification downstream. `ChateauSell`'s partial-entry-consumption logic exists only to service aggregated entries; with one entry per bottle, selling is a straight remove.
+
+**On collection growth:** empties accumulate permanently. A `MilkBottle` document is on the order of 150 bytes against Mongo's 16MB document ceiling, so this is not a practical limit concern, but the display cap in §2 exists so a long-serving resident's `!bottles` output stays readable.
+
+### Issuing serials
+
+Serials come from an atomic counter so two simultaneous milkings can never collide. A single-document `Counters` collection keyed `bottleSerial`, incremented with a `findAndModify` `$inc` that returns the new value. A milking that produces N bottles does **one** `$inc` of N and claims the returned range, rather than N separate round-trips.
+
+Serials are **never reused.** Selling bottle #142 to the Chateau retires #142 permanently; drinking it keeps it in your hands as an empty.
+
+### Backfill
+
+A one-time `mongosh` script, following the precedent of the employer-earnings historic backfill:
+
+1. Read every profile's `milkInventory`.
+2. Flatten to individual bottles, splitting any entry with `quantity > 1` into that many entries (same `substance`, `sourceName`, `milkedAt`, `corruptionTag`).
+3. Sort **all** bottles across **all** profiles by `milkedAt` ascending and assign serials from 1. Chronological assignment across the whole Chateau means low serials really are the oldest milk in the building, which is the property that makes them worth showing.
+4. Leave `emptiedAt` null on everything. Bottles drunk or sold before this ships are simply not recoverable, and inventing empties for them would be fiction.
+5. Set the `bottleSerial` counter to the highest assigned value.
+6. Write each profile's rebuilt `milkInventory`.
+
+**The backfill must run before or with the deploy.** Un-numbered bottles would otherwise render with no serial and be unreferenceable by `!drink` / `!pay`. Ties on `milkedAt` break by profile name then substance, purely for determinism if the script is re-run.
+
+> This remains the single largest cost in the spec: a schema change to live player data plus a migration script. Worth confirming appetite before implementation starts. The fallback if not: per-cellar indices, accepting the consent-gap hazard by re-resolving the index at consent time and aborting on mismatch.
+
+---
+
+## 2. `!bottles` — view
+
+Private self-command, modeled on [`ChateauBank`](../../FChatDicebot/BotCommands/ChateauBank.cs). Argument shape mirrors `!sell` so the two read as a pair.
+
+```
+!bottles                              — everything you have
+!bottles {substance}                  — filtered by substance
+!bottles {substance} [user]X[/user]   — filtered by substance and original donor
+```
+
+- `IdentifierCategory = "substance"`, `RequireChannel = false`, no cooldown, private reply.
+- Self-only in v1. Another resident's collection is visible in summary form via their `!dossier` (§5), which is the deliberate privacy line: counts are public, donor names are not.
+
+### Display
+
+Full bottles first, grouped by `(substance, sourceName, corruptionTag)`, ordered **newest-first** so the top line is what an unfiltered `!sell` or `!drink` acts on next. Each group lists its serials. Empties follow in their own section, grouped the same way — they have no sell value, so they carry no price column.
+
+Serial lists cap at `BottleSerialDisplayCap` per group with an `and N more` tail, so a large collection stays in one readable message. The empties section as a whole caps too; a resident with 200 empties wants the count and a sample, not a wall.
+
+Substance names render through `Utils.SubstanceToText`. **Donor names render through `MonDB.getDisplayName(sourceName)`** — `sourceName` is a stored `userName` and must never reach a player-facing string raw. (Note: [`ChateauSell.BuildResultMessage`](../../FChatDicebot/BotCommands/ChateauSell.cs) currently interpolates `line.SourceName` directly, which is this same bug already shipped. Fix it while in the area.)
+
+---
+
+## 3. `!drink` — consume
+
+**Channel self-command** (`RequireChannel = true`), **no consent flow** (you own the bottle). Structured like [`ChateauWash`](../../FChatDicebot/BotCommands/ChateauWash.cs) and `ChateauDetox`: a `ChatBotCommand` plus a pure `DrinkCommand.Execute(...)` helper so effect logic is unit-testable without a database.
+
+```
+!drink                                — your newest full bottle
+!drink {substance}                    — newest full bottle of that substance
+!drink #{serial}                      — that exact bottle
+```
+
+The `#` prefix is required on serials so the argument can't be confused with a count. Term parsing strips it before the int parse.
+
+**Naming:** `!consume` is already taken by the devour-a-resident Commitment interaction ([`ChateauConsume.cs:19`](../../FChatDicebot/BotCommands/ChateauConsume.cs)), so `!drink` is the primary. Suggested aliases: `!imbibe`, `!swig`. Note `drink` is itself a vice/substance identifier, so `!drink drink` is legal and slightly silly. Harmless, but worth knowing before someone reports it.
+
+### Why it must be a channel command
+
+The effects below produce **public** output: craving satisfaction and corruption drift are things the channel is supposed to witness (`!dose`'s consent text already promises *"Everyone will know when you're satisfying an addictive craving"*). Running `!drink` in a private message would either silently swallow that output or leak a public-by-design fragment into a PM. Channel-only also naturally rate-limits the command socially, which pairs with the 3-per-day corruption budget to keep it from being spammed.
+
+### Consumption mechanics
+
+1. Select **one full bottle**: by serial if given, otherwise newest-first among full bottles honoring the substance filter. Empties are never selected implicitly. This is the same selection `ChateauSell` performs; factor it into a shared helper with a full/empty predicate rather than copying it, so `!sell`, `!drink`, and transfer can never drift.
+2. Set `emptiedAt = UtcNow`. The entry stays in `milkInventory`.
+3. **No `bottle` currency is credited** — you keep the physical empty instead. (See §1.)
+4. Persist via the targeted `SetMilkInventory` write, not a whole-profile `SetProfile`, matching how `!sell` avoids clobbering concurrent currency writes.
+
+### Effects
+
+**(a) Craving satisfaction.** Today the only ways to satisfy a `!dose` craving are `!feed`, `!odorize`, or another `!dose` — *all of which require a second consenting resident*. An addict alone in the channel has no relief. Drinking a bottle of the substance you are hooked on becomes the first solo route.
+
+`DoseStatusContributor` already matches on `parentInteractionType` + `parentIdentifier`, so this is one case added to its satisfaction list: `parentInteractionType == "drink"` && `parentIdentifier == substance`. It reuses the contributor's existing approved satisfaction string, so no new copy is needed for this branch.
+
+> **Infra note.** Per the folder conventions, status effects fire on interactions you `!consent` to; self-commands don't invoke the hook. `!drink` is a deliberate exception — the drinker is consenting with themselves. `GetActiveStatusEffects` is currently an instance method on `InteractionProcessorBase`, so this needs a small **public** shared entry point a `ChatBotCommand` can call: invoke the registered contributors against a single subject at `StatusEffectCallSite.Completion` with `isInitiator: true`. `!detox` and `!wash` would benefit from the same hook later. This is the only genuinely new infrastructure in the spec.
+
+**(b) Corruption transfer.** The bottle's `corruptionTag` moves the *drinker*, closing the loop with Corrupt-and-Purify and giving the tag consequence beyond price:
+
+| Bottle tag | Corruption shift on the drinker |
+|---|---|
+| `"corrupt"` | −1 |
+| `"purified"` | +1 |
+| `null` | 0 |
+
+(Sign follows `ChateauCurrency.GetCorruptionTagForValue`: negative is corrupt, positive is pure. Player-facing text never shows the sign — it says "gains 1 corruption" or "gains 1 purity".)
+
+Bounded by a **daily shift budget of 3** per Chateau day, stored in `dailyMagnitudes` under a `drinkshift_{yyyy-MM-dd}` key with the same stale-key pruning `CorruptionProcessor.RecordUsedQuota` performs. Deliberately a **separate key** from the corruption quota, so drinking never draws from or eats a resident's 10/day `!corrupt` budget.
+
+Past the budget, further drinks still work and still taste of what they are. Only the mechanical half of the message is replaced (see the two-part fragment structure in the text section).
+
+**(c) Addiction risk.** A `DrinkAddictionChance` (10%) roll to intensify an **existing** `ViceInstance` for that substance, via `DoseProcessor.IntensifyExistingVices`. **Intensify-only, never creates** — the rule `!climaxfor`'s auto-dose already follows, so drinking your first bottle of something can never addict a clean resident.
+
+> **Corrected during implementation.** The design originally said this roll was skipped when the same drink satisfied a craving, on the grounds that relief-plus-escalation read as double-dipping. That rule makes the effect unreachable: only an existing vice can intensify, and an existing vice is exactly what satisfaction requires, so "skip when satisfied" and "intensify only what exists" have no overlap. The roll therefore fires regardless. This is the better mechanic anyway — the bottle quiets the want *and* tightens the hook, which is the dynamic the vice system exists to model.
+
+### Why this doesn't become a corruption farm
+
+Supply is throttled at the source: one milking per direction per Chateau day, 1 to 3 bottles, and every bottle in existence came from a consenting `!milk`. On top of that, the 3/day shift budget caps the stat impact regardless of how many bottles a resident holds — which is what keeps the numbers sane once transfer (§4) lets someone pool another resident's supply. The budget is doing the real balance work here, not scarcity.
+
+---
+
+## 4. Bottle transfer via `!pay`
+
+Full bottles **and empties** become payable between residents through the existing [`!pay`](../../FChatDicebot/BotCommands/ChateauPay.cs) flow. Empties are transferable on purpose: once a serial is a collectible, gifting or trading one is a meaningful act, and a numbered empty from a notable donor is exactly the sort of thing residents will want to hand around.
+
+### Syntax
+
+```
+!pay [user]Bob[/user] {amount} bottles              — N newest full bottles
+!pay [user]Bob[/user] {amount} bottles {substance}  — N newest full of a substance
+!pay [user]Bob[/user] bottle #142                   — that exact bottle, full or empty
+!pay [user]Bob[/user] bottles #142 #143 #187        — those exact bottles
+!pay [user]Bob[/user] -{amount} bottles             — bill Bob for bottles
+```
+
+Amount-based forms select **full bottles only** — someone asking for "3 bottles" means three with something in them. Empties move by explicit serial, which is the right friction for a collectible.
+
+The literal keyword `bottles` (accept `bottle` too) occupies `!pay`'s currency slot. This is available: `bottle` is **not** a currency-category identifier in the snapshot, so `!pay X 3 bottle` fails today with "type not found", meaning the empty-bottle side-currency is itself unpayable and there is no ambiguity to resolve. Worth confirming against live Mongo before implementing, since the snapshot can lag.
+
+`ChateauPay.Run` special-cases the keyword *before* the currency-identifier lookup, then reads either `#`-prefixed serials or an amount plus an optional `substance` identifier.
+
+**Serials resolve the donor-filter problem.** `!pay`'s `[user]` tag is already spoken for by the payee, so unlike `!sell` there is no room for a source filter. Naming bottles by serial sidesteps this entirely: you don't filter for Alice's milk, you hand over #142.
+
+### Bottles travel intact
+
+A transferred `MilkBottle` keeps its `serial`, `substance`, `sourceName`, `milkedAt`, `corruptionTag`, and `emptiedAt`. Provenance survives the handoff. A bottle milked from a corrupt donor still corrupts whoever eventually drinks it, three owners later, and it still answers to the same number.
+
+### Consent and TOCTOU
+
+Rides the existing `paymentGive` / `paymentReceive` processors and their consent flow. Two changes:
+
+- `PaymentProcessorBase.ProcessInteraction` branches: currency payments keep the atomic `TryDebitCurrency` path; bottle payments move `MilkBottle` entries between the two `milkInventory` lists.
+- `BuildConsentWarning` on both processors gains a bottle branch naming what is actually changing hands, including tags and whether any are empties. A recipient deserves to know they're being handed corrupt goods, or empties, before consenting.
+
+**Do not escrow at command time.** Between `!pay` and `!consent` the payer may `!sell` or `!drink` the bottles. Re-resolve at consent time and abort with a private message if the payer no longer holds them — the TOCTOU pattern [`MilkProcessor.ProcessInteraction`](../../FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs) already uses for its direction lock. Serials make this check exact.
+
+**A bottle drunk between command and consent is a mismatch, not a substitution.** It's still in the payer's collection under the same serial, but it's empty now, and the recipient consented to a full one. Abort rather than deliver an empty.
+
+Amount-based transfers resolve to concrete serials at command time and store those on the pending command, so the re-check is always the same exact-serial check. This stops a payer promising "3 bottles of milk", drinking the corrupt ones, and delivering three plain ones.
+
+Self-pay is already rejected by `ChateauPay` and stays rejected.
+
+---
+
+## 5. Surfacing changes to existing commands
+
+**`!bank`** — a collection line in *both* branches, counting full and empty separately. The no-currency branch matters: a resident with zero currency but a full collection is currently told they own nothing. Omit the line entirely when the collection is empty.
+
+**`!dossier`** — one cell in the At-a-Glance section ([`ChateauDossier.cs:662`](../../FChatDicebot/BotCommands/ChateauDossier.cs)), beside the most-abundant-currency cell. **Substance counts only, no donor names and no serials.** The dossier is public, and `sourceName` is effectively "who has this resident milked", which is the donor's business, not the reader's.
+
+**`!sell`** — fix the filter-miss text to point at `!bottles`. Show serials in its result message. Sells full bottles only in v1; empties stay put. Add `bottles` and `drink` to its `RelatedCommands`, and to `!milk`'s.
+
+> **Future hook, not v1:** the `!drink` closing pool jokes that someone out there pays well for an empty bottle. If empties should ever become sellable, that line is the setup already planted.
+
+---
+
+## Persistence
+
+**No new `Profile` fields.** Everything reuses `milkInventory`.
+
+| Key | Location | Meaning |
+|---|---|---|
+| `serial` | `MilkBottle` | Globally unique bottle number. Never reused. |
+| `emptiedAt` | `MilkBottle` | Null while full; set when drunk. The bottle stays in the collection either way. |
+| `bottleSerial` | `Counters` collection *(new)* | Atomic issuing counter for serials. |
+| `drinkshift_{yyyy-MM-dd}` | `Profile.dailyMagnitudes` | Corruption shift already spent by drinking today. Capped at `DrinkCorruptionDailyLimit`. Stale-dated keys pruned on write. |
+
+New constants on `ChateauCurrency`, alongside the existing milk and pricing constants:
+
+```csharp
+public const int DrinkCorruptionShiftPerBottle = 1;
+public const int DrinkCorruptionDailyLimit = 3;
+public const double DrinkAddictionChance = 0.10;
+public const int BottleSerialDisplayCap = 8;
+```
+
+---
+
+## User-facing text (as shipped)
+
+Drafted against [Style-Guide.md](../Style-Guide.md). No em-dashes, no "UTC", donor names via `getDisplayName`, `(or !no)` never hand-written (applied by `GetConsentWarning` from `ConsentWarningText.DeclineHint`).
+
+### `!bottles`
+
+**Populated (private):**
+> Our records show you're holding [b]7 bottles[/b]:
+> [b]milk[/b] from Alice, [b]corrupt[/b] | #142, #143, #187 | 7 copper each
+> [b]cum[/b] from Bob | #201, #202 | 25 copper each
+> [b]saliva[/b] from Bob, [b]pure[/b] | #55, #91 | 50 copper each
+> Empties: #12, #40, #41, #98
+> That's [b]171 copper[/b] if you choose to !sell the lot to the Chateau on the cheap, but someone might be willing to let you !pay them with a few bottles... or you could always have a !drink.
+
+Groups exceeding the serial display cap tail with `and 4 more`. The empties line is omitted when there are none.
+
+**Empty (private):**
+> No bottles to speak of yet. Go !milk a willing resident to start your collection!
+
+**Only empties left (private).** Added during implementation: persistent empties create a state where the collection is worth showing but "you're holding 0 bottles" would be a strange way to open it.
+> Nothing left to drink, but our records show you're keeping [b]4 empties[/b]:
+> #12, #40, #41, #98
+> Go !milk a willing resident if you'd like something to drink.
+
+**Filter matched nothing (private):**
+> We don't see anything like that in your collection. Use !bottles on its own to see everything you're holding.
+
+### `!drink`
+
+**Completion (channel).** Setup plus one randomly chosen closing flourish. Phrased "the tasty {substance} from {Donor}" rather than a possessive, since a `displayName` ending in *s* makes `'s` read badly and the substance is often not milk:
+> {Drinker} uncorks bottle [b]#142[/b] and drinks down the tasty {substance} from {Donor}.
+
+Closing pool:
+> Unbottled, unsealed, and thoroughly enjoyed.
+> Not a drop wasted!
+> Keep the empty for your collection.
+> Rumors say green clad adventurers will pay a lot for an empty bottle...
+> Got {substance}?
+
+**Corruption fragments** (appended). Two composable halves — a taste half that always fires, and an effect half that the daily budget can replace:
+
+| Half | Corrupt | Pure |
+|---|---|---|
+| Taste | `How delightfully dark and rich~` | `So light and invigorating!` |
+| Effect | `{Drinker} gains 1 corruption.` | `{Drinker} gains 1 purity.` |
+
+Assembled: `How delightfully dark and rich~ {Drinker} gains 1 corruption.`
+
+**Budget spent** — the taste half still fires, only the effect half is replaced:
+> No effect though... maybe tomorrow they'll be able to metabolize a bit more.
+
+Assembled: `How delightfully dark and rich~ No effect though... maybe tomorrow they'll be able to metabolize a bit more.`
+
+**Addiction intensified** (appended):
+> ...and {Drinker} finds themself wanting another already. [sub](addiction 4/10)[/sub]
+
+**Craving satisfied:** no new string. `DoseStatusContributor` emits its existing approved satisfaction fragment.
+
+**Empty collection (private):**
+> No bottles to speak of yet. Go !milk a willing resident to start your collection!
+
+**Filter matched nothing (private):**
+> We don't see any of that in your collection. Use !bottles to check what you're actually holding.
+
+**Everything you own is already empty (private).** Added during implementation, for the same reason as the `!bottles` case above:
+> Every bottle you're holding is already empty. Go !milk a willing resident if you'd like something to drink.
+
+**Unknown serial (private):**
+> Bottle [b]#142[/b] isn't in your collection. Perhaps you sold it off... use !bottles to check your numbers.
+
+**Bottle already empty (private).** New state created by persistent empties, and distinct from the case above:
+> Bottle [b]#142[/b] is already empty! Use !bottles to see which of yours still have something in them.
+
+### `!pay` bottle transfer
+
+**Consent prompt, give (channel).** The `(or !no)` reminder is appended by the framework:
+> {Initiator} is going to pass {Recipient} [b]3 bottles[/b]: two of the milk from {Donor} ([b]corrupt[/b]), and one of the cum from {Donor2}! Do you !consent to receiving them?
+
+**Consent prompt, bill (channel):**
+> {Initiator} is asking {Recipient} for [b]2 bottles[/b] of the milk from {Donor}! Do you !consent to handing them over?
+
+**Empty-bottle flag** (appended to the parcel description in either prompt). Added during implementation: whether the contents are still in there is the single most important thing a recipient needs before agreeing, so it goes on the whole parcel rather than per line, and a mixed parcel says exactly how many rather than implying either.
+> [sub](already emptied)[/sub]
+> [sub](1 of them already emptied)[/sub]
+
+**Completion, give (channel):**
+> {Initiator} hands [b]3 bottles[/b] over to {Recipient}. Is that a vintage?
+
+**Completion, bill (channel):**
+> {Initiator} accepts [b]3 bottles[/b] from {Recipient}. Is that a vintage?
+
+**Not enough bottles, command time (private):**
+> You don't have that many bottles to hand over. Use !bottles to see what you're holding.
+
+**Bottles gone by consent time (private, to initiator):**
+> {Payer} doesn't have those bottles anymore. It seems they were sold or enjoyed while we waited on an answer... nothing changed hands.
+
+### `!bank` addition
+
+Appended to both the has-currency and no-currency branches, omitted when the collection is empty:
+> You're also holding [b]7 bottles[/b] and [b]4 empties[/b] of your own. Use !bottles to look them over.
+
+### `!dossier` cell
+
+> [b]Bottled:[/b] 7 bottles (3 milk, 2 cum, 2 saliva) and 4 empties
+
+### `!sell` revised filter-miss
+
+Replaces the current false pointer:
+> No bottles in your collection matched that filter. Use !bottles to review what you've got bottled up.
+
+### Help fields
+
+**`!bottles`**
+- `ShortDescription`: `Look over the bottles you've collected.`
+- `LongDescription`: `Review the bottled fluid in your personal collection. Each bottle carries its own number, the resident it came from, whether it's corrupt or pure, and what the Chateau would pay for it. Empties keep their number too, so your collection remembers everything you've ever drunk. Filter by substance and by donor to narrow the list.`
+- `Usage`: `!bottles\nor\n!bottles {substance}\nor\n!bottles {substance} [noparse][user]NameInUserTag[/user][/noparse]`
+- `RelatedCommands`: `milk`, `sell`, `drink`, `pay`, `bank`
+
+**`!drink`**
+- `ShortDescription`: `Drink down one of the bottles you're holding.`
+- `LongDescription`: `Uncork and drink a bottle from your collection, keeping the empty. Whatever was inside affects you: a corrupt or pure bottle shifts you the same way, up to 3 bottles per day, and a substance you're addicted to will quiet the craving. There's always a small chance you find yourself wanting more. Name a bottle by its number, or leave it off to drink your newest.`
+- `CooldownDuration`: `null` (the 3-per-day limit is a corruption budget, not a cooldown, and is described in the long text)
+- `Usage`: `!drink\nor\n!drink {substance}\nor\n!drink #{number}`
+- `RelatedCommands`: `bottles`, `milk`, `sell`, `dose`, `detox`
+
+**`!pay`** `LongDescription` gains a trailing sentence:
+> You can also pass along bottles from your collection, full or empty, either by number or by naming a substance and an amount.
+
+---
+
+## Tests
+
+**`Bottleinventorytests.cs`** *(new)* — the shared selection contract: newest-first ordering, empties excluded from `SelectFull`, substance and donor filters, serial lookup finding full and empty alike, serial 0 never matching, grouping collapsing same-`(substance, source, tag)` bottles while separating on tag, the display cap's `and N more` tail, and unnumbered bottles rendering as `#?` rather than a misleading `#0`.
+
+**`Chateaubottlestests.cs`** *(new)* — the view: count, serials and per-bottle price; donor names rendered as `displayName`; total value counting full bottles only; the empties line present when there are empties and omitted when there aren't; corrupt/pure labelling; filter-miss distinguished from an empty collection; separate milkings collapsing to one line; and the `!bank` collection line counting full and empty separately and vanishing at zero.
+
+**`Chateaudrinktests.cs`** *(new)*
+- Empties the bottle but keeps it and its serial in the collection.
+- Credits **no** `bottle` currency.
+- Implicit selection takes the newest full bottle and never an empty, even when the empty is newest.
+- Serial targeting selects that exact bottle; an unknown serial changes nothing; an already-empty serial gets its own distinct message.
+- Corrupt shifts −1, purified +1, untagged 0.
+- Past the daily budget the bottle is still drunk and still narrated, but shifts 0 and prints the metabolize line; stale-dated `drinkshift_` keys are pruned; the drink budget never writes a `corruption_` key.
+- The addiction roll intensifies an existing vice and never creates one, and still fires on a drink that satisfied a craving.
+- Serial parsing requires the `#` prefix, so a bare number is never mistaken for one.
+
+**`Bottleserialtests.cs`** *(new)* — the counter starts at 1 on a fresh database, returns the first number of a claimed block, never repeats across 50 mixed-size claims, no-ops on a non-positive count; a sold serial leaves the collection while a drunk one stays; serials survive transfer unchanged.
+
+**`Bottlepaymenttests.cs`** *(new)*
+- The `bottles` keyword is recognised case-insensitively; serial parsing keeps order and drops duplicates.
+- Amount forms take newest-first full bottles only; a short collection fails; a substance filter narrows them.
+- A named serial can move an empty; a serial the payer doesn't hold fails by name.
+- Transfer moves serial, donor and tag intact.
+- Consent gap: a bottle sold in the gap aborts; a bottle *drunk* in the gap aborts rather than delivering the empty; a partial mismatch moves nothing at all.
+- `EncodePromise` carries the empty-state alongside the serial.
+- `Describe` names count, substance, donor and tag, and is distinguishable from a currency amount.
+
+**`Milkprocessortests.cs`** *(modified)* — a milking now writes one entry per bottle rather than one entry with a count, each numbered and full, and claims its serials as one contiguous block.
+
+**`Chateauselltests.cs`** *(unchanged, passing)* — the existing suite is the regression guard on the extracted selection helper. Its bottles are all full and un-numbered, which incidentally covers the legacy `quantity > 1` path still working.
+
+Full suite: 1766 passing.
+
+---
+
+## Assumptions / overrides
+
+- **Empties persist forever and are never garbage-collected.** That permanence is the feature. Override with a retention cap only if collection sizes become a real problem, which the arithmetic in §1 suggests they won't.
+- **`!drink` credits no `bottle` currency.** This is the inference from depreciating that currency: you keep the physical empty instead of a tally mark. `!sell` and the self-milk shortcut keep crediting it so existing balances aren't stranded. Override by crediting both, though then the tally and the empty say the same thing twice.
+- **Global serials over per-cellar indices**, at the cost of a data migration. Reasoning in §1.
+- **One entry per physical bottle.** `quantity` retained for legacy deserialization only.
+- **Chronological backfill across all profiles**, so low serials are genuinely the oldest bottles.
+- **Empties transfer by explicit serial only**, never by amount. Amount forms mean full bottles.
+- **Empties are not sellable in v1**, despite the joke in the closing pool.
+- **`!drink` is self-only.** Drinking *at* someone is `!feed`'s territory, and `!feed` stays free-form with no inventory precondition. Gating a shipped consent interaction on inventory would break every current use.
+- **One bottle per `!drink` call.** No `!drink 3`.
+- **Corruption shift is ±1 per bottle, 3 per day.** The daily cap is the load-bearing balance lever once transfer exists. Do not remove it without revisiting §3.
+- **Addiction risk is intensify-only at 10%, and fires even on a drink that satisfied a craving.** Matches the climax auto-dose precedent on the first half; the second half is a correction made during implementation (see §3c) without which the effect is unreachable.
+- **`bottle` is not a currency identifier.** Verified against `IdentifiersSnapshot.json`. **Worth confirming against live Mongo:** if someone has since added a `bottle` currency identifier, `!pay X 3 bottle` would now route to the bottle-transfer path instead of paying that currency.
+
+## Files
+
+**New:**
+- `FChatDicebot/BottleInventory.cs` — shared selection, grouping and serial formatting.
+- `FChatDicebot/BottlePayment.cs` — transfer parsing, selection, the promise encoding, and transfer wording.
+- `FChatDicebot/BotCommands/ChateauBottles.cs`
+- `FChatDicebot/BotCommands/ChateauDrink.cs` (thin command over a pure `Execute`)
+- `FChatDicebot/InteractionProcessors/SelfCommandStatusEffects.cs` — the public hook a consentless command uses to run the contributors.
+- `scripts/backfill-bottle-serials.js` (mongosh migration)
+- `FChatDicebot.Tests/Unit/Bottleinventorytests.cs`
+- `FChatDicebot.Tests/Unit/Bottlepaymenttests.cs`
+- `FChatDicebot.Tests/Unit/Bottleserialtests.cs`
+- `FChatDicebot.Tests/Unit/Chateaubottlestests.cs`
+- `FChatDicebot.Tests/Unit/Chateaudrinktests.cs`
+
+**Modified:**
+- `FChatDicebot/Model/MilkBottle.cs` — `serial`, `emptiedAt`, `IsEmpty`.
+- `FChatDicebot/InteractionProcessors/Involved/MilkProcessor.cs` — claims a serial block; writes one entry per bottle.
+- `FChatDicebot/BotCommands/ChateauSell.cs` — uses the shared selection; excludes empties; reports sold serials; fixes the filter-miss pointer; renders donor names via `getDisplayName`.
+- `FChatDicebot/BotCommands/ChateauPay.cs` — `bottles` keyword branch ahead of the currency lookup, serial and amount forms.
+- `FChatDicebot/InteractionProcessors/Involved/PaymentProcessorBase.cs` — bottle-transfer branch in `ProcessInteraction`.
+- `FChatDicebot/InteractionProcessors/Involved/PaymentGiveProcessor.cs` / `PaymentReceiveProcessor.cs` — bottle branch in `BuildConsentWarning` / `GetCompletionMessage`.
+- `FChatDicebot/InteractionProcessors/StatusEffectContributors/DoseStatusContributor.cs` — `"drink"` satisfaction case and the `DrinkType` key.
+- `FChatDicebot/ChateauCurrency.cs` — drink constants and the display cap.
+- `FChatDicebot/Database/Ichateaudatabase.cs` / `Chateaudatabase.cs` — `ClaimBottleSerials`.
+- `FChatDicebot/BotCommands/ChateauBank.cs` — collection line in both branches.
+- `FChatDicebot/BotCommands/ChateauDossier.cs` — At-a-Glance bottled cell.
+- `FChatDicebot/BotCommands/ChateauMilk.cs` — `RelatedCommands`.
+- `FChatDicebot.Tests/Fixtures/Testdatabasefixture.cs` — clears the `Counters` collection on reset.
+- `FChatDicebot.Tests/Unit/Milkprocessortests.cs` — one-entry-per-bottle and contiguous-serial coverage.
+- `wiki-docs/specs/Infrastructure/Currency-and-Milk-Inventory.md` — superseded-transfer and depreciated-currency notes.
+- `wiki-docs/Command-Reference.md` — the Bottle Collection section, the `!pay` bottle syntax, and the new aliases.
+
+Commands are discovered by reflection over `ChatBotCommand` subclasses (`BotCommandController.LoadChatBotCommands`), and `.csproj` globs `**\*.cs`, so neither new command needed a registration or project edit.

--- a/wiki-docs/specs/Infrastructure/Currency-and-Milk-Inventory.md
+++ b/wiki-docs/specs/Infrastructure/Currency-and-Milk-Inventory.md
@@ -25,7 +25,9 @@ public class MilkBottle
 }
 ```
 
-Different milking sessions of the same `(substance, sourceName)` stay as separate entries so each retains its own `milkedAt` and `corruptionTag`. Bottles cannot be transferred between users — they are either kept as a trophy or sold.
+Different milking sessions of the same `(substance, sourceName)` stay as separate entries so each retains its own `milkedAt` and `corruptionTag`.
+
+> **Superseded 2026-07-29 by [Bottle-Consumption-And-Transfer](../Bottle-Consumption-And-Transfer.md).** This document originally stated that bottles cannot be transferred between residents. They can now, through `!pay`. That later feature also adds a permanent `serial` and an `emptiedAt` to `MilkBottle`, splits aggregated `quantity > 1` entries into one entry per physical bottle, and adds `!bottles` and `!drink`. Read this document for the original inventory and pricing model; read that one for the current shape.
 
 There is **no `emptyBottles` field** on `Profile`. The original spec proposed one as a precondition for `!milk`; that gate was dropped before merge. The Chateau always provides the empty bottles needed to milk.
 
@@ -40,7 +42,9 @@ Two new constants in [`ChateauCurrency.cs`](../../../FChatDicebot/ChateauCurrenc
 | `SellPayoutCurrency` | `"copper"` | The currency `!sell` deposits substance-value proceeds into. |
 | `BottleCurrency` | `"bottle"` | A side-currency credited one-per-bottle when the Chateau takes the empty back at `!sell` time, or in the self-milk shortcut. |
 
-Players accumulate `currencies["bottle"]` over time. The bottle currency is purely a tally today — no command spends it. Future features (a milking achievement, an item the bottle currency unlocks, etc.) can hook into it without changing this layer.
+Players accumulate `currencies["bottle"]` over time. The bottle currency is purely a tally — no command spends it.
+
+> **Depreciated 2026-07-29 by [Bottle-Consumption-And-Transfer](../Bottle-Consumption-And-Transfer.md).** Once drinking a bottle leaves you holding the numbered empty, the tally is no longer the only record that a bottle passed through your hands, and the empty is far more specific. `!sell` and the self-milk shortcut still credit it so existing balances aren't stranded, but `!drink` does not, and nothing new should be built on it.
 
 ## Sell pricing
 

--- a/wiki-docs/specs/README.md
+++ b/wiki-docs/specs/README.md
@@ -12,7 +12,8 @@ Design + as-implemented documentation for the Chateau Contract interaction syste
 | Spec | Adds | Used by |
 |------|------|---------|
 | [Status-Effect-Hook](Infrastructure/Status-Effect-Hook.md) | `IStatusEffectContributor` + registry + base-class helpers | Corrupt/Purify, Odorize/Wash, future status interactions |
-| [Currency-and-Milk-Inventory](Infrastructure/Currency-and-Milk-Inventory.md) | `MilkBottle` model, `Profile.milkInventory`, `ChateauCurrency` constants, `!sell` command, bottle side-currency | Milk |
+| [Currency-and-Milk-Inventory](Infrastructure/Currency-and-Milk-Inventory.md) | `MilkBottle` model, `Profile.milkInventory`, `ChateauCurrency` constants, `!sell` command, bottle side-currency | Milk, Bottle-Consumption-And-Transfer |
+| [Bottle-Consumption-And-Transfer](Bottle-Consumption-And-Transfer.md) | Bottle serial numbers + `BottleInventory` selection, persistent empties, `!bottles`, `!drink`, bottle transfer through `!pay`, `SelfCommandStatusEffects` | Milk |
 
 ### Reporting
 
@@ -24,7 +25,7 @@ Design + as-implemented documentation for the Chateau Contract interaction syste
 
 | Spec | Reversal | Depends on |
 |------|----------|------------|
-| [Milk](Milk.md) | none (sold via `!sell`) | Currency-and-Milk-Inventory, Status-Effect-Hook |
+| [Milk](Milk.md) | none (sold via `!sell`, drunk via `!drink`) | Currency-and-Milk-Inventory, Status-Effect-Hook |
 
 ### Commitment
 


### PR DESCRIPTION
Closes the loop on the milk-bottle economy. Before this, `!milk` filled `milkInventory` and `!sell` was the only thing that ever read it: residents could not see what they owned and could not do anything with it but cash it out. A bottle's `corruptionTag` moved its sell price and nothing else.

## Bottle serial numbers

Every physical bottle gets a globally unique number from an atomic `Counters` document, claimed one block per milking. A serial names one bottle, so aggregated `quantity > 1` entries are split into one entry per bottle. `quantity` is retained on the model only so pre-migration documents still deserialize.

Global rather than a per-collection index because **`!pay` has a consent gap**. An index renumbers when you drink or sell, so the handle a payer typed could name a different bottle by the time the recipient answers. Serials are stable in anyone's collection forever, which also lets the consent-time recheck ask an exact question instead of re-running a filter.

## Empties keep their serial

Drinking stamps `emptiedAt` rather than deleting the bottle, so the number stays as proof of what was drunk. Selling still hands the bottle to the Chateau and retires the number.

| | Copper | `bottle` currency | Serial |
|---|---|---|---|
| `!sell` | substance value | +1 | leaves the collection |
| `!drink` | none | none | **stays, as an empty** |

That makes the two a real choice rather than two spellings of the same thing, and deliberately depreciates the `bottle` side-currency. `!sell` and the self-milk shortcut still credit it so existing balances are not stranded.

## `!bottles`

Private view of the collection: serials, donors, corrupt/pure tags, sell values, then the numbered empties. Same argument shape and same newest-first ordering as `!sell`, so the top line is what `!sell` and `!drink` act on next. Aliases: `!collection`.

## `!drink`

Channel-only, because its effects are things the channel is meant to witness and `!dose` already promises everyone will know when a craving is satisfied. Empties one bottle and applies three effects:

- **Corruption transfer** from the bottle's tag (±1), bounded by a 3/day budget under its own `drinkshift_` key so it never draws from the per-pair `!corrupt` quota. That budget is the load-bearing balance lever once transfer lets bottles be pooled.
- **Craving satisfaction** — the first route that does not need a second consenting resident. Reaching the status contributors from a command with no consent flow needed a public seam, added as `SelfCommandStatusEffects`; `!detox` and `!wash` can use it later.
- **Addiction risk**, a 10% intensify-only roll.

Aliases: `!imbibe`, `!swig`.

> **Design correction.** The approved design said the addiction roll was skipped when the drink satisfied a craving. That makes it unreachable: only an existing vice can intensify, and an existing vice is exactly what satisfaction requires, so the two conditions have no overlap. It now fires regardless, so a bottle quiets the want and tightens the hook at once. Documented in the spec's §3c.

## Bottle transfer through `!pay`

```
!pay [user]Bob[/user] 3 bottles {substance}
!pay [user]Bob[/user] bottles #142 #143
!pay [user]Bob[/user] -2 bottles
```

Bottles are not a currency bucket, so they cannot ride the atomic debit. Instead a request resolves to concrete serials at command time and those are re-checked at consent. A bottle **drunk** during the gap is still there under the same number but is an empty now, and nobody consented to an empty, so the transfer aborts rather than substituting. A partial mismatch moves nothing at all. Serial, donor, timestamp and tag all survive the handoff, so a bottle from a corrupt donor still corrupts whoever drinks it three owners later.

The `bottles` keyword was free because `bottle` is not a currency-category identifier.

## Incidental fixes

- `!sell` told residents to *"Use !bank or your !dossier to review what you've got bottled up"* when neither showed bottles.
- `!sell` rendered the donor's stored `userName` rather than their `displayName`, against the style guide.

## Migration

`scripts/backfill-bottle-serials.js` **has already been applied to the live `ChateauDb`** (2026-07-29): 35 bottles across 5 residents, serials #1-#35 assigned oldest-first Chateau-wide so a low number genuinely means an old bottle. Verified afterward: all numbered, all `quantity: 1`, contiguous and unique, no invented empties, corruption tags preserved, counter at 35.

The script is committed with `DRY_RUN = true` and refuses to re-run once serials exist. It also aborts and lists the server's databases if the target has no profiles, so a wrong `DB_NAME` cannot masquerade as a clean run.

## Testing

1768 passing (1692 before, 76 new) across five new files: `Bottleinventorytests`, `Chateaubottlestests`, `Chateaudrinktests`, `Bottleserialtests`, `Bottlepaymenttests`. Coverage includes the consent-gap abort paths, the daily budget boundary, empties never being implicitly selected, and serial uniqueness across many claims.

## Reviewer notes

- Three user-facing strings were added during implementation that were not in the approved draft, all created by persistent empties: the only-empties `!bottles` view, the everything-is-empty `!drink` refusal, and the empty-bottle flag on transfer consent prompts. Flagged in the spec.
- Worth confirming against live Mongo that nobody has since added a `bottle` currency identifier; if they have, `!pay X 3 bottle` would route to bottle transfer instead of paying that currency.
- Separately: [scripts/backfill-employee-earnings.js](scripts/backfill-employee-earnings.js) has the same wrong `DB_NAME = "chateau"` default this script had. If it was ever run as-shipped it wrote to a non-existent database and that backfill never landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
