### PR TITLE
Standardize readout BBCode behind a ReadoutText grammar

### DIFF
--- a/FChatDicebot.Tests/Unit/Bodyparteicontests.cs
+++ b/FChatDicebot.Tests/Unit/Bodyparteicontests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands;
+﻿using FChatDicebot.BotCommands;
 using FChatDicebot.Database;
 using FChatDicebot.InteractionProcessors;
 using FChatDicebot.InteractionProcessors.Casual;
@@ -499,7 +499,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string message = ChateauIdentifier.BuildIdentifierMessage(identifier, "Nobody");
 
-            Assert.StartsWith("[b]ass[/b] [eicon]stockbooty[/eicon]\nThe rear end.", message);
+            Assert.StartsWith(ReadoutText.Title("ass") + " [eicon]stockbooty[/eicon]\nThe rear end.", message);
         }
 
         [Fact]
@@ -514,7 +514,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string message = ChateauIdentifier.BuildIdentifierMessage(identifier, "Nobody");
 
-            Assert.StartsWith("[b]ass[/b]\nThe rear end.", message);
+            Assert.StartsWith(ReadoutText.Title("ass") + "\nThe rear end.", message);
         }
 
         [Fact]
@@ -530,7 +530,7 @@ namespace FChatDicebot.Tests.Unit.InteractionProcessors
 
             string message = ChateauIdentifier.BuildIdentifierMessage(identifier, "Alice");
 
-            Assert.EndsWith("\n[i]Your personal eicon: [eicon]MyBooty[/eicon][/i]", message);
+            Assert.EndsWith("\n" + ReadoutText.Small("Your personal eicon: [eicon]MyBooty[/eicon]"), message);
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Chateaubondtreetests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubondtreetests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Support;
+﻿using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using FChatDicebot.Tests.Builders;
 using System;
@@ -98,10 +98,11 @@ namespace FChatDicebot.Tests.Unit
 
             string result = BondTreeSupport.BuildBondTree("Alice", 1, familyOnly: false, Lookup);
 
-            Assert.Contains("Bond tree for Alice, up to 1 degree:", result);
-            Assert.Contains("1st degree:", result);
-            Assert.Contains("Bob (Alice's pet)", result);     // initiated → BondToText(type, true)
-            Assert.Contains("Dom (Alice's dominant)", result); // received  → BondToText(type, false)
+            Assert.Contains(ReadoutText.Title("Bond Tree of Alice"), result);
+            Assert.Contains("Up to 1 degree", result);
+            Assert.Contains(ReadoutText.Section("1st degree", ReadoutDomain.Relationship), result);
+            Assert.Contains("Bob [sub](Alice's pet)[/sub]", result);     // initiated → BondToText(type, true)
+            Assert.Contains("Dom [sub](Alice's dominant)[/sub]", result); // received  → BondToText(type, false)
         }
 
         // ---- Second degree + dedup to shallowest ---------------------------
@@ -123,11 +124,11 @@ namespace FChatDicebot.Tests.Unit
 
             string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
 
-            Assert.Contains("Carol (Alice's ally)", result);  // reached at 1st degree, via Alice
-            Assert.DoesNotContain("Carol (Bob's", result);    // never the 2nd-degree label
-            Assert.Equal(1, Count(result, "Carol ("));        // appears exactly once
-            Assert.Contains("2nd degree:", result);
-            Assert.Contains("Dave (Bob's sibling)", result);  // genuine 2nd-degree node
+            Assert.Contains("Carol [sub](Alice's ally)[/sub]", result);  // reached at 1st degree, via Alice
+            Assert.DoesNotContain("Carol [sub](Bob's", result);    // never the 2nd-degree label
+            Assert.Equal(1, Count(result, "Carol [sub]("));        // appears exactly once
+            Assert.Contains(ReadoutText.Section("2nd degree", ReadoutDomain.Relationship), result);
+            Assert.Contains("Dave [sub](Bob's sibling)[/sub]", result);  // genuine 2nd-degree node
         }
 
         // ---- Cycles --------------------------------------------------------
@@ -150,9 +151,9 @@ namespace FChatDicebot.Tests.Unit
             string result = BondTreeSupport.BuildBondTree("A", 3, familyOnly: false, Lookup);
 
             // Each non-root node appears exactly once; the root is never listed as a connection.
-            Assert.Equal(1, Count(result, "B (A's ally)"));
-            Assert.Equal(1, Count(result, "C (A's ally)"));
-            Assert.DoesNotContain("A (", result);
+            Assert.Equal(1, Count(result, "B [sub](A's ally)[/sub]"));
+            Assert.Equal(1, Count(result, "C [sub](A's ally)[/sub]"));
+            Assert.DoesNotContain(ReadoutText.RowIndent + "A [sub](", result);
         }
 
         // ---- Family-only filter --------------------------------------------
@@ -213,7 +214,7 @@ namespace FChatDicebot.Tests.Unit
 
             string result = BondTreeSupport.BuildBondTree("Alpha", 5, familyOnly: false, Lookup);
 
-            Assert.Contains("up to 3 degrees:", result);
+            Assert.Contains("Up to 3 degrees", result);
             Assert.Contains("Bravo", result);
             Assert.Contains("Charlie", result);
             Assert.Contains("Delta", result);
@@ -237,8 +238,8 @@ namespace FChatDicebot.Tests.Unit
 
             string result = BondTreeSupport.BuildBondTree("Alice", 2, familyOnly: false, Lookup);
 
-            Assert.Contains("Ghost (Alice's pet)", result); // falls back to the stored userName
-            Assert.Contains("Bob (Alice's sibling)", result); // traversal still reaches the rest
+            Assert.Contains("Ghost [sub](Alice's pet)[/sub]", result); // falls back to the stored userName
+            Assert.Contains("Bob [sub](Alice's sibling)[/sub]", result); // traversal still reaches the rest
         }
     }
 }

--- a/FChatDicebot.Tests/Unit/Chateaubottlestests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubottlestests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot;
+﻿using FChatDicebot;
 using FChatDicebot.BotCommands;
 using FChatDicebot.Database;
 using FChatDicebot.Model;
@@ -48,9 +48,9 @@ namespace FChatDicebot.Tests.Unit
 
             string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
 
-            Assert.Contains("[b]2 bottles[/b]", text);
+            Assert.Contains("[b]2[/b] bottles", text);
             Assert.Contains("#11, #12", text);
-            Assert.Contains(ChateauCurrency.StandardBottlePrice + " " + ChateauCurrency.SellPayoutCurrency + " each", text);
+            Assert.Contains(ReadoutText.Num(ChateauCurrency.StandardBottlePrice) + " " + ChateauCurrency.SellPayoutCurrency + " each", text);
         }
 
         [Fact]
@@ -78,9 +78,9 @@ namespace FChatDicebot.Tests.Unit
 
             string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
 
-            Assert.Contains("[b]1 bottle[/b]", text);
-            Assert.Contains("[b]" + ChateauCurrency.StandardBottlePrice + " "
-                + ChateauCurrency.SellPayoutCurrency + "[/b] if you choose to !sell", text);
+            Assert.Contains("[b]1[/b] bottle", text);
+            Assert.Contains(ReadoutText.Num(ChateauCurrency.StandardBottlePrice) + " "
+                + ChateauCurrency.SellPayoutCurrency + " if you choose to !sell", text);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace FChatDicebot.Tests.Unit
             string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
 
             Assert.DoesNotContain("0 bottles", text);
-            Assert.Contains("[b]1 empty[/b]", text);
+            Assert.Contains("[b]1[/b] empty", text);
             Assert.Contains("#12", text);
         }
 
@@ -109,7 +109,7 @@ namespace FChatDicebot.Tests.Unit
 
             string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
 
-            Assert.Contains("Empties: #12", text);
+            Assert.Contains(ReadoutText.Section("Empties", ReadoutDomain.Economy) + " #12", text);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace FChatDicebot.Tests.Unit
                 .WithMilkBottle(Bottle(11, "cum", "Bob", hour: 1))
                 .Build();
 
-            Assert.DoesNotContain("Empties:", ChateauBottles.BuildCollectionText(_database, profile, null, null));
+            Assert.DoesNotContain("Empties", ChateauBottles.BuildCollectionText(_database, profile, null, null));
         }
 
         [Fact]
@@ -161,8 +161,9 @@ namespace FChatDicebot.Tests.Unit
             string text = ChateauBottles.BuildCollectionText(_database, profile, null, null);
 
             // Three separate milkings collapse into one readable line.
+            // Title, lead-in, the one group line, footer.
             Assert.Contains("#11, #12, #13", text);
-            Assert.Equal(3, text.Split('\n').Length);
+            Assert.Equal(4, text.Split('\n').Length);
         }
 
         [Fact]
@@ -185,8 +186,8 @@ namespace FChatDicebot.Tests.Unit
 
             string line = ChateauBank.BuildCollectionLine(profile, ownAccount: true);
 
-            Assert.Contains("[b]1 bottle[/b]", line);
-            Assert.Contains("[b]1 empty[/b]", line);
+            Assert.Contains("[b]1[/b] bottle", line);
+            Assert.Contains("[b]1[/b] empty", line);
             Assert.Contains("!bottles", line);
         }
 

--- a/FChatDicebot.Tests/Unit/Chateaubusinesstests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaubusinesstests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands;
+﻿using FChatDicebot.BotCommands;
 using FChatDicebot.Model;
 using FChatDicebot.Tests.Builders;
 using System;
@@ -115,8 +115,8 @@ namespace FChatDicebot.Tests.Unit
 
             string output = ChateauBusiness.BuildBusiness(profile, un => "Alice");
 
-            Assert.Contains("Alice: [b]42 copper[/b]", output);
-            Assert.Contains("Total earned from all employees: [b]42 copper[/b]", output);
+            Assert.Contains("[u]Alice:[/u] Copper: [b]42[/b]", output);
+            Assert.Contains(ReadoutText.Section("Total from all employees", ReadoutDomain.Economy) + " Copper: [b]42[/b]", output);
         }
 
         [Fact]
@@ -138,11 +138,11 @@ namespace FChatDicebot.Tests.Unit
             Assert.True(iAlice < iBob, "Higher earner Alice should render before Bob");
 
             // Currencies within a row are alphabetical.
-            Assert.Contains("Alice: [b]42 copper[/b] | [b]3 silver[/b]", output);
-            Assert.Contains("Bob: [b]18 copper[/b]", output);
+            Assert.Contains("[u]Alice:[/u] Copper: [b]42[/b]" + ReadoutText.InlineSeparator + "Silver: [b]3[/b]", output);
+            Assert.Contains("[u]Bob:[/u] Copper: [b]18[/b]", output);
 
             // Grand totals sum across employees, per currency.
-            Assert.Contains("Total earned from all employees: [b]60 copper[/b] | [b]3 silver[/b]", output);
+            Assert.Contains(ReadoutText.Section("Total from all employees", ReadoutDomain.Economy) + " Copper: [b]60[/b]" + ReadoutText.InlineSeparator + "Silver: [b]3[/b]", output);
         }
 
         [Fact]
@@ -158,10 +158,10 @@ namespace FChatDicebot.Tests.Unit
             var names = new Dictionary<string, string> { { "alice", "Alice" }, { "bob", "Bob" } };
             string output = ChateauBusiness.BuildBusiness(profile, un => names[un]);
 
-            Assert.Contains("Alice: [b]10 copper[/b]", output);
+            Assert.Contains("[u]Alice:[/u] Copper: [b]10[/b]", output);
             Assert.DoesNotContain("silver", output);
             Assert.DoesNotContain("Bob", output);
-            Assert.Contains("Total earned from all employees: [b]10 copper[/b]", output);
+            Assert.Contains(ReadoutText.Section("Total from all employees", ReadoutDomain.Economy) + " Copper: [b]10[/b]", output);
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace FChatDicebot.Tests.Unit
             // Resolver returns null (profile gone) -> the stored userName key is shown.
             string output = ChateauBusiness.BuildBusiness(profile, un => null);
 
-            Assert.Contains("ghost_user: [b]5 copper[/b]", output);
+            Assert.Contains("[u]ghost_user:[/u] Copper: [b]5[/b]", output);
         }
     }
 }

--- a/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands;
+﻿using FChatDicebot.BotCommands;
 using FChatDicebot.Model;
 using FChatDicebot.Tests.Builders;
 using FChatDicebot.Tests.Fixtures;
@@ -336,7 +336,7 @@ namespace FChatDicebot.Tests.Unit
 
             // Assert
             Assert.NotEmpty(result);
-            Assert.Contains("Experience", result);
+            Assert.Contains("Days of experience", result);
             Assert.Contains("5", result);
             Assert.Contains("3", result);
         }
@@ -536,8 +536,8 @@ namespace FChatDicebot.Tests.Unit
 
             Assert.Contains("Currently employs", result);
             // Roles are pluralised by headcount and name their employees, mirroring Bonds.
-            Assert.Contains("[u]Maids:[/u] Worker 1, Worker 2", result);
-            Assert.Contains("[u]Cook:[/u] Other", result);
+            Assert.Contains(ReadoutText.RowIndent + "[u]Maids:[/u] Worker 1, Worker 2", result);
+            Assert.Contains(ReadoutText.RowIndent + "[u]Cook:[/u] Other", result);
             // Two roles is under the threshold, so nothing is hidden.
             Assert.DoesNotContain("[spoiler]", result);
         }
@@ -581,7 +581,7 @@ namespace FChatDicebot.Tests.Unit
             string result = InvokeBuildCurrentlyEmploysSection("Boss");
 
             // 7 roles is past the threshold: header and scale stay visible, detail collapses.
-            Assert.Contains("[b]Currently employs:[/b] 7 residents across 7 roles [spoiler]", result);
+            Assert.Contains(ReadoutText.Section("Currently employs", ReadoutDomain.Relationship) + " 7 residents across 7 roles [spoiler]", result);
             Assert.EndsWith("[/spoiler]\n", result);
             // Every employee is still present inside the spoiler — collapsing hides, never truncates.
             foreach (string job in jobs)
@@ -608,7 +608,7 @@ namespace FChatDicebot.Tests.Unit
 
             // Biggest team leads, and names within a role read alphabetically.
             Assert.True(result.IndexOf("Maids:") < result.IndexOf("Cook:"));
-            Assert.Contains("[u]Maids:[/u] Alice, Mabel, Zara", result);
+            Assert.Contains(ReadoutText.RowIndent + "[u]Maids:[/u] Alice, Mabel, Zara", result);
         }
 
         [Fact]
@@ -630,7 +630,7 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildTitlesEarnedSection(updated);
 
-            Assert.Contains("Titles earned", result);
+            Assert.Contains("Titles Earned", result);
             Assert.Contains("3", result);
         }
 
@@ -646,7 +646,7 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildMostAbundantCurrencySection(profile);
 
-            Assert.Contains("Most abundant currency", result);
+            Assert.Contains("Richest Currency", result);
             Assert.Contains("5", result);
             Assert.Contains("lustessence", result);
         }
@@ -793,8 +793,8 @@ namespace FChatDicebot.Tests.Unit
             string result = InvokeBuildJobExperienceSection(profile);
 
             Assert.Equal(1, result.Split('\n').Length - 1); // exactly one trailing newline
-            Assert.Contains("[u]Maid:[/u] 5", result);
-            Assert.Contains("[u]Cook:[/u] 3", result);
+            Assert.Contains("[u]Maid:[/u] [b]5[/b]", result);
+            Assert.Contains("[u]Cook:[/u] [b]3[/b]", result);
             Assert.DoesNotContain("[spoiler]", result);
         }
 
@@ -809,7 +809,7 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildCasualInteractionsSection(profile);
 
-            Assert.EndsWith("10\n", result);
+            Assert.EndsWith("[b]10[/b]\n", result);
         }
 
         [Fact]
@@ -851,9 +851,9 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildOffspringSection(profile, "TestUser");
 
-            Assert.StartsWith("[b]Offspring:[/b]", result);
-            Assert.Contains("[u]Sired:[/u] Ogres: 4", result);
-            Assert.Contains("[u]Birthed:[/u] Goblins: 5", result);
+            Assert.StartsWith(ReadoutText.Section("Offspring", ReadoutDomain.Record), result);
+            Assert.Contains("[u]Sired:[/u] Ogres: [b]4[/b]", result);
+            Assert.Contains("[u]Birthed:[/u] Goblins: [b]5[/b]", result);
             Assert.Equal(1, result.Split('\n').Length - 1);
         }
 
@@ -868,7 +868,7 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildOffspringSection(profile, "TestUser");
 
-            Assert.Contains("[u]Birthed:[/u] Goblins: 5", result);
+            Assert.Contains("[u]Birthed:[/u] Goblins: [b]5[/b]", result);
             Assert.DoesNotContain("Sired", result);
         }
 
@@ -885,8 +885,8 @@ namespace FChatDicebot.Tests.Unit
 
             string result = InvokeBuildAtAGlanceSection(_fixture.Database.GetProfile("TestUser"));
 
-            Assert.Contains("[b]Titles earned:[/b] 1", result);
-            Assert.Contains("[b]Most abundant currency:[/b] 12 gold", result);
+            Assert.Contains("[u]Titles Earned:[/u] [b]1[/b]", result);
+            Assert.Contains("[u]Richest Currency:[/u] [b]12[/b] gold", result);
             Assert.Equal(1, result.Split('\n').Length - 1);
         }
 
@@ -964,7 +964,7 @@ namespace FChatDicebot.Tests.Unit
             // Employs is a roster now, so it sits with the relationship blocks rather than
             // among the numeric tallies.
             Assert.True(result.IndexOf("Currently employs") < result.IndexOf("Casual interactions"));
-            Assert.True(result.IndexOf("Casual interactions") < result.IndexOf("Days of [b]Experience[/b]"));
+            Assert.True(result.IndexOf("Casual interactions") < result.IndexOf("Days of experience"));
         }
 
         [Fact]

--- a/FChatDicebot.Tests/Unit/Chateaustatisticstests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaustatisticstests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands;
+﻿using FChatDicebot.BotCommands;
 using FChatDicebot.BotCommands.Support;
 using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
@@ -56,19 +56,22 @@ namespace FChatDicebot.Tests.Unit
                 corruptInteractions: new List<Interaction>(),
                 purifyInteractions: new List<Interaction>());
 
-            // Section headers always show, but the zero-count rows beneath them are hidden.
-            Assert.Contains("Population", result);
-            Assert.Contains("Influence", result);
-            Assert.Contains("Workforce", result);
+            // A section with no qualifying rows is hidden entirely, header included — a bare
+            // "Influence" heading introducing nothing is worse than no heading at all.
+            Assert.DoesNotContain("Population", result);
+            Assert.DoesNotContain("Influence", result);
+            Assert.DoesNotContain("Workforce", result);
+            // The title line and the drill-down pointers still stand on their own.
+            Assert.Contains("The Chateau at a Glance", result);
             Assert.Contains("!flora", result);
             Assert.DoesNotContain("Converted to Monsterkind", result);
-            Assert.DoesNotContain("Monsters birthed", result);
-            Assert.DoesNotContain("Parasites spread", result);
-            Assert.DoesNotContain("Climaxes recorded", result);
+            Assert.DoesNotContain("Monsters Birthed", result);
+            Assert.DoesNotContain("Parasites Spread", result);
+            Assert.DoesNotContain("Climaxes Recorded", result);
             Assert.DoesNotContain("Corruption Cultivated", result);
             Assert.DoesNotContain("Balanced, as all things should be", result);
-            Assert.DoesNotContain("Total employees", result);
-            Assert.DoesNotContain("Most earned currencies", result);
+            Assert.DoesNotContain("Total Employees", result);
+            Assert.DoesNotContain("Most Earned", result);
         }
 
         [Fact]
@@ -99,17 +102,17 @@ namespace FChatDicebot.Tests.Unit
                 corruptInteractions, purifyInteractions);
 
             // Two monsterized, both goblins — most common: goblin.
-            Assert.Contains("Converted to Monsterkind: 2 (most common: goblin)", result);
+            Assert.Contains("[u]Converted to Monsterkind:[/u] [b]2[/b] [sub](most common: goblin)[/sub]", result);
             // Birthed total only from monster:* rows, not category:*. Should be 30 + 4 = 34.
-            Assert.Contains("Monsters birthed: 34 (most bred: goblin)", result);
+            Assert.Contains("[u]Monsters Birthed:[/u] [b]34[/b] [sub](most bred: goblin)[/sub]", result);
             // Corruption ahead by 4.
             Assert.Contains("Corruption Conquers Purity by 4", result);
             // Workforce totals.
-            Assert.Contains("Total employees: 2", result);
-            Assert.Contains("Duties completed: 7", result);
+            Assert.Contains("[u]Total Employees:[/u] [b]2[/b]", result);
+            Assert.Contains("[u]Duties Completed:[/u] [b]7[/b]", result);
             // Top currencies — silvercoin > gold by raw count.
-            Assert.Contains("Silvercoin: 1,000", result);
-            Assert.Contains("Gold: 150", result);
+            Assert.Contains("Silvercoin: [b]1,000[/b]", result);
+            Assert.Contains("Gold: [b]150[/b]", result);
         }
 
         [Fact]

--- a/FChatDicebot/BotCommands/BotInfo.cs
+++ b/FChatDicebot/BotCommands/BotInfo.cs
@@ -39,14 +39,16 @@ namespace FChatDicebot.BotCommands
                 onlineTime = DoubleTime.GetCurrentTimestampSeconds() - bot.DiscordLoginTime;
             }
 
-            string resultMessageString = "Chateau Contract Bot was developed by [user]Queen Contract[/user] as an adaptation of Dice Bot, developed by [user]Ambitious Syndra[/user]"
-                + "\nCurrent version " + BotMain.Version
-                + "\nCurrently operating in " + channelsNumber + " channels."
-                + "\nOnline for " + DoubleTime.PrintTimeFromSeconds(onlineTime)
-                + "\nCurrent Game Sessions Active: " + (bot.DiceBot.GameSessions != null? bot.DiceBot.GameSessions.Count() : 0)
-                + "\nCurrent Chip Piles Recorded: " + (bot.DiceBot.ChipPiles != null ? bot.DiceBot.ChipPiles.Count() : 0)
-                + "\nCurrent Tables Recorded: " + (bot.SavedTables != null ? bot.SavedTables.Count() : 0)
-                + "\nFor a list of dice commands, use !dicehelp. See the profiles [user]Chateau Contract[/user] and [user]Dice Bot[/user] for more detailed information (this bot may not be up to date with Dice Bot)";
+            string resultMessageString = Model.ReadoutText.Title("Chateau Contract Bot")
+                + "\nDeveloped by [user]Queen Contract[/user] as an adaptation of Dice Bot, developed by [user]Ambitious Syndra[/user]"
+                + "\n" + Model.ReadoutText.Section("Status", Model.ReadoutDomain.Reference)
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Version", Model.ReadoutText.Num(BotMain.Version))
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Channels", Model.ReadoutText.Num(channelsNumber))
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Online For", Model.ReadoutText.Num(DoubleTime.PrintTimeFromSeconds(onlineTime)))
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Game Sessions Active", Model.ReadoutText.Num(bot.DiceBot.GameSessions != null ? bot.DiceBot.GameSessions.Count() : 0))
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Chip Piles Recorded", Model.ReadoutText.Num(bot.DiceBot.ChipPiles != null ? bot.DiceBot.ChipPiles.Count() : 0))
+                + "\n" + Model.ReadoutText.RowIndent + Model.ReadoutText.Row("Tables Recorded", Model.ReadoutText.Num(bot.SavedTables != null ? bot.SavedTables.Count() : 0))
+                + "\n" + Model.ReadoutText.Footer("For a list of dice commands, use !dicehelp. See the profiles [user]Chateau Contract[/user] and [user]Dice Bot[/user] for more detailed information (this bot may not be up to date with Dice Bot)");
 
             if (!commandController.MessageCameFromChannel(address))
             {

--- a/FChatDicebot/BotCommands/ChateauBank.cs
+++ b/FChatDicebot/BotCommands/ChateauBank.cs
@@ -67,10 +67,16 @@ namespace FChatDicebot.BotCommands
                         selfEmployed = true;
                     }
                 }
+                // Every readout opens with a Title line naming whose it is. Deliberately the
+                // displayName rather than "Your" even when you're reading your own: displayName
+                // carries the "[s]old[/s] new" form after a rename, so the title doubles as a
+                // reminder of who the Chateau currently has you filed under.
+                bankText = ReadoutText.Title("Account of " + profile.displayName) + "\n";
+
                 if (profile.currencies == null || profile.currencies.Count == 0)
                 {
                     // No currencies - build appropriate message based on situation
-                    bankText = ownAccount
+                    bankText += ownAccount
                         ? "It doesn't look like you're storing any currency in our vault yet."
                         : $"It doesn't look like {profile.displayName} is storing any currency in our vault.";
 
@@ -110,22 +116,25 @@ namespace FChatDicebot.BotCommands
 
                     if (profile.characteristics.ContainsKey("job")) //has currencies and a job
                     {
-                        bankText = "Our records show ";
+                        bankText += "Our records show ";
                         bankText += selfEmployed
                             ? (ownAccount ? "you are self-employed" : $"{profile.displayName} is self-employed")
                             : (ownAccount ? $"you are employed by {employerDisplayName}" : $"{profile.displayName} is employed by {employerDisplayName}");
-                        bankText += " as " + Utils.AnOrA(Utils.JobToText(profile.characteristics["job"])) + " " + Utils.JobToText(profile.characteristics["job"]) + ". ";
+                        bankText += " as " + Utils.AnOrA(Utils.JobToText(profile.characteristics["job"])) + " [b]" + Utils.JobToText(profile.characteristics["job"]) + "[/b]. ";
                     }
                     bankText += ownAccount
                         ? "Through your hard !work and !volunteer efforts, as well as other exploits, you have amassed:\n"
                         : $"{profile.displayName}'s account contains:\n";
 
-                    var alphabatizedCurrencyList = profile.currencies.OrderBy(kv => kv.Key).ToList();
-                    foreach (var currency in alphabatizedCurrencyList)
-                    {
-                        bankText += $"[b]{currency.Value} {currency.Key}[/b] | ";
-                    }
-                    bankText = bankText.TrimEnd(' ', '|');
+                    // Was a pipe-separated run of "[b]340 gold[/b]" cells, which bolded the
+                    // whole phrase and put the label after the number — the inverse of every
+                    // other readout. Now label-then-bold-number, on the shared separator.
+                    var currencyCells = profile.currencies
+                        .OrderBy(kv => kv.Key)
+                        .Select(kv => ReadoutText.Row(Utils.Capitalize(kv.Key), ReadoutText.Num(kv.Value)))
+                        .ToList();
+                    bankText += ReadoutText.InlineSection("In the vault", ReadoutDomain.Economy, currencyCells)
+                        .TrimEnd('\n');
                 }
 
                 // Bottles live outside the vault, so they hang off both branches: a resident with
@@ -151,13 +160,14 @@ namespace FChatDicebot.BotCommands
             if (full == 0 && empty == 0) return string.Empty;
 
             var pieces = new List<string>();
-            if (full > 0) pieces.Add("[b]" + full + " bottle" + (full == 1 ? "" : "s") + "[/b]");
-            if (empty > 0) pieces.Add("[b]" + empty + " empt" + (empty == 1 ? "y" : "ies") + "[/b]");
+            if (full > 0) pieces.Add(ReadoutText.Num(full) + " bottle" + (full == 1 ? "" : "s"));
+            if (empty > 0) pieces.Add(ReadoutText.Num(empty) + " empt" + (empty == 1 ? "y" : "ies"));
             string held = string.Join(" and ", pieces);
 
-            return ownAccount
-                ? $"You're also holding {held} of your own. Use !bottles to look them over."
-                : $"{profile.displayName} is also holding {held}.";
+            // Bottles sit outside the vault, so they get their own section rather than trailing
+            // the currency line as loose prose.
+            return ReadoutText.Section("Held personally", ReadoutDomain.Economy) + " " + held
+                + (ownAccount ? "\n" + ReadoutText.Footer("Use !bottles to look them over, or !sell to trade them in.") : "");
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauBirthrates.cs
+++ b/FChatDicebot/BotCommands/ChateauBirthrates.cs
@@ -70,18 +70,22 @@ namespace FChatDicebot.BotCommands
             }
 
             var sb = new System.Text.StringBuilder();
+            sb.Append(ReadoutText.Title("Births of the Chateau")).Append('\n');
             sb.Append("Monsters born to the Chateau:\n");
             foreach (var entry in offspring.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
             {
                 if (entry.Value <= 0) continue;
                 int preg = pregnancies.ContainsKey(entry.Key) ? pregnancies[entry.Key] : 0;
-                sb.Append("  ").Append(Utils.Capitalize(entry.Key)).Append(": ")
-                  .Append(entry.Value.ToString("N0", CultureInfo.InvariantCulture))
-                  .Append(" offspring across ")
-                  .Append(preg.ToString("N0", CultureInfo.InvariantCulture))
-                  .Append(preg == 1 ? " pregnancy\n" : " pregnancies\n");
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(Utils.Capitalize(entry.Key),
+                      ReadoutText.Num(entry.Value.ToString("N0", CultureInfo.InvariantCulture))
+                      + " offspring across "
+                      + ReadoutText.Num(preg.ToString("N0", CultureInfo.InvariantCulture))
+                      + (preg == 1 ? " pregnancy" : " pregnancies")))
+                  .Append('\n');
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("See !statistics for the Chateau-wide overview."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauBottles.cs
+++ b/FChatDicebot/BotCommands/ChateauBottles.cs
@@ -79,47 +79,53 @@ namespace FChatDicebot.BotCommands
             }
 
             var lines = new List<string>();
+            // "Bottle Collection" rather than bare "Collection" so it doesn't read as a
+            // collection of residents.
+            lines.Add(ReadoutText.Title("Bottle Collection of " + profile.displayName));
 
             // A resident who has drunk everything they own still has a collection worth
             // showing, but "you're holding 0 bottles" would be a strange way to open it.
             if (full.Count == 0)
             {
                 string emptyWord = empties.Count == 1 ? "empty" : "empties";
-                lines.Add("Nothing left to drink, but our records show you're keeping [b]"
-                    + empties.Count + " " + emptyWord + "[/b]:");
-                lines.Add(BottleInventory.FormatSerials(
+                lines.Add("Nothing left to drink, but our records show you're keeping "
+                    + ReadoutText.Num(empties.Count) + " " + emptyWord + ":");
+                lines.Add(ReadoutText.RowIndent + BottleInventory.FormatSerials(
                     empties.Select(b => b.serial), ChateauCurrency.BottleSerialDisplayCap));
-                lines.Add("Go !milk a willing resident if you'd like something to drink.");
+                lines.Add(ReadoutText.Footer("Go !milk a willing resident if you'd like something to drink."));
                 return string.Join("\n", lines);
             }
 
             string bottleWord = full.Count == 1 ? "bottle" : "bottles";
-            lines.Add("Our records show you're holding [b]" + full.Count + " " + bottleWord + "[/b]:");
+            lines.Add("Our records show you're holding " + ReadoutText.Num(full.Count) + " " + bottleWord + ":");
 
             int totalValue = 0;
             foreach (var group in BottleInventory.Group(full))
             {
                 int pricePer = ChateauCurrency.GetSellPricePerBottle(group.Substance, group.CorruptionTag);
                 totalValue += pricePer * group.Count;
-                lines.Add(BuildGroupLine(database, group, pricePer));
+                lines.Add(ReadoutText.RowIndent + BuildGroupLine(database, group, pricePer));
             }
 
             if (empties.Count > 0)
             {
-                lines.Add("Empties: " + BottleInventory.FormatSerials(
-                    empties.Select(b => b.serial), ChateauCurrency.BottleSerialDisplayCap));
+                lines.Add(ReadoutText.Section("Empties", ReadoutDomain.Economy) + " "
+                    + BottleInventory.FormatSerials(
+                        empties.Select(b => b.serial), ChateauCurrency.BottleSerialDisplayCap));
             }
 
-            lines.Add("That's [b]" + totalValue + " " + ChateauCurrency.SellPayoutCurrency
-                + "[/b] if you choose to !sell the lot to the Chateau on the cheap, but someone might be"
-                + " willing to let you !pay them with a few bottles... or you could always have a !drink.");
+            lines.Add(ReadoutText.Footer("That's " + ReadoutText.Num(totalValue) + " " + ChateauCurrency.SellPayoutCurrency
+                + " if you choose to !sell the lot to the Chateau on the cheap, but someone might be"
+                + " willing to let you !pay them with a few bottles... or you could always have a !drink."));
 
             return string.Join("\n", lines);
         }
 
         private static string BuildGroupLine(IChateauDatabase database, BottleInventory.BottleGroup group, int pricePer)
         {
-            string line = "[b]" + Utils.SubstanceToText(group.Substance) + "[/b] from "
+            // Substance is the row's label, so it takes [u] like every other labelled row;
+            // corrupt/pure stay bold because they're a state flag, not a heading.
+            string line = ReadoutText.Label(ReadoutText.CapitalizePastTags(Utils.SubstanceToText(group.Substance))) + " from "
                 + DonorText(database, group.SourceName);
 
             if (group.CorruptionTag == ChateauCurrency.CorruptTag)
@@ -131,8 +137,10 @@ namespace FChatDicebot.BotCommands
                 line += ", [b]pure[/b]";
             }
 
-            line += " | " + BottleInventory.FormatSerials(group.Serials, ChateauCurrency.BottleSerialDisplayCap)
-                + " | " + pricePer + " " + ChateauCurrency.SellPayoutCurrency + " each";
+            line += ReadoutText.InlineSeparator
+                + BottleInventory.FormatSerials(group.Serials, ChateauCurrency.BottleSerialDisplayCap)
+                + ReadoutText.InlineSeparator
+                + ReadoutText.Num(pricePer) + " " + ChateauCurrency.SellPayoutCurrency + " each";
             return line;
         }
 

--- a/FChatDicebot/BotCommands/ChateauBusiness.cs
+++ b/FChatDicebot/BotCommands/ChateauBusiness.cs
@@ -95,12 +95,15 @@ namespace FChatDicebot.BotCommands
 
             var grandTotals = new Dictionary<string, int>();
             var sb = new StringBuilder();
+            sb.Append(ReadoutText.Title("Business of " + profile.displayName)).Append('\n');
             sb.Append("Here's what your employees have earned you:\n");
+            sb.Append(ReadoutText.Section("Earnings by employee", ReadoutDomain.Economy)).Append('\n');
             foreach (EmployeeRow row in rows)
             {
-                sb.Append("  ").Append(row.DisplayName).Append(": ");
-                sb.Append(string.Join(" | ", row.Currencies.Select(c => "[b]" + c.Value + " " + c.Key + "[/b]")));
-                sb.Append('\n');
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(row.DisplayName, string.Join(ReadoutText.InlineSeparator,
+                      row.Currencies.Select(c => Utils.Capitalize(c.Key) + ": " + ReadoutText.Num(c.Value)))))
+                  .Append('\n');
 
                 foreach (var c in row.Currencies)
                 {
@@ -111,10 +114,12 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
-            string totalChips = string.Join(" | ", grandTotals
+            string totalChips = string.Join(ReadoutText.InlineSeparator, grandTotals
                 .OrderBy(c => c.Key, StringComparer.OrdinalIgnoreCase)
-                .Select(c => "[b]" + c.Value + " " + c.Key + "[/b]"));
-            sb.Append("Total earned from all employees: ").Append(totalChips);
+                .Select(c => Utils.Capitalize(c.Key) + ": " + ReadoutText.Num(c.Value)));
+            sb.Append(ReadoutText.Section("Total from all employees", ReadoutDomain.Economy))
+              .Append(' ').Append(totalChips).Append('\n');
+            sb.Append(ReadoutText.Footer("See !payroll for the Chateau-wide workforce, or !bank for your own account."));
 
             return sb.ToString();
         }

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -160,68 +160,20 @@ namespace FChatDicebot.BotCommands
         // (job -> number) was inline while "Currently employs" (job -> number) was one line
         // per job, which is what made a heavy employer's dossier enormous.
         //
-        // A Lines block longer than SpoilerLineThreshold collapses into a [spoiler], with a
-        // count summary left visible so the reader knows the scale without opening it.
-        // Inline blocks are one line by construction and never collapse.
+        // Both shapes now come from ReadoutText, shared with every other readout, so the
+        // dossier's header/label/number conventions can't drift from !bank's or !statistics'
+        // again. Section colours come from the ReadoutDomain passed at each call site.
         // ---------------------------------------------------------------------------
 
-        /// <summary>Row count above which a Lines-shaped section collapses into a spoiler.</summary>
-        public const int SpoilerLineThreshold = 6;
+        /// <summary>
+        /// Row count above which a Lines-shaped section collapses into a spoiler. Forwards to
+        /// the shared grammar; kept as a member so callers and tests can name it on the class
+        /// that owns the behaviour they're exercising.
+        /// </summary>
+        public const int SpoilerLineThreshold = ReadoutText.SpoilerLineThreshold;
 
         /// <summary>Gap between entries in an Inline-shaped section.</summary>
-        private const string InlineSeparator = "   ";
-
-        /// <summary>
-        /// Renders an Inline section: one wrapped row of "label: value" cells under a header.
-        /// <paramref name="header"/> carries its own BBCode and trailing colon. Returns empty
-        /// for an empty cell list so callers can append unconditionally.
-        /// </summary>
-        private static string RenderInlineSection(string header, IList<string> cells)
-        {
-            if (cells == null || cells.Count == 0) return string.Empty;
-            return header + " " + string.Join(InlineSeparator, cells) + "\n";
-        }
-
-        /// <summary>
-        /// Renders a Lines section: one line per row under a header. Past
-        /// <see cref="SpoilerLineThreshold"/> rows the body is wrapped in a spoiler and
-        /// <paramref name="summary"/> (e.g. "23 residents across 11 roles") is shown beside
-        /// the header so the collapsed block still reports its own size.
-        /// </summary>
-        private static string RenderLineSection(string header, string summary, IList<string> rows)
-        {
-            if (rows == null || rows.Count == 0) return string.Empty;
-
-            StringBuilder sb = new StringBuilder();
-            sb.Append(header);
-            if (rows.Count > SpoilerLineThreshold)
-            {
-                if (!string.IsNullOrEmpty(summary))
-                {
-                    sb.Append(' ').Append(summary);
-                }
-                sb.Append(" [spoiler]\n");
-                sb.Append(string.Join("\n", rows));
-                sb.Append("[/spoiler]\n");
-            }
-            else
-            {
-                sb.Append('\n');
-                sb.Append(string.Join("\n", rows));
-                sb.Append('\n');
-            }
-            return sb.ToString();
-        }
-
-        /// <summary>
-        /// Joins the cluster strings that actually produced content, separating each with a
-        /// blank line. Skipping empties is what stops a resident with no active curses from
-        /// getting a stray gap where the state cluster would have been.
-        /// </summary>
-        private static string JoinClusters(params string[] clusters)
-        {
-            return string.Join("\n", clusters.Where(c => !string.IsNullOrEmpty(c)));
-        }
+        private const string InlineSeparator = ReadoutText.InlineSeparator;
 
         /// <summary>
         /// Constructor for dependency injection (for testing)
@@ -323,10 +275,10 @@ namespace FChatDicebot.BotCommands
             if (jobSection.Length == 0 && state.Length == 0 && relationships.Length == 0
                 && tallies.Length == 0 && lately.Length == 0)
             {
-                return identity + "\n[sub]A recent arrival to the Chateau. There doesn't seem to be much in their file... there will be more to read once they interact with others. Maybe you should give them a !kiss[/sub]";
+                return identity + "\n" + ReadoutText.Small("A recent arrival to the Chateau. There doesn't seem to be much in their file... there will be more to read once they interact with others. Maybe you should give them a !kiss");
             }
 
-            return JoinClusters(identity, state, relationships, tallies, lately);
+            return ReadoutText.JoinClusters(identity, state, relationships, tallies, lately);
         }
 
         /// <summary>
@@ -335,7 +287,6 @@ namespace FChatDicebot.BotCommands
         private string BuildNameTitleSpecialties(Profile profile, string targetUser)
         {
             StringBuilder sb = new StringBuilder();
-            sb.Append("[b][u]");
             sb.Append(profile.displayName);
 
             // Compose the header parts in order: optional monster, optional specialist titles.
@@ -375,57 +326,55 @@ namespace FChatDicebot.BotCommands
                 specialistTitles.Add(consequenceSpecialist);
             }
 
-            // Render: "{name} the {monster}; {specialty1} and {specialty2} Specialist"
-            // Each portion is added only when populated; separators glue exactly the parts
-            // present so no trailing "; " or stray "the " can appear.
-            bool anyAfterName = !string.IsNullOrEmpty(monsterPart) || specialistTitles.Count > 0;
-            if (anyAfterName)
-            {
-                sb.Append(" the ");
-            }
+            // Title line is "{name} the {monster}"; the specialist run moves to its own line
+            // below. The deferred-separator handling that stopped a monsterless profile
+            // trailing "the " is preserved — it just has one fewer part to glue now.
             if (!string.IsNullOrEmpty(monsterPart))
             {
-                sb.Append(monsterPart);
-                if (specialistTitles.Count > 0)
+                sb.Append(" the ").Append(monsterPart);
+            }
+
+            // "{specialty1} and {specialty2} Specialist", built the same way as before.
+            StringBuilder specialistRun = new StringBuilder();
+            for (int i = 0; i < specialistTitles.Count; i++)
+            {
+                specialistRun.Append(specialistTitles[i]);
+
+                int remaining = specialistTitles.Count - i;
+                if (remaining == 1)
                 {
-                    sb.Append("; ");
+                    specialistRun.Append(" Specialist");
+                }
+                else if (remaining == 2)
+                {
+                    specialistRun.Append(" and ");
+                }
+                else
+                {
+                    specialistRun.Append(", ");
                 }
             }
+
+            // The name-and-monster line is the readout's Title and takes bold-underline; the
+            // specialist run and the displayed titles get their own lines below it. Previously
+            // all three were inside one [b][u]...[/u][/b], so a decorated resident opened their
+            // dossier with a four-line underlined block that swamped everything under it.
+            StringBuilder header = new StringBuilder();
+            header.Append(ReadoutText.Title(sb.ToString()));
+
             if (specialistTitles.Count > 0)
             {
-                for (int i = 0; i < specialistTitles.Count; i++)
-                {
-                    sb.Append(specialistTitles[i]);
-
-                    int remaining = specialistTitles.Count - i;
-                    if (remaining == 1)
-                    {
-                        sb.Append(" Specialist");
-                    }
-                    else if (remaining == 2)
-                    {
-                        sb.Append(" and ");
-                    }
-                    else
-                    {
-                        sb.Append(", ");
-                    }
-                }
+                header.Append('\n').Append(ReadoutText.Small(specialistRun.ToString()));
             }
 
-            // Add displayed titles
             string displayedTitles = Utils.GetDisplayedTitlesText(profile);
             if (!string.IsNullOrEmpty(displayedTitles))
             {
-                if (anyAfterName)
-                {
-                    sb.AppendLine("");
-                }
-                sb.Append(displayedTitles);
+                header.Append('\n').Append(displayedTitles);
             }
 
-            sb.Append("[/u][/b]\n");
-            return sb.ToString();
+            header.Append('\n');
+            return header.ToString();
         }
 
         /// <summary>
@@ -457,11 +406,13 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
+            // Bold only: bold-underline is reserved for the readout's Title line, so a job
+            // no longer competes with the resident's own name for the eye.
             sb.Append("as ");
             sb.Append(Utils.AnOrA(job));
-            sb.Append(" [b][u]");
-            sb.Append(job);
-            sb.Append("[/u][/b]\n");
+            sb.Append(' ');
+            sb.Append("[b]" + job + "[/b]");
+            sb.Append(".\n");
 
             return sb.ToString();
         }
@@ -481,7 +432,7 @@ namespace FChatDicebot.BotCommands
             }
             // Bare count: the header already names what's being counted, so "7 curses" here
             // would just repeat itself.
-            return RenderLineSection("[b]Active Curses:[/b]", rows.Count.ToString(), rows);
+            return ReadoutText.LineSection("Active curses", ReadoutDomain.Affliction, rows.Count.ToString(), rows);
         }
 
         /// <summary>
@@ -503,8 +454,8 @@ namespace FChatDicebot.BotCommands
                 }
                 rows.Add(row);
             }
-            // Bare count, as with Active Curses — the header already says what these are.
-            return RenderLineSection("[b]Active Parasites:[/b]", rows.Count.ToString(), rows);
+            // Bare count, as with Active curses — the header already says what these are.
+            return ReadoutText.LineSection("Active parasites", ReadoutDomain.Affliction, rows.Count.ToString(), rows);
         }
 
         /// <summary>
@@ -516,10 +467,11 @@ namespace FChatDicebot.BotCommands
         {
             var breaks = BreakInstance.LoadAll(profile);
             List<string> cells = breaks
-                .Select(b => "[u]" + Utils.Capitalize(Utils.BodypartToText(b.Part ?? string.Empty)) + ":[/u] "
-                    + b.Severity + (b.Severity == 1 ? " day left" : " days left"))
+                .Select(b => ReadoutText.Row(
+                    Utils.Capitalize(Utils.BodypartToText(b.Part ?? string.Empty)),
+                    ReadoutText.Num(b.Severity) + (b.Severity == 1 ? " day left" : " days left")))
                 .ToList();
-            return RenderInlineSection("[b]Active Breaks:[/b]", cells);
+            return ReadoutText.InlineSection("Active breaks", ReadoutDomain.Affliction, cells);
         }
 
         /// <summary>
@@ -538,10 +490,11 @@ namespace FChatDicebot.BotCommands
                 string appliedByDisplay = _database.GetDisplayName(s.AppliedBy) ?? s.AppliedBy;
                 string scentPhrase = ScentText.ScentPhrase(scentIdentifier, s.Scent, appliedByDisplay);
 
-                cells.Add("[u]" + Utils.Capitalize(scentPhrase) + ":[/u] "
-                    + s.Layers + (s.Layers == 1 ? " layer" : " layers"));
+                cells.Add(ReadoutText.Row(
+                    Utils.Capitalize(scentPhrase),
+                    ReadoutText.Num(s.Layers) + (s.Layers == 1 ? " layer" : " layers")));
             }
-            return RenderInlineSection("[b]Active Scents:[/b]", cells);
+            return ReadoutText.InlineSection("Active scents", ReadoutDomain.Affliction, cells);
         }
 
         /// <summary>
@@ -565,7 +518,7 @@ namespace FChatDicebot.BotCommands
             string birthed = BuildBirthedSection(profile);
             if (!string.IsNullOrEmpty(sired)) cells.Add(sired);
             if (!string.IsNullOrEmpty(birthed)) cells.Add(birthed);
-            return RenderInlineSection("[b]Offspring:[/b]", cells);
+            return ReadoutText.InlineSection("Offspring", ReadoutDomain.Record, cells);
         }
 
         /// <summary>
@@ -597,9 +550,11 @@ namespace FChatDicebot.BotCommands
             }
             List<string> cells = byPlant
                 .OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key)
-                .Select(kv => "[u]" + (kv.Value == 1 ? Utils.Capitalize(kv.Key) : Utils.Capitalize(kv.Key) + "s") + ":[/u] " + kv.Value)
+                .Select(kv => ReadoutText.Row(
+                    kv.Value == 1 ? Utils.Capitalize(kv.Key) : Utils.Capitalize(kv.Key) + "s",
+                    ReadoutText.Num(kv.Value)))
                 .ToList();
-            return RenderInlineSection("[b]Has personally planted:[/b]", cells);
+            return ReadoutText.InlineSection("Has personally planted", ReadoutDomain.Record, cells);
         }
 
         /// <summary>
@@ -634,13 +589,14 @@ namespace FChatDicebot.BotCommands
             // employer lead; names within a role are alphabetical for a stable read.
             List<string> rows = byJob
                 .OrderByDescending(kv => kv.Value.Count).ThenBy(kv => kv.Key)
-                .Select(kv => "[u]" + (kv.Value.Count == 1 ? Utils.JobToText(kv.Key) : Utils.JobToPlural(kv.Key)) + ":[/u] "
-                    + string.Join(", ", kv.Value.OrderBy(n => n, StringComparer.OrdinalIgnoreCase)))
+                .Select(kv => ReadoutText.Row(
+                    kv.Value.Count == 1 ? Utils.JobToText(kv.Key) : Utils.JobToPlural(kv.Key),
+                    string.Join(", ", kv.Value.OrderBy(n => n, StringComparer.OrdinalIgnoreCase))))
                 .ToList();
 
             int totalEmployees = byJob.Sum(kv => kv.Value.Count);
             string summary = totalEmployees + " residents across " + rows.Count + " roles";
-            return RenderLineSection("[b]Currently employs:[/b]", summary, rows);
+            return ReadoutText.LineSection("Currently employs", ReadoutDomain.Relationship, summary, rows);
         }
 
         /// <summary>
@@ -651,13 +607,17 @@ namespace FChatDicebot.BotCommands
         {
             int count = profile.titles?.Count ?? 0;
             if (count <= 0) return string.Empty;
-            return "[b]Titles earned:[/b] " + count;
+            return ReadoutText.Row("Titles Earned", ReadoutText.Num(count));
         }
 
         /// <summary>
-        /// Two standalone one-line facts — titles earned and wealthiest currency — sharing a
-        /// row so they read as an at-a-glance stat line rather than owning a line each.
-        /// Either half renders alone when the other is absent.
+        /// Three standalone one-line facts — titles earned, wealthiest currency and bottle
+        /// count — sharing a row so they read as an at-a-glance stat line rather than owning a
+        /// line each. Any one renders alone when the others are absent.
+        ///
+        /// These used to be bare "[b]Label:[/b] value" fragments with no header of their own,
+        /// which made three unrelated facts look like three separate sections. They're cells
+        /// now, under one header like every other inline block.
         /// </summary>
         private string BuildAtAGlanceSection(Profile profile)
         {
@@ -668,8 +628,7 @@ namespace FChatDicebot.BotCommands
             if (!string.IsNullOrEmpty(titles)) cells.Add(titles);
             if (!string.IsNullOrEmpty(currency)) cells.Add(currency);
             if (!string.IsNullOrEmpty(bottled)) cells.Add(bottled);
-            if (cells.Count == 0) return string.Empty;
-            return string.Join(InlineSeparator, cells) + "\n";
+            return ReadoutText.InlineSection("At a glance", ReadoutDomain.Economy, cells);
         }
 
         /// <summary>
@@ -690,17 +649,17 @@ namespace FChatDicebot.BotCommands
             if (full.Count > 0)
             {
                 var breakdown = BottleInventory.CountsBySubstance(full)
-                    .Select(kv => kv.Value + " " + Utils.SubstanceToText(kv.Key))
+                    .Select(kv => kv.Value + " " + ReadoutText.CapitalizePastTags(Utils.SubstanceToText(kv.Key)))
                     .ToList();
-                parts.Add(full.Count + " bottle" + (full.Count == 1 ? "" : "s")
+                parts.Add(ReadoutText.Num(full.Count) + " bottle" + (full.Count == 1 ? "" : "s")
                     + (breakdown.Count > 0 ? " (" + string.Join(", ", breakdown) + ")" : ""));
             }
             if (emptyCount > 0)
             {
-                parts.Add(emptyCount + " empt" + (emptyCount == 1 ? "y" : "ies"));
+                parts.Add(ReadoutText.Num(emptyCount) + " empt" + (emptyCount == 1 ? "y" : "ies"));
             }
 
-            return "[b]Bottled:[/b] " + string.Join(" and ", parts);
+            return ReadoutText.Row("Bottled", string.Join(" and ", parts));
         }
 
         /// <summary>
@@ -716,7 +675,7 @@ namespace FChatDicebot.BotCommands
             int max = positive.Max(kv => kv.Value);
             var top = positive.Where(kv => kv.Value == max).Select(kv => kv.Key).OrderBy(k => k).ToList();
             string currencyText = string.Join("/", top);
-            return "[b]Most abundant currency:[/b] " + max + " " + currencyText;
+            return ReadoutText.Row("Richest Currency", ReadoutText.Num(max) + " " + currencyText);
         }
 
         /// <summary>
@@ -732,10 +691,10 @@ namespace FChatDicebot.BotCommands
             {
                 if (entry.Value <= 0) continue;
                 string monster = entry.Value == 1 ? Utils.Capitalize(entry.Key) : Utils.Capitalize(entry.Key) + "s";
-                parts.Add(monster + ": " + entry.Value);
+                parts.Add(monster + ": " + ReadoutText.Num(entry.Value));
             }
             if (parts.Count == 0) return string.Empty;
-            return "[u]" + label + ":[/u] " + string.Join(", ", parts);
+            return ReadoutText.Row(label, string.Join(", ", parts));
         }
 
         /// <summary>
@@ -771,9 +730,9 @@ namespace FChatDicebot.BotCommands
 
             List<string> cells = casualCounts
                 .Where(c => CountDisplayNames.ContainsKey(c.Key))
-                .Select(c => "[u]" + CountDisplayNames[c.Key] + ":[/u] " + c.Value)
+                .Select(c => ReadoutText.Row(CountDisplayNames[c.Key], ReadoutText.Num(c.Value)))
                 .ToList();
-            return RenderInlineSection("[b]Casual interactions:[/b]", cells);
+            return ReadoutText.InlineSection("Casual interactions", ReadoutDomain.Record, cells);
         }
 
         /// <summary>
@@ -810,13 +769,13 @@ namespace FChatDicebot.BotCommands
             List<string> cells = new List<string>();
             foreach (var entry in summed)
             {
-                cells.Add("[u]" + entry.Key + ":[/u] " + entry.Value);
+                cells.Add(ReadoutText.Row(entry.Key, ReadoutText.Num(entry.Value)));
             }
             foreach (var entry in individual.OrderBy(kv => CountDisplayNames[kv.Key]))
             {
-                cells.Add("[u]" + CountDisplayNames[entry.Key] + ":[/u] " + entry.Value);
+                cells.Add(ReadoutText.Row(CountDisplayNames[entry.Key], ReadoutText.Num(entry.Value)));
             }
-            return RenderInlineSection("[b]Notable counts:[/b]", cells);
+            return ReadoutText.InlineSection("Notable counts", ReadoutDomain.Record, cells);
         }
 
         /// <summary>
@@ -856,12 +815,14 @@ namespace FChatDicebot.BotCommands
                     totalMarks += symbols.Count;
                     // BodypartToText returns a bare lowercase key ("neck"); every other
                     // labelled row in the dossier capitalises, so capitalise here too.
-                    rows.Add("[u]" + Utils.Capitalize(Utils.BodypartToText(bodyPart)) + ":[/u] "
-                        + string.Join(" ", symbols));
+                    rows.Add(ReadoutText.Row(
+                        Utils.Capitalize(Utils.BodypartToText(bodyPart)),
+                        string.Join(" ", symbols)));
                 }
             }
 
-            return RenderLineSection("Currently known [b]Marks[/b]:", totalMarks + " across " + rows.Count + " places", rows);
+            return ReadoutText.LineSection("Marks", ReadoutDomain.Relationship,
+                totalMarks + " across " + rows.Count + " places", rows);
         }
 
         /// <summary>
@@ -908,13 +869,15 @@ namespace FChatDicebot.BotCommands
                         }
 
                         totalBonds += displayNames.Count;
-                        rows.Add("[u]" + Utils.Capitalize(Utils.BondToPlural(bondType, isInitiated)) + ":[/u] "
-                            + string.Join(", ", displayNames));
+                        rows.Add(ReadoutText.Row(
+                            Utils.Capitalize(Utils.BondToPlural(bondType, isInitiated)),
+                            string.Join(", ", displayNames)));
                     }
                 }
             }
 
-            return RenderLineSection("Currently known [b]Bonds[/b]:", totalBonds + " across " + rows.Count + " kinds", rows);
+            return ReadoutText.LineSection("Bonds", ReadoutDomain.Relationship,
+                totalBonds + " across " + rows.Count + " kinds", rows);
         }
 
         /// <summary>
@@ -928,9 +891,9 @@ namespace FChatDicebot.BotCommands
             }
 
             List<string> cells = profile.jobExperience
-                .Select(jobExp => "[u]" + Utils.JobToText(jobExp.Key) + ":[/u] " + jobExp.Value)
+                .Select(jobExp => ReadoutText.Row(Utils.JobToText(jobExp.Key), ReadoutText.Num(jobExp.Value)))
                 .ToList();
-            return RenderInlineSection("Days of [b]Experience[/b] working as...", cells);
+            return ReadoutText.InlineSection("Days of experience", ReadoutDomain.Economy, cells);
         }
 
         /// <summary>
@@ -953,12 +916,10 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Last reported:[/b]\n");
-            sb.Append(Utils.GetInteractionDescription(mostRecent));
-            sb.Append("\n");
-
-            return sb.ToString();
+            // One line rather than two: the description is a single short sentence, so the
+            // header owned an entire line to introduce a fragment shorter than itself.
+            return ReadoutText.Section("Last reported", ReadoutDomain.None) + " "
+                + Utils.GetInteractionDescription(mostRecent) + "\n";
         }
 
         /// <summary>
@@ -990,12 +951,8 @@ namespace FChatDicebot.BotCommands
                 }
             }
 
-            StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Last seen:[/b]\n");
-            sb.Append(Utils.GetInteractionDescription(mostRecent));
-            sb.Append("\n");
-
-            return sb.ToString();
+            return ReadoutText.Section("Last seen", ReadoutDomain.None) + " "
+                + Utils.GetInteractionDescription(mostRecent) + "\n";
         }
 
         /// <summary>

--- a/FChatDicebot/BotCommands/ChateauEconomics.cs
+++ b/FChatDicebot/BotCommands/ChateauEconomics.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Base;
+﻿using FChatDicebot.BotCommands.Base;
 using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using System.Collections.Generic;
@@ -49,13 +49,17 @@ namespace FChatDicebot.BotCommands
                 return "No currency has been accumulated by any resident yet. The vaults are quiet.";
             }
             var sb = new System.Text.StringBuilder();
+            sb.Append(ReadoutText.Title("The Chateau's Wealth")).Append('\n');
             sb.Append("The accumulated wealth of Chateau residents, by currency:\n");
             foreach (var entry in positive.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
             {
-                sb.Append("  ").Append(entry.Key).Append(": ")
-                  .Append(entry.Value.ToString("N0", CultureInfo.InvariantCulture)).Append('\n');
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(Utils.Capitalize(entry.Key),
+                      ReadoutText.Num(entry.Value.ToString("N0", CultureInfo.InvariantCulture))))
+                  .Append('\n');
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("See !bank for your own account, or !statistics for the overview."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauFeedbackList.cs
+++ b/FChatDicebot/BotCommands/ChateauFeedbackList.cs
@@ -67,15 +67,16 @@ namespace FChatDicebot.BotCommands
             List<FeedbackEntry> ordered = entries.OrderByDescending(e => e.submittedAt).ToList();
 
             StringBuilder sb = new StringBuilder();
-            sb.Append("[b]Recent feedback submissions:[/b]\n");
+            sb.Append(ReadoutText.Title("Recent Feedback Submissions")).Append('\n');
 
             int shown = 0;
             foreach (FeedbackEntry e in ordered)
             {
-                string relative = Utils.TimeDifferenceText(e.submittedAt, now) + " ago";
-                string cat = string.IsNullOrEmpty(e.category) ? ChateauFeedback.DefaultCategory : e.category;
-                string name = string.IsNullOrEmpty(e.submitterDisplayName) ? e.submitterUserName : e.submitterDisplayName;
-                string block = "\n" + relative + " — [b]" + name + "[/b] ([i]" + cat + "[/i]): " + e.text + "\n";
+                // One prefix builder for both the normal and the truncation path: they used to
+                // be built separately, so the budget arithmetic could drift from what was
+                // actually emitted.
+                string prefix = "\n" + EntryPrefix(e, now);
+                string block = prefix + e.text + "\n";
 
                 if (shown == 0 && block.Length > maxChars)
                 {
@@ -83,18 +84,18 @@ namespace FChatDicebot.BotCommands
                     // let this through unconditionally, producing an over-cap message the
                     // caller's PM layer would silently drop entirely. Truncate this entry's
                     // own text instead of skipping straight to "nothing shown".
-                    string prefix = "\n" + relative + " — [b]" + name + "[/b] ([i]" + cat + "[/i]): ";
-                    int textBudget = Math.Max(0, maxChars - prefix.Length - "\n(truncated)\n".Length);
+                    string truncNote = "\n" + ReadoutText.Small("(truncated)") + "\n";
+                    int textBudget = Math.Max(0, maxChars - prefix.Length - truncNote.Length);
                     string truncatedText = e.text.Length > textBudget ? e.text.Substring(0, textBudget) : e.text;
-                    sb.Append(prefix).Append(truncatedText).Append("\n(truncated)\n");
+                    sb.Append(prefix).Append(truncatedText).Append(truncNote);
                     shown++;
                     continue;
                 }
 
                 if (shown > 0 && sb.Length + block.Length > maxChars)
                 {
-                    sb.Append("\n…(output truncated — showing the ").Append(shown)
-                      .Append(" most recent of ").Append(ordered.Count).Append(')');
+                    sb.Append('\n').Append(ReadoutText.Small("(output truncated, showing the " + shown
+                        + " most recent of " + ordered.Count + ")"));
                     break;
                 }
 
@@ -103,6 +104,21 @@ namespace FChatDicebot.BotCommands
             }
 
             return sb.ToString().TrimEnd('\n');
+        }
+
+        /// <summary>
+        /// "  [u]Alice:[/u] [sub](bug, 2 hours ago)[/sub] " — the submitter is the row label,
+        /// with category and age as small print beside it. Was
+        /// "2 hours ago — [b]Alice[/b] ([i]bug[/i]): ", which led with the timestamp and used
+        /// an em-dash the style guide bans.
+        /// </summary>
+        private static string EntryPrefix(FeedbackEntry e, DateTime now)
+        {
+            string relative = Utils.TimeDifferenceText(e.submittedAt, now) + " ago";
+            string cat = string.IsNullOrEmpty(e.category) ? ChateauFeedback.DefaultCategory : e.category;
+            string name = string.IsNullOrEmpty(e.submitterDisplayName) ? e.submitterUserName : e.submitterDisplayName;
+            return ReadoutText.RowIndent + ReadoutText.Label(name) + " "
+                + ReadoutText.Small("(" + cat + ", " + relative + ")") + " ";
         }
 
         // First-draft empty-state wording, pending owner review.

--- a/FChatDicebot/BotCommands/ChateauFlora.cs
+++ b/FChatDicebot/BotCommands/ChateauFlora.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Base;
+﻿using FChatDicebot.BotCommands.Base;
 using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using System.Collections.Generic;
@@ -48,13 +48,17 @@ namespace FChatDicebot.BotCommands
                 return "Nothing has ever been planted in the Chateau gardens. The earth waits for its first !plant.";
             }
             var sb = new System.Text.StringBuilder();
+            sb.Append(ReadoutText.Title("The Chateau Gardens")).Append('\n');
             sb.Append("Plants ever cultivated in the Chateau gardens:\n");
             foreach (var entry in counts.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
             {
-                sb.Append("  ").Append(Utils.Capitalize(entry.Key)).Append(": ")
-                  .Append(entry.Value.ToString("N0", CultureInfo.InvariantCulture)).Append('\n');
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(Utils.Capitalize(entry.Key),
+                      ReadoutText.Num(entry.Value.ToString("N0", CultureInfo.InvariantCulture))))
+                  .Append('\n');
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("See !statistics for the Chateau-wide overview."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauHelp.cs
+++ b/FChatDicebot/BotCommands/ChateauHelp.cs
@@ -217,20 +217,19 @@ namespace FChatDicebot.BotCommands
         {
             StringBuilder sb = new StringBuilder();
 
-            // Command name and aliases
-            sb.Append("[b]!");
-            sb.Append(cmd.Name);
-            sb.Append("[/b]");
+            // Command name and aliases. The name is this readout's Title line.
+            sb.Append(ReadoutText.Title("!" + cmd.Name));
 
             if (cmd.Aliases != null && cmd.Aliases.Length > 0)
             {
-                sb.Append("[sub]");
-                sb.Append(string.Join(", ", cmd.Aliases.Select(a => "!" + a)));
-                sb.Append("[/sub]");
+                sb.Append(' ');
+                sb.Append(ReadoutText.Small(string.Join(", ", cmd.Aliases.Select(a => "!" + a))));
             }
             sb.AppendLine("");
 
-            // Category
+            // Category. These colours are deliberately NOT the ReadoutDomain palette: the tier
+            // line is a stoplight (green -> yellow -> orange -> red) reading as escalating
+            // seriousness, which is worth more here than palette consistency. Owner-confirmed.
             if (!string.IsNullOrEmpty(cmd.Category))
             {
                 switch (cmd.Category)
@@ -275,12 +274,12 @@ namespace FChatDicebot.BotCommands
                 sb.AppendLine("");
             }
 
-            // Usage
+            // Usage. Field headings are Reference-domain sections (purple), consistent across
+            // every field below.
             if (!string.IsNullOrEmpty(cmd.Usage))
             {
-                sb.AppendLine("[u]Usage:[/u]");
-                sb.AppendLine(cmd.Usage);
-                sb.AppendLine("");
+                sb.AppendLine(ReadoutText.Section("Usage", ReadoutDomain.Reference));
+                sb.AppendLine(Indent(cmd.Usage));
             }
 
             // Identifier list (if applicable)
@@ -289,11 +288,11 @@ namespace FChatDicebot.BotCommands
                 List<Model.Identifier> identifiers = MonDB.getIdentifiers(cmd.IdentifierCategory);
                 if (identifiers != null && identifiers.Count > 0)
                 {
-                    sb.Append("[u]Available ");
-                    sb.Append(cmd.IdentifierCategory.EndsWith("y") ? (cmd.IdentifierCategory.TrimEnd('y') + "ie") : cmd.IdentifierCategory);
-                    sb.AppendLine("s:[/u]");
-                    sb.AppendLine(Utils.sortedListDisplayText(identifiers.Select(i => i.type).ToList()));
-                    sb.AppendLine("");
+                    string categoryPlural = (cmd.IdentifierCategory.EndsWith("y")
+                        ? cmd.IdentifierCategory.TrimEnd('y') + "ie"
+                        : cmd.IdentifierCategory) + "s";
+                    sb.AppendLine(ReadoutText.Section("Available " + categoryPlural, ReadoutDomain.Reference));
+                    sb.AppendLine(Indent(Utils.sortedListDisplayText(identifiers.Select(i => i.type).ToList())));
                 }
             }
 
@@ -314,44 +313,49 @@ namespace FChatDicebot.BotCommands
             }
             if (!string.IsNullOrEmpty(cooldownDuration))
             {
-                sb.Append("[u]Cooldown:[/u] ");
-                sb.Append(cooldownDuration);
+                sb.Append(ReadoutText.Section("Cooldown", ReadoutDomain.Reference)).Append(' ');
+                sb.Append(ReadoutText.Num(cooldownDuration));
                 if (!string.IsNullOrEmpty(cooldownAppliesTo))
                 {
-                    sb.Append(" (applies to ");
-                    sb.Append(cooldownAppliesTo);
-                    sb.Append(")");
+                    sb.Append(' ').Append(ReadoutText.Small("(applies to " + cooldownAppliesTo + ")"));
                 }
                 if (cmd.Category == "Casual Interaction")
                 {
-                    sb.Append(" [sub](Casual command cooldowns are only for incrementing dossier counts, and can still be performed at any time)[/sub]");
+                    sb.Append(' ').Append(ReadoutText.Small("(Casual command cooldowns are only for incrementing dossier counts, and can still be performed at any time)"));
                 }
                 else if (cmd.Category == "Involved Interaction")
                 {
-                    sb.Append(" [sub](Involved command cooldowns are only for incrementing dossier counts, and can still be performed at any time[/sub])");
+                    // Closing bracket used to sit outside the [sub], rendering as a stray ")".
+                    sb.Append(' ').Append(ReadoutText.Small("(Involved command cooldowns are only for incrementing dossier counts, and can still be performed at any time)"));
                 }
-                sb.AppendLine("\n");
+                sb.AppendLine("");
             }
 
             // Channel requirement
-            if (cmd.RequireChannel)
-            {
-                sb.Append("[u]Channel Required:[/u] Yes\n\n");
-            }
-            else
-            {
-                sb.Append("[u]Channel Required:[/u] No\n\n");
-            }
+            sb.Append(ReadoutText.Section("Channel required", ReadoutDomain.Reference))
+              .Append(cmd.RequireChannel ? " Yes\n" : " No\n");
 
             // Related commands
             if (cmd.RelatedCommands != null && cmd.RelatedCommands.Length > 0)
             {
-                sb.Append("[u]Related Commands:[/u] ");
-                sb.Append(string.Join(", ", cmd.RelatedCommands.Select(c => "!" + c)));
+                sb.Append(ReadoutText.Footer("Related commands: "
+                    + string.Join(", ", cmd.RelatedCommands.Select(c => "!" + c))));
                 sb.Append("\n");
             }
 
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// Indents every line of a multi-line help field so it sits under its section header
+        /// the way rows do in the other readouts. <c>Usage</c> is frequently multi-line
+        /// ("!bank\nor\n!bank [user]...[/user]"), so this can't just prepend once.
+        /// </summary>
+        private static string Indent(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+            return ReadoutText.RowIndent
+                + text.Replace("\n", "\n" + ReadoutText.RowIndent);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauIdentifier.cs
+++ b/FChatDicebot/BotCommands/ChateauIdentifier.cs
@@ -67,14 +67,15 @@ namespace FChatDicebot.BotCommands
             // The identifier's own bot-wide eicon (if the Chateau has one on file for it)
             // rides on the title line.
             string titleEicon = string.IsNullOrEmpty(identifier.eicon) ? string.Empty : " " + identifier.eicon;
-            string returnText = "[b]" + identifier.type + "[/b]" + titleEicon + "\n" + identifier.description;
+            string returnText = ReadoutText.Title(identifier.type) + titleEicon + "\n" + identifier.description;
 
             if (identifier.categories != null && identifier.categories.Contains("monster", StringComparer.OrdinalIgnoreCase))
             {
                 BreedProcessor.ResolveGestationAndBroodRange(identifier, out int gestationDays, out int broodSizeMin, out int broodSizeMax);
                 string broodText = broodSizeMin == broodSizeMax ? broodSizeMin.ToString() : broodSizeMin + "-" + broodSizeMax;
                 string dayWord = gestationDays == 1 ? "day" : "days";
-                returnText += "\n[i]Gestation: " + gestationDays + " " + dayWord + ". Brood size: " + broodText + ".[/i]";
+                returnText += "\n" + ReadoutText.Row("Gestation", ReadoutText.Num(gestationDays) + " " + dayWord)
+                    + ReadoutText.InlineSeparator + ReadoutText.Row("Brood size", ReadoutText.Num(broodText));
             }
 
             // For bodyparts, remind the asker what they've pinned to their own (this reply is
@@ -101,7 +102,7 @@ namespace FChatDicebot.BotCommands
             string personalEicon = InteractionEiconSupport.GetBodypartEicon(profile, identifier.type);
             return string.IsNullOrEmpty(personalEicon)
                 ? string.Empty
-                : "\n[i]Your personal eicon: " + personalEicon + "[/i]";
+                : "\n" + ReadoutText.Small("Your personal eicon: " + personalEicon);
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauIdentifiers.cs
+++ b/FChatDicebot/BotCommands/ChateauIdentifiers.cs
@@ -105,30 +105,34 @@ namespace FChatDicebot.BotCommands
             string returnText = string.Empty;
             if (terms.Length < 1 || terms == null)
             {
-                returnText = "Use this command to list out the currently available identifiers within a certain category. If you want to see the description of a specific identifier, use !identifier instead. Please note that only the first category provided will be listed out, and any additional terms will be ignored.\n\nThe currently available categories are: \n";
-                returnText += Utils.sortedListDisplayText(categoryDisplay.Keys.ToList());
-                returnText += "\n\nCurrently available subcategories are: \n";
-                returnText += Utils.sortedListDisplayText(subCategoryDisplay.Keys.ToList());
+                returnText = ReadoutText.Title("Identifier Categories") + "\n"
+                    + "Use this command to list out the currently available identifiers within a certain category. If you want to see the description of a specific identifier, use !identifier instead. Please note that only the first category provided will be listed out, and any additional terms will be ignored.\n\n";
+                returnText += ReadoutText.Section("Categories", ReadoutDomain.Reference) + "\n";
+                returnText += ReadoutText.RowIndent + Utils.sortedListDisplayText(categoryDisplay.Keys.ToList());
+                returnText += "\n" + ReadoutText.Section("Subcategories", ReadoutDomain.Reference) + "\n";
+                returnText += ReadoutText.RowIndent + Utils.sortedListDisplayText(subCategoryDisplay.Keys.ToList());
             }
             else if (categoryDisplay.ContainsKey(lowerTerm))
             {
-                returnText = "Currently known [b]" + categoryDisplay[lowerTerm] + "[/b] are: \n";
+                returnText = ReadoutText.Title("Known " + categoryDisplay[lowerTerm]) + "\n";
                 List<string> categoryList = new List<string>();
                 foreach (Identifier identifier in MonDB.getIdentifiers(lowerTerm))
                 {
                     categoryList.Add(identifier.type);
                 }
-                returnText += Utils.sortedListDisplayText(categoryList);
+                returnText += ReadoutText.RowIndent + Utils.sortedListDisplayText(categoryList);
+                returnText += "\n" + ReadoutText.Footer("Use !identifier {name} for a description of any one of these.");
             }
             else if (subCategoryDisplay.ContainsKey(lowerTerm))
             {
-                returnText = "Currently known [b]" + subCategoryDisplay[lowerTerm] + "[/b] are: \n";
+                returnText = ReadoutText.Title("Known " + subCategoryDisplay[lowerTerm]) + "\n";
                 List<string> subCategoryList = new List<string>();
                 foreach (Identifier identifier in MonDB.getIdentifiers(lowerTerm))
                 {
                     subCategoryList.Add(identifier.type);
                 }
-                returnText += Utils.sortedListDisplayText(subCategoryList);
+                returnText += ReadoutText.RowIndent + Utils.sortedListDisplayText(subCategoryList);
+                returnText += "\n" + ReadoutText.Footer("Use !identifier {name} for a description of any one of these.");
             }
             else
             {

--- a/FChatDicebot/BotCommands/ChateauParasites.cs
+++ b/FChatDicebot/BotCommands/ChateauParasites.cs
@@ -63,6 +63,7 @@ namespace FChatDicebot.BotCommands
             }
 
             var sb = new System.Text.StringBuilder();
+            sb.Append(ReadoutText.Title("Parasites of the Chateau")).Append('\n');
             sb.Append("Parasites recorded in the Chateau:\n");
             var ordered = allParasites
                 .Select(p => new
@@ -78,12 +79,15 @@ namespace FChatDicebot.BotCommands
 
             foreach (var entry in ordered)
             {
-                sb.Append("  ").Append(Utils.Capitalize(ParasiteText.ParasiteName(entry.Name))).Append(": ")
-                  .Append(entry.Current.ToString("N0", CultureInfo.InvariantCulture)).Append(" currently infested, ")
-                  .Append(entry.Spread.ToString("N0", CultureInfo.InvariantCulture)).Append(" spread, ")
-                  .Append(entry.Purged.ToString("N0", CultureInfo.InvariantCulture)).Append(" purged\n");
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(Utils.Capitalize(ParasiteText.ParasiteName(entry.Name)),
+                      ReadoutText.Num(entry.Current.ToString("N0", CultureInfo.InvariantCulture)) + " currently infested, "
+                      + ReadoutText.Num(entry.Spread.ToString("N0", CultureInfo.InvariantCulture)) + " spread, "
+                      + ReadoutText.Num(entry.Purged.ToString("N0", CultureInfo.InvariantCulture)) + " purged"))
+                  .Append('\n');
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("Carrying one yourself? !purge will see to it."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauPayroll.cs
+++ b/FChatDicebot/BotCommands/ChateauPayroll.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Base;
+﻿using FChatDicebot.BotCommands.Base;
 using FChatDicebot.BotCommands.Support;
 using FChatDicebot.Model;
 using System.Collections.Generic;
@@ -53,35 +53,42 @@ namespace FChatDicebot.BotCommands
             }
 
             var sb = new System.Text.StringBuilder();
-            sb.Append("The Chateau's current workforce:\n");
+            sb.Append(ReadoutText.Title("The Chateau Payroll")).Append('\n');
+
+            sb.Append(ReadoutText.Section("Current workforce", ReadoutDomain.Economy)).Append('\n');
             if (employed.Count == 0)
             {
-                sb.Append("  Nobody is currently employed.\n");
+                sb.Append(ReadoutText.RowIndent).Append(ReadoutText.Small("Nobody is currently employed.")).Append('\n');
             }
             else
             {
                 foreach (var entry in employed.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
                 {
                     string label = entry.Value == 1 ? Utils.JobToText(entry.Key) : Utils.JobToPlural(entry.Key);
-                    sb.Append("  ").Append(label).Append(": ").Append(entry.Value.ToString("N0", CultureInfo.InvariantCulture)).Append('\n');
+                    sb.Append(ReadoutText.RowIndent)
+                      .Append(ReadoutText.Row(label, ReadoutText.Num(entry.Value.ToString("N0", CultureInfo.InvariantCulture))))
+                      .Append('\n');
                 }
             }
 
-            sb.Append("\nDuties completed by job:\n");
+            sb.Append(ReadoutText.Section("Duties completed by job", ReadoutDomain.Economy)).Append('\n');
             if (duties.Count == 0 || duties.Values.Sum() == 0)
             {
-                sb.Append("  No duties have been completed yet.\n");
+                sb.Append(ReadoutText.RowIndent).Append(ReadoutText.Small("No duties have been completed yet.")).Append('\n');
             }
             else
             {
                 foreach (var entry in duties.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key))
                 {
                     if (entry.Value <= 0) continue;
-                    sb.Append("  ").Append(Utils.JobToText(entry.Key)).Append(": ")
-                      .Append(entry.Value.ToString("N0", CultureInfo.InvariantCulture)).Append('\n');
+                    sb.Append(ReadoutText.RowIndent)
+                      .Append(ReadoutText.Row(Utils.JobToText(entry.Key),
+                          ReadoutText.Num(entry.Value.ToString("N0", CultureInfo.InvariantCulture))))
+                      .Append('\n');
                 }
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("Employers can see their own kickbacks with !business."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauPledges.cs
+++ b/FChatDicebot/BotCommands/ChateauPledges.cs
@@ -62,41 +62,52 @@ namespace FChatDicebot.BotCommands
             pledgesGiven = pledgesGiven.Where(p => p.IsActive).ToList();
             pledgesReceived = pledgesReceived.Where(p => p.IsActive).ToList();
 
-            StringBuilder message = new StringBuilder($"[b]{userProfile.displayName}'s Pledges:[/b]\n\n");
-            
+            StringBuilder message = new StringBuilder(
+                ReadoutText.Title("Pledges of " + userProfile.displayName) + "\n");
 
             // Show pledges this user has made
+            string givenHeader = viewingSelf ? "Pledges made" : "Pledges " + userProfile.displayName + " has made";
             if (pledgesGiven.Count > 0)
             {
-                message.AppendLine (viewingSelf ? "[b]Pledges You Have Made:[/b]" : $"[b]Pledges {userProfile.displayName} Has Made:[/b]");
+                message.AppendLine(ReadoutText.Section(givenHeader, ReadoutDomain.Relationship));
                 foreach (var pledge in pledgesGiven)
                 {
                     string pledgeeName = MonDB.getDisplayName(pledge.pledgee);
                     string timeAgo = Utils.TimeDifferenceText(pledge.pledgeTime, DateTime.UtcNow);
-                    message.Append( $"  • Pledged to {Utils.interactionToVerb(pledge.interactionType, false)} {pledgeeName} ({timeAgo} ago)\n");
+                    message.Append(ReadoutText.RowIndent)
+                        .Append($"Pledged to {Utils.interactionToVerb(pledge.interactionType, false)} {pledgeeName} ")
+                        .AppendLine(ReadoutText.Small($"({timeAgo} ago)"));
                 }
-                message.AppendLine();
             }
             else
             {
-                message.AppendLine(viewingSelf ? "[b]Pledges You Have Made:[/b] None\n" : $"[b]Pledges {userProfile.displayName} Has Made:[/b] None\n");
+                // Small print rather than body weight: an empty slot shouldn't read as loudly
+                // as a real pledge.
+                message.AppendLine(ReadoutText.Section(givenHeader, ReadoutDomain.Relationship) + " " + ReadoutText.None());
             }
 
             // Show pledges others have made to this user
+            string receivedHeader = viewingSelf ? "Pledges made to you" : "Pledges made to " + userProfile.displayName;
             if (pledgesReceived.Count > 0)
             {
-                message.AppendLine(viewingSelf ? "[b]Pledges Made to You:[/b]" : $"[b]Pledges Others Have Made to {userProfile.displayName}:[/b]");
+                message.AppendLine(ReadoutText.Section(receivedHeader, ReadoutDomain.Relationship));
                 foreach (var pledge in pledgesReceived)
                 {
                     string pledgerName = MonDB.getDisplayName(pledge.pledger);
                     string timeAgo = Utils.TimeDifferenceText(pledge.pledgeTime, DateTime.UtcNow);
-                    message.AppendLine( viewingSelf ? $"  • {pledgerName} pledged to {Utils.interactionToVerb(pledge.interactionType, false)} you ({timeAgo} ago)" : $"  • {pledgerName} pledged to {Utils.interactionToVerb(pledge.interactionType, false)} {userProfile.displayName} ({timeAgo} ago)");
+                    string who = viewingSelf ? "you" : userProfile.displayName;
+                    message.Append(ReadoutText.RowIndent)
+                        .Append($"{pledgerName} pledged to {Utils.interactionToVerb(pledge.interactionType, false)} {who} ")
+                        .AppendLine(ReadoutText.Small($"({timeAgo} ago)"));
                 }
             }
             else
             {
-                message.Append(viewingSelf ? "[b]Pledges Made to You:[/b] None" : $"[b]Pledges Others Have Made to {userProfile.displayName}:[/b] None (Maybe you could be the first?)");
+                message.AppendLine(ReadoutText.Section(receivedHeader, ReadoutDomain.Relationship) + " " + ReadoutText.None()
+                    + (viewingSelf ? "" : " " + ReadoutText.Small("(Maybe you could be the first?)")));
             }
+
+            message.Append(ReadoutText.Footer("Use !fulfill to make good on a pledge, or !abandonpledge to let one go."));
             bot.SendPrivateMessage(message.ToString(), characterName);
         }
     }

--- a/FChatDicebot/BotCommands/ChateauPopulations.cs
+++ b/FChatDicebot/BotCommands/ChateauPopulations.cs
@@ -59,16 +59,20 @@ namespace FChatDicebot.BotCommands
             }
 
             var sb = new System.Text.StringBuilder();
+            sb.Append(ReadoutText.Title("Monsterkind of the Chateau")).Append('\n');
             sb.Append("Currently dwelling in the Chateau as monsters:\n");
             var ordered = bySpecies.OrderByDescending(kv => kv.Value.Count).ThenBy(kv => kv.Key);
             foreach (var entry in ordered)
             {
                 entry.Value.Sort();
-                sb.Append("  ").Append(Utils.Capitalize(entry.Key)).Append(": ")
-                  .Append(entry.Value.Count).Append(" — ")
-                  .Append(string.Join(", ", entry.Value)).Append('\n');
+                // Em-dash removed per the style guide's "no em-dashes in user-facing strings".
+                sb.Append(ReadoutText.RowIndent)
+                  .Append(ReadoutText.Row(Utils.Capitalize(entry.Key),
+                      ReadoutText.Num(entry.Value.Count) + " (" + string.Join(", ", entry.Value) + ")"))
+                  .Append('\n');
             }
-            return sb.ToString().TrimEnd('\n');
+            sb.Append(ReadoutText.Footer("See !statistics for the Chateau-wide overview."));
+            return sb.ToString();
         }
     }
 }

--- a/FChatDicebot/BotCommands/ChateauStatistics.cs
+++ b/FChatDicebot/BotCommands/ChateauStatistics.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Base;
+﻿using FChatDicebot.BotCommands.Base;
 using FChatDicebot.BotCommands.Support;
 using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.InteractionProcessors.Consequence;
@@ -119,76 +119,102 @@ namespace FChatDicebot.BotCommands
 
             // --- Compose ---
             var sb = new System.Text.StringBuilder();
-            sb.Append("A record of life within the Chateau, in broad strokes~\n");
+            sb.Append(ReadoutText.Title("The Chateau at a Glance")).Append('\n');
+            sb.Append("A record of life within the Chateau, in broad strokes~\n\n");
 
-            sb.Append("[b]Population[/b]\n");
-            AppendLifetimeOrSnapshotLine(sb, "Converted to Monsterkind", monsterizedTotal, "most common", monsterizedTop);
-            AppendLifetimeOrSnapshotLine(sb, "Monsters birthed", birthedTotal, "most bred", birthedTop);
-            AppendLifetimeOrSnapshotLine(sb, "People planted", plantsTotal, "most planted", plantsTop);
-            AppendLifetimeOrSnapshotLine(sb, "Statues petrified", statuesTotal, "most decorated", statuesTop);
-            AppendLifetimeOrSnapshotLine(sb, "Infested Individuals", infestedDistinctHosts, "most widespread", infestedTop);
+            // Each block's rows are gathered first and the header is only emitted when at least
+            // one survived. Previously the headers were unconditional, so a young Chateau with
+            // no corruption or climaxes yet printed a bare "Influence" heading introducing
+            // nothing — invisible when headers were plain, obvious once they took a colour.
+            var population = new List<string>();
+            AppendLifetimeOrSnapshotLine(population, "Converted to Monsterkind", monsterizedTotal, "most common", monsterizedTop);
+            AppendLifetimeOrSnapshotLine(population, "Monsters Birthed", birthedTotal, "most bred", birthedTop);
+            AppendLifetimeOrSnapshotLine(population, "People Planted", plantsTotal, "most planted", plantsTop);
+            AppendLifetimeOrSnapshotLine(population, "Statues Petrified", statuesTotal, "most decorated", statuesTop);
+            AppendLifetimeOrSnapshotLine(population, "Infested Individuals", infestedDistinctHosts, "most widespread", infestedTop);
             if (parasitesSpreadTotal > 0 || parasitesPurgedTotal > 0)
             {
-                sb.Append("  Parasites spread: ").Append(FormatNumber(parasitesSpreadTotal))
-                  .Append("   Parasites purged: ").Append(FormatNumber(parasitesPurgedTotal)).Append('\n');
+                population.Add(ReadoutText.Row("Parasites Spread", ReadoutText.Num(FormatNumber(parasitesSpreadTotal)))
+                    + ReadoutText.InlineSeparator
+                    + ReadoutText.Row("Parasites Purged", ReadoutText.Num(FormatNumber(parasitesPurgedTotal))));
             }
+            AppendBlock(sb, "Population", ReadoutDomain.Relationship, population);
 
-            sb.Append("[b]Influence[/b]\n");
+            var influence = new List<string>();
             if (climaxes > 0)
             {
-                sb.Append("  Climaxes recorded: ").Append(FormatNumber(climaxes)).Append('\n');
+                influence.Add(ReadoutText.Row("Climaxes Recorded", ReadoutText.Num(FormatNumber(climaxes))));
             }
             if (corruption > 0 || purity > 0)
             {
-                sb.Append("  Corruption Cultivated: ").Append(FormatNumber(corruption))
-                  .Append("    Purity Promoted: ").Append(FormatNumber(purity)).Append('\n');
-                sb.Append("  ").Append(FormatNetTilt(corruption, purity)).Append('\n');
+                influence.Add(ReadoutText.Row("Corruption Cultivated", ReadoutText.Num(FormatNumber(corruption)))
+                    + ReadoutText.InlineSeparator
+                    + ReadoutText.Row("Purity Promoted", ReadoutText.Num(FormatNumber(purity))));
+                influence.Add(FormatNetTilt(corruption, purity));
             }
+            AppendBlock(sb, "Influence", ReadoutDomain.Affliction, influence);
 
-            sb.Append("[b]Workforce[/b]\n");
+            var workforce = new List<string>();
             if (totalEmployees > 0)
             {
-                sb.Append("  Total employees: ").Append(FormatNumber(totalEmployees)).Append('\n');
+                workforce.Add(ReadoutText.Row("Total Employees", ReadoutText.Num(FormatNumber(totalEmployees))));
                 if (!string.IsNullOrEmpty(topJobs))
                 {
-                    sb.Append("  Most employed: ").Append(topJobs).Append('\n');
+                    workforce.Add(ReadoutText.Row("Most Employed", topJobs));
                 }
             }
             if (totalDuties > 0)
             {
-                sb.Append("  Duties completed: ").Append(FormatNumber(totalDuties)).Append('\n');
+                workforce.Add(ReadoutText.Row("Duties Completed", ReadoutText.Num(FormatNumber(totalDuties))));
             }
             if (!string.IsNullOrEmpty(topCurrencies))
             {
-                sb.Append("  Most earned currencies - ").Append(topCurrencies).Append('\n');
+                workforce.Add(ReadoutText.Row("Most Earned", topCurrencies));
             }
+            AppendBlock(sb, "Workforce", ReadoutDomain.Economy, workforce);
 
-            sb.Append("[sub]Further information can be found through !statues, !populations,\n");
-            sb.Append("!flora, !birthrates, !parasites, !payroll, !economics.[/sub]");
+            sb.Append(ReadoutText.Footer("Further information can be found through !statues, !populations,"
+                + " !flora, !birthrates, !parasites, !payroll, !economics."));
             return sb.ToString();
         }
 
-        private static void AppendLifetimeOrSnapshotLine(System.Text.StringBuilder sb, string label, int total, string superlativeLabel, string superlativeValue)
+        /// <summary>
+        /// Emits a headed block, or nothing at all when no row qualified.
+        /// </summary>
+        private static void AppendBlock(System.Text.StringBuilder sb, string header, ReadoutDomain domain, List<string> rows)
+        {
+            if (rows.Count == 0) return;
+            sb.Append(ReadoutText.Section(header, domain)).Append('\n');
+            foreach (string row in rows)
+            {
+                sb.Append(ReadoutText.RowIndent).Append(row).Append('\n');
+            }
+        }
+
+        private static void AppendLifetimeOrSnapshotLine(List<string> rows, string label, int total, string superlativeLabel, string superlativeValue)
         {
             if (total <= 0) return; // hide the whole line when there's nothing to count yet
-            sb.Append("  ").Append(label).Append(": ").Append(FormatNumber(total));
+            string row = ReadoutText.Row(label, ReadoutText.Num(FormatNumber(total)));
             if (!string.IsNullOrEmpty(superlativeValue))
             {
-                sb.Append(" (").Append(superlativeLabel).Append(": ").Append(superlativeValue).Append(')');
+                // Small print: the superlative is context for the number, not a second fact.
+                row += " " + ReadoutText.Small("(" + superlativeLabel + ": " + superlativeValue + ")");
             }
-            sb.Append('\n');
+            rows.Add(row);
         }
 
         private static string FormatTopCurrencies(Dictionary<string, int> totals, int topN)
         {
             if (totals == null || totals.Count == 0) return string.Empty;
+            // Plain "Name: value" cells rather than [u] labels: these sit inside a row that
+            // already carries one, and nesting underlines makes the line unreadable.
             var ordered = totals
                 .Where(kv => kv.Value > 0)
                 .OrderByDescending(kv => kv.Value)
                 .ThenBy(kv => kv.Key)
                 .Take(topN)
-                .Select(kv => Utils.Capitalize(kv.Key) + ": " + FormatNumber(kv.Value));
-            return string.Join("    ", ordered);
+                .Select(kv => Utils.Capitalize(kv.Key) + ": " + ReadoutText.Num(FormatNumber(kv.Value)));
+            return string.Join(ReadoutText.InlineSeparator, ordered);
         }
 
         /// <summary>

--- a/FChatDicebot/BotCommands/ChateauStatues.cs
+++ b/FChatDicebot/BotCommands/ChateauStatues.cs
@@ -44,8 +44,9 @@ namespace FChatDicebot.BotCommands
             List<Interaction> petrifyInteractions = MonDB.getInteractionsByType("petrify");
             if (terms.Length < 1 || terms == null)
             {
-                returnText = "Listed below are the number of 'statues' or otherwise petrified beings in every location. To see the individuals petrified at a given location, use !statues {location}.\n";
-                
+                returnText = ReadoutText.Title("Statues of the Chateau") + "\n"
+                    + "Listed below are the number of 'statues' or otherwise petrified beings in every location. To see the individuals petrified at a given location, use !statues {location}.\n";
+
                 Dictionary<string, int> statueNum = new Dictionary<string, int> { };
                 foreach (Interaction interaction in petrifyInteractions)
                 {
@@ -56,14 +57,19 @@ namespace FChatDicebot.BotCommands
                     else
                     {
                         statueNum[interaction.identifier]++;
-                    } 
+                    }
                 }
                 foreach (KeyValuePair<string,int> count in statueNum)
                 {
-                    returnText += "\nStatues " + Utils.LocationToText(count.Key, "the initiator", "the recipient") + ": " + count.Value;
+                    returnText += ReadoutText.RowIndent
+                        + ReadoutText.Row(
+                            Utils.Capitalize(Utils.LocationToText(count.Key, "the initiator", "the recipient")),
+                            ReadoutText.Num(count.Value))
+                        + "\n";
                 }
+                returnText += ReadoutText.Footer("Use !statues {location} to see who stands where.");
             }
-            
+
             else
             {
                 if (location == null)
@@ -72,14 +78,16 @@ namespace FChatDicebot.BotCommands
                 }
                 else
                 {
-                    returnText = "Listed below is the identity of every resident that has been petrified " + Utils.LocationToText(location, "the initiator", "the recipient") + ", as well as their species (if known) to indicate their appearance.\n";
+                    string locationText = Utils.LocationToText(location, "the initiator", "the recipient");
+                    returnText = ReadoutText.Title("Statues " + locationText) + "\n"
+                        + "Listed below is the identity of every resident that has been petrified " + locationText + ", as well as their species (if known) to indicate their appearance.\n";
                     foreach (Interaction interaction in petrifyInteractions)
                     {
                         if (interaction.identifier == location)
                         {
                             Profile statue = MonDB.getProfile(interaction.recipient);
                             if (statue == null) continue; // petrified resident's profile no longer exists (L13)
-                            returnText += "\n" + statue.displayName;
+                            returnText += ReadoutText.RowIndent + statue.displayName;
                             if (statue.characteristics.ContainsKey("monster"))
                             {
                                 returnText += ", " + statue.characteristics["monster"];
@@ -89,6 +97,7 @@ namespace FChatDicebot.BotCommands
                             {
                                 returnText += " " + Utils.LocationToText(location, interaction.initiator, interaction.recipient);
                             }
+                            returnText += "\n";
                         }
                     }
                 }

--- a/FChatDicebot/BotCommands/ChateauTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauTitles.cs
@@ -65,9 +65,7 @@ namespace FChatDicebot.BotCommands
 
         private string BuildTitlesText(Profile profile, bool viewingOwnTitles)
         {
-            string header = viewingOwnTitles
-                ? "[b][u]Your Titles[/u][/b]\n"
-                : $"[b][u]{profile.displayName}'s Titles[/u][/b]\n";
+            string header = ReadoutText.Title("Titles of " + profile.displayName) + "\n";
 
             if (profile.titles == null || profile.titles.Count == 0)
             {
@@ -77,43 +75,31 @@ namespace FChatDicebot.BotCommands
             }
 
             StringBuilder sb = new StringBuilder(header);
-            DateTime Dat = DateTime.UtcNow;
-            sb.AppendLine($"Total titles: {profile.titles.Count}\n");
-            //version that includes dates
-            //sb.AppendLine($"Total titles: {profile.titles.Count}\n Dates are provided in Unified Time of Chateau. It is currently the " + Dat.Day + Utils.GetDaySuffix(Dat.Day) + " day, " + Dat.Month.ToString() + Utils.GetDaySuffix(Dat.Month) + " month, in year 1" + Dat.Year.ToString() +  " of our Queen");
+            sb.Append(ReadoutText.Row("Total titles", ReadoutText.Num(profile.titles.Count))).Append('\n');
 
-            for (int i = 0; i < profile.titles.Count; i++)
-            {
-                Title title = profile.titles[i];
-                string formattedTitle = title.GetFormattedTitle();
-                string grantedBy = title.IsSystemTitle ? "[i]Chateau[/i]" : MonDB.getDisplayName(title.givenBy);
-                string grantedDate = title.grantedTime.ToString("dd-MM-1yyyy");
+            // Every earned title, on one wrapped row. Was a manual four-space join that also
+            // left a trailing separator on the last entry.
+            sb.Append(ReadoutText.InlineSection("All titles", ReadoutDomain.Relationship,
+                profile.titles.Select(t => t.GetFormattedTitle()).ToList()));
 
-                sb.Append($"{formattedTitle}    ");
-                //version that includes dates
-                //sb.AppendLine($"{formattedTitle}    [sub]Granted by: {grantedBy} on {grantedDate}[/sub]");
-            }
-
-            // Show which titles are currently displayed
+            // Which of them the resident has pinned to their dossier. Only filled slots are
+            // listed: rendering all nine unconditionally meant a resident using two of them got
+            // seven numbered rows with nothing after the colon.
             if (profile.displayedTitleSlots != null)
             {
-                sb.AppendLine("");
-                sb.AppendLine("[u]Currently Displayed Titles[/u]");
-                int slotCount = 0;
-                foreach (int slot in profile.displayedTitleSlots)
+                List<string> displayed = new List<string>();
+                for (int i = 0; i < profile.displayedTitleSlots.Length; i++)
                 {
-                    slotCount++;
-                    sb.Append($"    {slotCount}: ");
-                    if (slot >= 0)
-                    {
-                        sb.Append(profile.titles[slot].GetFormattedTitle());
-                    }
+                    int slot = profile.displayedTitleSlots[i];
+                    if (slot < 0 || slot >= profile.titles.Count) continue;
+                    displayed.Add(ReadoutText.Row((i + 1).ToString(), profile.titles[slot].GetFormattedTitle()));
                 }
+                sb.Append(ReadoutText.InlineSection("Currently displayed", ReadoutDomain.Relationship, displayed));
             }
 
             if (viewingOwnTitles)
             {
-                sb.AppendLine("\n[sub]You can use !settitle {slot number} {\"title text in quotes\"} to set which titles display in your dossier (up to 9).[/sub]");
+                sb.Append(ReadoutText.Footer("You can use !settitle {slot number} {\"title text in quotes\"} to set which titles display in your dossier (up to 9)."));
             }
 
             return sb.ToString();

--- a/FChatDicebot/BotCommands/Support/BondTreeSupport.cs
+++ b/FChatDicebot/BotCommands/Support/BondTreeSupport.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.Model;
+﻿using FChatDicebot.Model;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -173,24 +173,25 @@ namespace FChatDicebot.BotCommands.Support
                     : rootDisplay + " has no bonds yet.";
             }
 
-            string treeLabel = familyOnly ? "Family tree" : "Bond tree";
-            string header = "[b]" + treeLabel + " for " + rootDisplay + ", up to " + degrees +
-                            (degrees == 1 ? " degree:" : " degrees:") + "[/b]";
+            string treeLabel = familyOnly ? "Family Tree" : "Bond Tree";
+            string header = ReadoutText.Title(treeLabel + " of " + rootDisplay) + "\n"
+                + ReadoutText.Small("Up to " + degrees + (degrees == 1 ? " degree" : " degrees"));
 
             StringBuilder body = new StringBuilder();
             foreach (KeyValuePair<int, List<Connection>> kv in byDegree)
             {
                 if (kv.Value.Count == 0) continue;
-                body.Append("\n[u]").Append(kv.Key).Append(Utils.GetDaySuffix(kv.Key)).Append(" degree:[/u]");
+                body.Append('\n').Append(ReadoutText.Section(
+                    kv.Key + Utils.GetDaySuffix(kv.Key) + " degree", ReadoutDomain.Relationship));
                 foreach (Connection c in kv.Value.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
                 {
-                    body.Append("\n  ").Append(c.Name).Append(" (").Append(c.ConnectorName)
-                        .Append("'s ").Append(c.Role).Append(")");
+                    body.Append('\n').Append(ReadoutText.RowIndent).Append(c.Name).Append(' ')
+                        .Append(ReadoutText.Small("(" + c.ConnectorName + "'s " + c.Role + ")"));
                 }
             }
             if (capReached)
             {
-                body.Append("\n…and more (limit reached)");
+                body.Append('\n').Append(ReadoutText.Small("...and more (limit reached)"));
             }
 
             string bodyText = body.ToString();

--- a/FChatDicebot/BotCommands/Support/ChateauStatisticsSupport.cs
+++ b/FChatDicebot/BotCommands/Support/ChateauStatisticsSupport.cs
@@ -43,7 +43,7 @@ namespace FChatDicebot.BotCommands.Support
             foreach (var entry in top)
             {
                 string label = entry.Value == 1 ? Utils.JobToText(entry.Key) : Utils.JobToPlural(entry.Key);
-                parts.Add(entry.Value + " " + label);
+                parts.Add(ReadoutText.Num(entry.Value) + " " + label);
             }
             return string.Join(", ", parts);
         }

--- a/FChatDicebot/BotCommands/Uptime.cs
+++ b/FChatDicebot/BotCommands/Uptime.cs
@@ -40,11 +40,11 @@ namespace FChatDicebot.BotCommands
 
             if (!commandController.MessageCameFromChannel(address))
             {
-                bot.SendPrivateMessage("Chateau Contract has been online for " + DoubleTime.PrintTimeFromSeconds(onlineTime), address);
+                bot.SendPrivateMessage("Chateau Contract has been online for " + Model.ReadoutText.Num(DoubleTime.PrintTimeFromSeconds(onlineTime)), address);
             }
             else
             {
-                bot.SendMessageInChannel("Chateau Contract has been online for " + DoubleTime.PrintTimeFromSeconds(onlineTime), address);
+                bot.SendMessageInChannel("Chateau Contract has been online for " + Model.ReadoutText.Num(DoubleTime.PrintTimeFromSeconds(onlineTime)), address);
             }
         }
     }

--- a/FChatDicebot/Model/ReadoutText.cs
+++ b/FChatDicebot/Model/ReadoutText.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FChatDicebot.Model
+{
+    /// <summary>
+    /// Which family of information a readout section belongs to. Drives the section-header
+    /// colour so the same kind of fact wears the same colour in every readout — a resident
+    /// who learns that red means "something is currently on you" in <c>!dossier</c> reads
+    /// <c>!statistics</c> the same way without being taught twice.
+    /// </summary>
+    public enum ReadoutDomain
+    {
+        /// <summary>No colour. Neutral sections and anything historical or narrative.</summary>
+        None,
+        /// <summary>Things currently afflicting someone: curses, parasites, breaks, scents, corruption.</summary>
+        Affliction,
+        /// <summary>Connections between residents: bonds, marks, employment rosters, populations.</summary>
+        Relationship,
+        /// <summary>Tallies and history: interaction counts, offspring, experience, lifetime totals.</summary>
+        Record,
+        /// <summary>Money, goods and work: vaults, collections, payroll, workforce.</summary>
+        Economy,
+        /// <summary>Documentation fields in <c>!help</c> and the identifier lookups.</summary>
+        Reference
+    }
+
+    /// <summary>
+    /// Single source of truth for the BBCode grammar shared by every informative readout
+    /// (<c>!dossier</c>, <c>!bank</c>, <c>!statistics</c>, the drill-downs, <c>!help</c>, ...).
+    ///
+    /// Before this, each readout was written on its own and drifted: <c>!dossier</c> alone
+    /// carried three section-header shapes (<c>[b]Active Curses:[/b]</c>,
+    /// <c>Currently known [b]Marks[/b]:</c>, <c>Days of [b]Experience[/b] working as...</c>),
+    /// <c>!bank</c> bolded the value where <c>!dossier</c> bolded the label, and four different
+    /// inline separators were in use across five commands. Route new readout text through the
+    /// helpers here rather than hand-assembling tags.
+    ///
+    /// Colour note: F-Chat resolves <c>[color=x]</c> to a fixed hex regardless of theme
+    /// (<c>scss/_flist_derived.scss</c>; only <c>blue</c> is redefined per theme). Colours are
+    /// therefore chosen once here and not per call site. Black and white are never used —
+    /// each is invisible on one of the two themes.
+    /// </summary>
+    public static class ReadoutText
+    {
+        /// <summary>Gap between cells in a one-line section. The only inline separator in use.</summary>
+        public const string InlineSeparator = "   ";
+
+        /// <summary>Leading indent for rows sitting under a section header.</summary>
+        public const string RowIndent = "  ";
+
+        /// <summary>Row count above which a multi-line section collapses into a spoiler.</summary>
+        public const int SpoilerLineThreshold = 6;
+
+        /// <summary>
+        /// The colour a section header wears for a given domain, or null for no colour.
+        /// </summary>
+        public static string DomainColor(ReadoutDomain domain)
+        {
+            switch (domain)
+            {
+                case ReadoutDomain.Affliction: return "red";
+                case ReadoutDomain.Relationship: return "purple";
+                case ReadoutDomain.Record: return "blue";
+                case ReadoutDomain.Economy: return "brown";
+                case ReadoutDomain.Reference: return "purple";
+                default: return null;
+            }
+        }
+
+        /// <summary>
+        /// The readout's opening line: <c>[b][u]Title[/u][/b]</c>. Exactly one per readout, and
+        /// the only place bold-and-underline is used, so it can't be confused with a section.
+        /// </summary>
+        public static string Title(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return "[b][u]" + text + "[/u][/b]";
+        }
+
+        /// <summary>
+        /// A section header: <c>[b][color=x]Header:[/color][/b]</c>. The colon is applied here
+        /// rather than by callers, which is what kept it drifting inside and outside the tag.
+        /// Pass <paramref name="header"/> without trailing punctuation.
+        /// </summary>
+        public static string Section(string header, ReadoutDomain domain)
+        {
+            if (string.IsNullOrEmpty(header)) return string.Empty;
+            string color = DomainColor(domain);
+            string inner = header.TrimEnd(':', ' ') + ":";
+            if (!string.IsNullOrEmpty(color))
+            {
+                inner = "[color=" + color + "]" + inner + "[/color]";
+            }
+            return "[b]" + inner + "[/b]";
+        }
+
+        /// <summary>
+        /// A row label: <c>[u]Label:[/u]</c>. Pass <paramref name="label"/> without the colon.
+        /// </summary>
+        public static string Label(string label)
+        {
+            if (string.IsNullOrEmpty(label)) return string.Empty;
+            return "[u]" + label.TrimEnd(':', ' ') + ":[/u]";
+        }
+
+        /// <summary>
+        /// The number a line exists to report. The unit stays outside the tag, so
+        /// <c>Num(340) + " gold"</c> gives "[b]340[/b] gold" rather than bolding the whole
+        /// phrase — the value is what the eye should catch.
+        ///
+        /// Deliberately does not apply thousands separators: <see cref="TextFormat.ApplyNumberCommas"/>
+        /// does that downstream when the channel opts in, and it already knows to skip digits
+        /// inside identifier-bearing tags.
+        /// </summary>
+        public static string Num(long value)
+        {
+            return "[b]" + value + "[/b]";
+        }
+
+        /// <summary>Overload for values a caller has already formatted (e.g. "8,140" or "3 copper").</summary>
+        public static string Num(string formatted)
+        {
+            if (string.IsNullOrEmpty(formatted)) return string.Empty;
+            return "[b]" + formatted + "[/b]";
+        }
+
+        /// <summary>A full row: <c>[u]Label:[/u] value</c>.</summary>
+        public static string Row(string label, string value)
+        {
+            return Label(label) + " " + value;
+        }
+
+        /// <summary>
+        /// Capitalises the first actual letter, stepping over any leading BBCode tags.
+        ///
+        /// Row labels are Title Case, but some <c>Utils.*ToText</c> helpers hand back a
+        /// colour-wrapped phrase rather than a bare word — <c>SubstanceToText("lustessence")</c>
+        /// returns "[color=purple]Lust Essence[/color]" while <c>SubstanceToText("milk")</c>
+        /// returns "milk". A plain <c>char.ToUpper(s[0])</c> would uppercase the "[" and leave
+        /// the word untouched, so the two rendered with different casing side by side.
+        ///
+        /// Deliberately not folded into <see cref="Label"/>: plenty of labels are display names
+        /// or userName fallbacks, which must be shown exactly as stored.
+        /// </summary>
+        public static string CapitalizePastTags(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return text;
+
+            int i = 0;
+            while (i < text.Length && text[i] == '[')
+            {
+                int close = text.IndexOf(']', i);
+                if (close < 0) return text; // malformed; leave it alone
+                i = close + 1;
+            }
+            if (i >= text.Length || !char.IsLetter(text[i]) || char.IsUpper(text[i])) return text;
+
+            return text.Substring(0, i) + char.ToUpper(text[i]) + text.Substring(i + 1);
+        }
+
+        /// <summary>Small print. Bookkeeping notes, parentheticals and command pointers.</summary>
+        public static string Small(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return string.Empty;
+            return "[sub]" + text + "[/sub]";
+        }
+
+        /// <summary>
+        /// A section's closing pointer at sibling commands, on its own line in small print.
+        /// </summary>
+        public static string Footer(string text)
+        {
+            return Small(text);
+        }
+
+        /// <summary>
+        /// An empty slot. Small print rather than body weight so a resident with no pledges
+        /// doesn't read a screenful of "None" as loudly as real data.
+        /// </summary>
+        public static string None()
+        {
+            return Small("None");
+        }
+
+        /// <summary>
+        /// Renders a one-line section: a header followed by cells on the same line, separated
+        /// by <see cref="InlineSeparator"/>. Returns empty for an empty cell list so callers
+        /// can append unconditionally. Used wherever a row is a short label and one number.
+        /// </summary>
+        public static string InlineSection(string header, ReadoutDomain domain, IList<string> cells)
+        {
+            if (cells == null || cells.Count == 0) return string.Empty;
+            return Section(header, domain) + " " + string.Join(InlineSeparator, cells) + "\n";
+        }
+
+        /// <summary>
+        /// Renders a multi-line section: one indented row per line under the header. Past
+        /// <see cref="SpoilerLineThreshold"/> rows the body collapses into a spoiler with
+        /// <paramref name="summary"/> (e.g. "23 residents across 11 roles") left visible beside
+        /// the header, so a collapsed block still reports its own size.
+        /// </summary>
+        public static string LineSection(string header, ReadoutDomain domain, string summary, IList<string> rows)
+        {
+            if (rows == null || rows.Count == 0) return string.Empty;
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(Section(header, domain));
+
+            IEnumerable<string> indented = rows.Select(r => RowIndent + r);
+
+            if (rows.Count > SpoilerLineThreshold)
+            {
+                if (!string.IsNullOrEmpty(summary))
+                {
+                    sb.Append(' ').Append(summary);
+                }
+                sb.Append(" [spoiler]\n");
+                sb.Append(string.Join("\n", indented));
+                sb.Append("[/spoiler]\n");
+            }
+            else
+            {
+                sb.Append('\n');
+                sb.Append(string.Join("\n", indented));
+                sb.Append('\n');
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Joins the section groups that actually produced content, separating each with a
+        /// blank line. Skipping empties is what stops a resident with no active curses from
+        /// getting a stray gap where the affliction group would have been.
+        /// </summary>
+        public static string JoinClusters(params string[] clusters)
+        {
+            return string.Join("\n", clusters.Where(c => !string.IsNullOrEmpty(c)));
+        }
+    }
+}

--- a/wiki-docs/Style-Guide.md
+++ b/wiki-docs/Style-Guide.md
@@ -70,6 +70,49 @@ If you add a new interaction whose past/present/future form isn't a regular `-ed
 
 `[user]…[/user]` appears in literal usage examples and inside error text — not in narration.
 
+### 7a. Colour
+
+F-Chat resolves `[color=x]` to a **fixed hex regardless of theme** (`scss/_flist_derived.scss` in `f-list/exported`; only `blue` is redefined per theme, `#00f` → `#06f` on dark). The palette was tuned for a black background, so most of it has poor contrast on the light theme. Measured against the real backgrounds (`#000` dark, `#e5e5e5` light):
+
+| Colour | Contrast dark / light | Use |
+|--------|----------------------|-----|
+| `blue`, `purple`, `brown`, `red` | ≥3:1 on both | the readout section palette — safe anywhere |
+| `orange`, `green`, `yellow`, `cyan`, `pink`, `gray` | fails on light | sparingly, and only where losing it on one theme is acceptable |
+| `black`, `white` | each invisible on one theme | **never** |
+
+The `!help` tier line deliberately keeps green → yellow → orange → red because the stoplight ramp reads as escalating seriousness, which is worth more there than palette consistency. `ViceText` likewise keeps `[color=yellow]` for golden fluid.
+
+### 7b. The readout grammar
+
+Every informative readout (`!dossier`, `!bank`, `!statistics`, `!bottles`, `!titles`, `!pledges`, `!business`, `!help`, the drill-downs) builds its output from `Model/ReadoutText.cs`. Don't hand-assemble these tags — the helpers exist because five commands had drifted into five different conventions for the same data shape.
+
+| Element | Helper | Form |
+|---------|--------|------|
+| Title line | `ReadoutText.Title(text)` | `[b][u]Title[/u][/b]` — exactly one, first line, the only bold-underline in the readout |
+| Section header | `ReadoutText.Section(header, domain)` | `[b][color=x]Header:[/color][/b]` — Sentence case, colon applied by the helper |
+| Row label | `ReadoutText.Label(label)` / `Row(label, value)` | `[u]Label:[/u] value` — Title Case |
+| Number | `ReadoutText.Num(value)` | `[b]148[/b]` — the unit stays outside the tag |
+| Small print | `ReadoutText.Small(text)` | `[sub]…[/sub]` |
+| Footer | `ReadoutText.Footer(text)` | `[sub]…[/sub]` on its own last line, pointing at sibling commands |
+| Empty slot | `ReadoutText.None()` | `[sub]None[/sub]` — never a bare body-weight "None" |
+| Row indent | `ReadoutText.RowIndent` | two spaces, for rows under a section header |
+| Inline separator | `ReadoutText.InlineSeparator` | three spaces, the only separator |
+| One-line block | `ReadoutText.InlineSection(header, domain, cells)` | header plus cells on one line |
+| Multi-line block | `ReadoutText.LineSection(header, domain, summary, rows)` | one indented row per line; collapses to `[spoiler]` past 6 rows with the count left visible |
+
+`ReadoutDomain` picks the section colour so the same kind of fact wears the same colour in every readout:
+
+| Domain | Colour | Covers |
+|--------|--------|--------|
+| `Affliction` | red | curses, parasites, breaks, scents, corruption |
+| `Relationship` | purple | bonds, marks, employment rosters, populations, pledges |
+| `Record` | blue | interaction counts, offspring, lifetime totals |
+| `Economy` | brown | vaults, collections, payroll, workforce |
+| `Reference` | purple | `!help` fields, identifier lookups |
+| `None` | none | history and neutral sections |
+
+**A section with no qualifying rows is hidden entirely, header included.** Both `InlineSection` and `LineSection` return empty for an empty row list; hand-rolled blocks must do the same. A bare coloured heading introducing nothing reads as a bug.
+
 ## 8. Punctuation and flavor
 
 - **Exclamation marks are abundant.** Nearly every completion and most consent prompts end with `!`. The Chateau is enthusiastic. Use them.


### PR DESCRIPTION
Standardizes BBCode across the informative readouts and adds section colour, behind a shared grammar helper.

## Why

The readouts had each been written on their own and drifted. `!dossier` alone carried three section-header shapes — `[b]Active Curses:[/b]`, `Currently known [b]Marks[/b]:`, `Days of [b]Experience[/b] working as...` — `!bank` bolded the value where `!dossier` bolded the label, and four different inline separators were in use across five commands.

## What changed

New `FChatDicebot/Model/ReadoutText.cs` is the SSOT for the grammar: `Title` / `Section` / `Label` / `Row` / `Num` / `Small` / `Footer` / `None`, plus `InlineSection`, `LineSection`, `RowIndent`, `InlineSeparator`, and the spoiler-past-six-rows rule generalized out of `ChateauDossier`. Section colour comes from a `ReadoutDomain` passed at each call site, so the same kind of fact wears the same colour everywhere.

Applied to 21 commands plus `BondTreeSupport` and `ChateauStatisticsSupport`. Personal readouts are titled `{Thing} of {displayName}` so a renamed resident's title line carries the `[s]old[/s] new` strikethrough.

## On colour — the constraint that shaped this

F-Chat resolves `[color=x]` to a **fixed hex regardless of theme** (`scss/_flist_derived.scss` in `f-list/exported`; only `blue` is redefined per theme, `#00f` → `#06f` on dark). The palette was tuned for a black background, so measured against the real grounds (`#000` dark, `#e5e5e5` light) only **blue, purple, brown and red** clear 3:1 on both. Those four are the section palette:

| Domain | Colour | Covers |
|---|---|---|
| Affliction | red | curses, parasites, breaks, scents, corruption |
| Relationship | purple | bonds, marks, employment rosters, populations, pledges |
| Record | blue | interaction counts, offspring, lifetime totals |
| Economy | brown | vaults, collections, payroll, workforce |
| Reference | purple | `!help` fields, identifier lookups |

`!help`'s tier line deliberately keeps its green → yellow → orange → red stoplight — the escalation reading is worth more there than palette consistency — and `ViceText` keeps golden yellow. Both owner-confirmed.

## Latent bugs fixed in passing

- `!titles` rendered all nine display slots unconditionally, so a resident using two of them got seven numbered rows with nothing after the colon.
- `!statistics` emitted section headers unconditionally, so a young Chateau printed a bare `Influence` heading introducing nothing.
- `!help`'s Involved-tier cooldown note had its closing bracket outside the `[sub]`, rendering a stray `)`.
- `!populations` and `!feedbacklist` both used em-dashes, which the style guide bans.

## Reviewer notes

- **No behaviour change beyond text.** No DB schema, no new collections, no interaction logic touched. `ReadoutText.Num` deliberately does not apply thousands separators — `TextFormat.ApplyNumberCommas` still does that downstream when the channel opts in.
- **`[sub]` is true subscript in F-Chat**, smaller *and* baseline-shifted. The codebase uses it as small print and this sweep leans on it more than before (footers, superlatives, parentheticals). Worth a real-client eyeball.
- **Not swept:** `!work`, `!volunteer`, `!sell`, `!abandonpledge`, `!feedback`, `!joinchateau`, `!modmessage`, `!random`, `!seteicon`, `!settitle` — action commands that report a result rather than readouts. `!work`/`!volunteer`/`!sell` quote currency amounts and would benefit from the same bold-number rule; easy follow-up.
- Grammar and palette documented in `wiki-docs/Style-Guide.md` §7a/§7b.

## Testing

1768 unit tests pass; main project builds clean with no warnings. Every string in the review page was captured from the built code against a seeded resident rather than hand-written, which is how the `!titles` empty-slot and `!statistics` empty-header bugs surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
