### PR TITLE
Give the dossier a masthead and separate its record and holdings blocks

### DIFF
--- a/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
+++ b/FChatDicebot.Tests/Unit/Chateaudossiertests.cs
@@ -873,7 +873,7 @@ namespace FChatDicebot.Tests.Unit
         }
 
         [Fact]
-        public void BuildAtAGlanceSection_MergesTitlesAndCurrency()
+        public void BuildCollectionsSection_MergesTitlesAndCurrency()
         {
             var profile = new ProfileBuilder()
                 .WithUserName("TestUser")
@@ -883,7 +883,7 @@ namespace FChatDicebot.Tests.Unit
             profile.titles = new List<Title> { new Title { titleText = "The Brave", givenBy = "Alice" } };
             _fixture.Database.SetProfile("TestUser", profile);
 
-            string result = InvokeBuildAtAGlanceSection(_fixture.Database.GetProfile("TestUser"));
+            string result = InvokeBuildCollectionsSection(_fixture.Database.GetProfile("TestUser"));
 
             Assert.Contains("[u]Titles Earned:[/u] [b]1[/b]", result);
             Assert.Contains("[u]Richest Currency:[/u] [b]12[/b] gold", result);
@@ -891,14 +891,14 @@ namespace FChatDicebot.Tests.Unit
         }
 
         [Fact]
-        public void BuildAtAGlanceSection_NoTitlesOrCurrency_ReturnsEmpty()
+        public void BuildCollectionsSection_NoTitlesOrCurrency_ReturnsEmpty()
         {
             var profile = new ProfileBuilder()
                 .WithUserName("TestUser")
                 .WithDisplayName("Test User")
                 .BuildAndSave(_fixture.Database);
 
-            Assert.Empty(InvokeBuildAtAGlanceSection(profile));
+            Assert.Empty(InvokeBuildCollectionsSection(profile));
         }
 
         [Fact]
@@ -1102,9 +1102,9 @@ namespace FChatDicebot.Tests.Unit
             return (string)method.Invoke(_dossier, new object[] { profile, targetUser });
         }
 
-        private string InvokeBuildAtAGlanceSection(Profile profile)
+        private string InvokeBuildCollectionsSection(Profile profile)
         {
-            var method = typeof(ChateauDossier).GetMethod("BuildAtAGlanceSection",
+            var method = typeof(ChateauDossier).GetMethod("BuildCollectionsSection",
                 BindingFlags.NonPublic | BindingFlags.Instance);
             return (string)method.Invoke(_dossier, new object[] { profile });
         }

--- a/FChatDicebot/BotCommands/ChateauDossier.cs
+++ b/FChatDicebot/BotCommands/ChateauDossier.cs
@@ -176,6 +176,13 @@ namespace FChatDicebot.BotCommands
         private const string InlineSeparator = ReadoutText.InlineSeparator;
 
         /// <summary>
+        /// Letterhead occupying the dossier's first line, where F-Chat prepends the sender name
+        /// and timestamp. Superscript because it's a document header rather than content, and
+        /// it needs to stay visually subordinate to the resident's name on the line below.
+        /// </summary>
+        public const string Masthead = "[sup]Official Chateau Contract Dossier[/sup]\n";
+
+        /// <summary>
         /// Constructor for dependency injection (for testing)
         /// </summary>
         public ChateauDossier(IChateauDatabase database)
@@ -235,10 +242,15 @@ namespace FChatDicebot.BotCommands
         /// </summary>
         private string BuildFullDossier(Profile profile, string targetUser)
         {
-            // Who they are.
-            string header = BuildNameTitleSpecialties(profile, targetUser);
+            // Who they are. The masthead exists to absorb the client's own prefix: F-Chat puts
+            // the sender name and timestamp ahead of the first line only, so whatever lands
+            // there is indented relative to everything below it. Spending that line on a
+            // letterhead means the resident's name — and every section under it — starts flush
+            // left instead of the name alone sitting adrift.
+            string identity = Masthead
+                + BuildNameTitleSpecialties(profile, targetUser);
             string jobSection = BuildJobSection(profile);
-            string identity = header + jobSection;
+            identity += jobSection;
 
             // What's currently on them.
             string state =
@@ -254,13 +266,19 @@ namespace FChatDicebot.BotCommands
                 BuildMarksSection(profile) +
                 BuildCurrentlyEmploysSection(targetUser);
 
-            // What they've done.
-            string tallies =
+            // What they've done. Kept apart from the holdings cluster below so the blue
+            // record sections and the brown economy sections don't butt up against each other
+            // with no breathing room — every other colour change in the dossier gets a blank
+            // line, and this one was the exception.
+            string records =
                 BuildCasualInteractionsSection(profile) +
                 BuildInteractionCountsSection(profile) +
                 BuildOffspringSection(profile, targetUser) +
-                BuildPersonallyPlantedSection(targetUser) +
-                BuildAtAGlanceSection(profile) +
+                BuildPersonallyPlantedSection(targetUser);
+
+            // What they hold.
+            string holdings =
+                BuildCollectionsSection(profile) +
                 BuildJobExperienceSection(profile);
 
             // What happened lately.
@@ -273,12 +291,12 @@ namespace FChatDicebot.BotCommands
             // header + "\n\n") keeps this correct as sections get added or reordered. A job
             // counts as content — it's something in their file, even with no interactions yet.
             if (jobSection.Length == 0 && state.Length == 0 && relationships.Length == 0
-                && tallies.Length == 0 && lately.Length == 0)
+                && records.Length == 0 && holdings.Length == 0 && lately.Length == 0)
             {
                 return identity + "\n" + ReadoutText.Small("A recent arrival to the Chateau. There doesn't seem to be much in their file... there will be more to read once they interact with others. Maybe you should give them a !kiss");
             }
 
-            return ReadoutText.JoinClusters(identity, state, relationships, tallies, lately);
+            return ReadoutText.JoinClusters(identity, state, relationships, records, holdings, lately);
         }
 
         /// <summary>
@@ -612,14 +630,14 @@ namespace FChatDicebot.BotCommands
 
         /// <summary>
         /// Three standalone one-line facts — titles earned, wealthiest currency and bottle
-        /// count — sharing a row so they read as an at-a-glance stat line rather than owning a
-        /// line each. Any one renders alone when the others are absent.
+        /// count — sharing a row rather than owning a line each. Any one renders alone when
+        /// the others are absent.
         ///
         /// These used to be bare "[b]Label:[/b] value" fragments with no header of their own,
         /// which made three unrelated facts look like three separate sections. They're cells
         /// now, under one header like every other inline block.
         /// </summary>
-        private string BuildAtAGlanceSection(Profile profile)
+        private string BuildCollectionsSection(Profile profile)
         {
             List<string> cells = new List<string>();
             string titles = BuildTitlesEarnedSection(profile);
@@ -628,7 +646,7 @@ namespace FChatDicebot.BotCommands
             if (!string.IsNullOrEmpty(titles)) cells.Add(titles);
             if (!string.IsNullOrEmpty(currency)) cells.Add(currency);
             if (!string.IsNullOrEmpty(bottled)) cells.Add(bottled);
-            return ReadoutText.InlineSection("At a glance", ReadoutDomain.Economy, cells);
+            return ReadoutText.InlineSection("Collections", ReadoutDomain.Economy, cells);
         }
 
         /// <summary>

--- a/wiki-docs/Style-Guide.md
+++ b/wiki-docs/Style-Guide.md
@@ -89,6 +89,7 @@ Every informative readout (`!dossier`, `!bank`, `!statistics`, `!bottles`, `!tit
 | Element | Helper | Form |
 |---------|--------|------|
 | Title line | `ReadoutText.Title(text)` | `[b][u]Title[/u][/b]` — exactly one, first line, the only bold-underline in the readout |
+| Masthead | `ChateauDossier.Masthead` | `[sup]…[/sup]` letterhead above the title line. `!dossier` only — see below |
 | Section header | `ReadoutText.Section(header, domain)` | `[b][color=x]Header:[/color][/b]` — Sentence case, colon applied by the helper |
 | Row label | `ReadoutText.Label(label)` / `Row(label, value)` | `[u]Label:[/u] value` — Title Case |
 | Number | `ReadoutText.Num(value)` | `[b]148[/b]` — the unit stays outside the tag |
@@ -112,6 +113,10 @@ Every informative readout (`!dossier`, `!bank`, `!statistics`, `!bottles`, `!tit
 | `None` | none | history and neutral sections |
 
 **A section with no qualifying rows is hidden entirely, header included.** Both `InlineSection` and `LineSection` return empty for an empty row list; hand-rolled blocks must do the same. A bare coloured heading introducing nothing reads as a bug.
+
+**Leave a blank line between colour changes.** Sections of the same `ReadoutDomain` sit flush against each other; a change of domain gets a blank line, so the colour shift reads as a new part of the document rather than a stray highlight. `ChateauDossier.BuildFullDossier` does this by grouping sections into clusters and joining them with `ReadoutText.JoinClusters`, which also drops empty clusters so an absent group leaves no gap.
+
+**`!dossier` opens with a masthead, not its title line.** F-Chat prepends the sender name and timestamp to the first line of a message only, so whatever lands there is indented relative to everything below it. `!dossier` spends that line on `[sup]Official Chateau Contract Dossier[/sup]` and puts the resident's name on line two, flush left with the rest of the document. Other readouts are short enough that the indent on their title line doesn't matter; if that changes, reuse this pattern rather than inventing a second one.
 
 ## 8. Punctuation and flavor
 


### PR DESCRIPTION
Three nitpicks from reading a real dossier in the client.

F-Chat prepends the sender name and timestamp to the first line of a message only, so the resident's name sat indented while every section below it was flush left. Spend that first line on a "[sup]Official Chateau Contract Dossier[/sup]" letterhead instead, so the name and the body share a left edge. Superscript keeps it subordinate to the name on the line below. The recent-arrival path gets it too.

The blue record sections ran straight into the brown economy sections with no blank line, which was the one colour change in the dossier that didn't get breathing room. Split the tallies cluster in two so JoinClusters separates them (and still drops either if it's empty).

Rename "At a glance" to "Collections".

Style guide gains the blank-line-between-colour-changes rule and a note on why !dossier opens with a masthead rather than its title line.