### PR TITLE
Automated daily feedback triage

### DIFF
--- a/scripts/feedback-triage/IMPLEMENT_PLAYBOOK.md
+++ b/scripts/feedback-triage/IMPLEMENT_PLAYBOOK.md
@@ -1,0 +1,109 @@
+# Implementation pass — playbook
+
+Runs after the owner approves an item in the review pass. A bug or wording fix goes straight to
+a branch and a PR. A feature stops at a spec for sign-off before any code is written.
+
+Everything here happens with the owner in the session. Nothing in this playbook is safe to run
+unattended.
+
+## Bug and wording fixes
+
+1. **Branch from main** in the main checkout:
+
+   ```
+   git checkout main
+   git pull
+   git checkout -b claude/feedback-<shortId>-<slug>
+   ```
+
+2. **Mark it in flight:**
+
+   ```
+   powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 set ^
+     -Id <full feedback id> -Fields "{\"status\":\"in_progress\",\"branch\":\"claude/feedback-<shortId>-<slug>\"}" ^
+     -Event implement -Detail "started"
+   ```
+
+3. **Fix the root cause**, not the symptom the resident happened to see. Follow the conventions
+   the codebase already uses — read the neighbours before writing:
+   - `wiki-docs\Development-Guide.md` and `wiki-docs\Architecture.md` for structure.
+   - Interactions are a processor + a command class + a registry entry + tests. Aliases are
+     their own delegating command class; the `Aliases` array is display-only and does not route.
+   - Shared text lives in one place: cooldown/consent warnings come from the `CooldownSpec` /
+     `ConsentWarningText` single source of truth (override `BuildConsentWarning`, never
+     `GetConsentWarning`); vices render through `ViceText.ViceName`; `Utils.*ToText` helpers read
+     `Identifier.displayText` from the DB, so new identifiers need no code change.
+   - Never expose "UTC day" to residents — say "Chateau day", or just "day".
+   - `FChatDicebot.csproj` globs `**\*.cs`, so a new file builds without a csproj edit.
+
+4. **Add or extend tests.** Pure helpers get unit tests (the `BuildFeedbackList` /
+   `ParseFeedback` mold); DB-touching behavior uses `Testdatabasefixture`, which needs local
+   Mongo running.
+
+   ```
+   dotnet build FChatDicebot.sln
+   dotnet test FChatDicebot.Tests\FChatDicebot.Tests.csproj
+   ```
+
+   A red build or a failing test is a stop-and-report, not something to work around.
+
+5. **Surface the wording.** Before calling anything done, list every changed user-facing string
+   (before → after) for the owner's approval, even when the dossier already drafted it and even
+   when the change is a single word. Apply their rewrites verbatim. First drafts come from
+   `wiki-docs\Style-Guide.md`.
+
+6. **Update the docs the change invalidates** — the relevant `wiki-docs\specs\*.md` as-shipped
+   notes, `wiki-docs\Command-Reference.md` if help text or usage changed.
+
+7. **Commit** (ask first; committing is gated), including the dossier and any ledger-adjacent
+   files so the paper trail lands with the fix:
+
+   ```
+   git add -A
+   git commit
+   ```
+
+   Message: what changed and why, referencing the feedback short id. End with the
+   `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>` trailer.
+
+8. **Open the PR** against `main` with `gh pr create`. The body states the resident's complaint,
+   the root cause, the fix, test coverage, and a link to the dossier path. End with the
+   `🤖 Generated with [Claude Code](https://claude.com/claude-code)` line. Never merge it —
+   merging is the owner's.
+
+9. **Record the PR:**
+
+   ```
+   powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 set ^
+     -Id <full feedback id> -Fields "{\"status\":\"pr_open\",\"prNumber\":<n>,\"prUrl\":\"<url>\"}" ^
+     -Event pr -Detail "<pr title>"
+   ```
+
+   The next daily pass notices the merge, sets `shipped`, and moves the dossier to `done\`.
+
+## Features
+
+1. **Write the spec first**, following the existing format and the conventions in
+   `wiki-docs\specs\README.md`: pre-implementation specs live in the `Future-*` subfolder that
+   fits (`Future-Interactions`, `Future-Economy`, `Future-Social`, `Infrastructure`), carry
+   Assumptions / dependencies / file-scaffolding sections, and mark every user-facing string as
+   pending owner wording review.
+2. Point the ledger at it and pause for sign-off:
+
+   ```
+   powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 set ^
+     -Id <full feedback id> -Fields "{\"status\":\"approved\",\"specPath\":\"wiki-docs/specs/Future-.../<Name>.md\"}" ^
+     -Event spec -Detail "spec written, awaiting sign-off"
+   ```
+
+3. Once the owner signs off on the spec, implement it exactly as the bug flow above (branch →
+   code → tests → wording review → PR). When it ships, the spec moves out of `Future-*` and
+   gains its `**Status:** Implemented.` line, per the specs README.
+
+## Do not
+
+- Merge PRs, or push to `main` directly.
+- Implement anything the owner declined or deferred, or expand scope past what they approved —
+  a second finding along the way is a note in the PR body or a new dossier, not a bonus commit.
+- Touch the `Feedback` collection. Ledger writes go through `ft.ps1`.
+- Message residents as the bot.

--- a/scripts/feedback-triage/README.md
+++ b/scripts/feedback-triage/README.md
@@ -1,0 +1,101 @@
+# Feedback triage
+
+A daily pass over the bot's `Feedback` collection (what residents send with `!feedback` /
+`!suggestion`): assess each new submission against the actual code, write it up, ask the owner
+for a decision, then take the approved ones through to a PR.
+
+Three phases, each with its playbook in this folder:
+
+| Phase | When | Playbook | Ends with |
+|-------|------|----------|-----------|
+| **Triage** | daily, unattended | [TRIAGE_PLAYBOOK.md](TRIAGE_PLAYBOOK.md) | a dossier per new submission + a notification |
+| **Review** | when you run `/feedback-review` | [REVIEW_PLAYBOOK.md](REVIEW_PLAYBOOK.md) | your decision + design answers recorded |
+| **Implement** | straight after approval | [IMPLEMENT_PLAYBOOK.md](IMPLEMENT_PLAYBOOK.md) | a PR (bugs) or a spec for sign-off (features) |
+
+The playbooks live in the repo on purpose — they are the actual instructions the automation
+follows, so improving the system is a normal PR.
+
+## What it never does
+
+- Writes to the `Feedback` collection. `FeedbackEntry` in `FChatDicebot/Model/ChateauDB.cs` has
+  no `[BsonIgnoreExtraElements]`, so any extra field there would break `!feedbacklist`
+  deserialization until the bot model changes and redeploys. All state lives in a separate
+  `FeedbackTriage` collection.
+- Commits, branches, or changes code in the unattended pass.
+- Merges a PR.
+- Messages residents as the bot. A submission needing clarification becomes a `needs_info`
+  item for you to relay.
+
+## Daily run
+
+Installed as a Claude Code scheduled task (`feedback-triage` in
+`C:\Users\blazi\.claude\scheduled-tasks\`), firing daily at 08:12 local. It runs while the
+desktop app is open; if the app was closed at that time, it runs on next launch.
+
+You get a push notification **only when something needs you** — a new assessment, a stalled
+item, a merged fix, or entries left over past the per-run cap. Quiet days stay quiet, and the
+run still appends a line to `triage-log.md`.
+
+To run the pass by hand: `/feedback-triage`. To review what is waiting: `/feedback-review`
+(optionally with a short id, e.g. `/feedback-review 6a69a8a2`).
+
+## The ledger
+
+`ft.ps1` is the only thing that touches state. Every verb prints JSON.
+
+```bash
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 info
+```
+
+| Verb | Does |
+|------|------|
+| `info` | counts by status, plus how many submissions have never been assessed |
+| `new` | submissions with no ledger row yet — the work list, oldest first |
+| `status` | ledger rows; `-AwaitingOwner`, `-Open`, `-Status approved,pr_open` filter it |
+| `set` | upsert one row: `-Id <24-char hex> -Fields '<json>' -Event <name> -Detail <text>` |
+| `seed` | insert rows only where none exists — for pre-marking history, never clobbers |
+
+Connection overrides: `-Conn mongodb://... -Database OtherDb -MongoSh C:\path\mongosh.exe`.
+Requires [mongosh](https://www.mongodb.com/try/download/shell) on PATH.
+
+A row is keyed by the feedback `_id` hex, snapshots the submission (so it stays readable after
+you delete the original), and appends a `history` entry on every write.
+
+### Statuses
+
+```
+assessed ─┬─> approved ──> in_progress ──> pr_open ──> shipped
+          ├─> deferred          (kept in queue/, not re-assessed)
+          ├─> declined          (closed; the detail is the only record of why)
+          └─> needs_info ──> (you relay the question) ──> approved | declined
+
+duplicate   another row covers it, see duplicateOf
+obsolete    the submission was deleted from the collection before a decision
+```
+
+`assessed` and `needs_info` are the two that mean "waiting on you".
+
+## Files
+
+```
+ft.ps1                  ledger CLI (the only writer)
+bin/ft.js               mongosh backend
+dossier-template.md     the per-submission write-up format
+queue/                  dossiers awaiting a decision, or deferred
+done/                   dossiers for shipped, declined, and obsolete items
+triage-log.md           one line per daily run (created on first run)
+```
+
+Dossiers are written untracked by the daily pass and get committed alongside the fix, so the
+assessment and the owner decision land in the PR that resolves them.
+
+## Troubleshooting
+
+- **`mongosh not found`** — install it, or pass `-MongoSh`.
+- **Connection refused** — the bot's Mongo (`mongodb://localhost:27017`) is not running.
+- **The task reports the playbook is missing** — it ran against a checkout that predates this
+  folder. `git pull` in `C:\source\repos\FCDiceBotCCVer`.
+- **An item you handled by hand keeps coming back** — it has no ledger row. Close it out with
+  `ft.ps1 seed`, e.g. `-Rows '[{"feedbackId":"<id>","fields":{"status":"shipped"},"detail":"fixed manually in <commit>"}]'`.
+- **A dossier got lost** — the ledger row still has the verdict and history. Delete the row's
+  status back to `assessed` only if you want the whole assessment redone.

--- a/scripts/feedback-triage/REVIEW_PLAYBOOK.md
+++ b/scripts/feedback-triage/REVIEW_PLAYBOOK.md
@@ -1,0 +1,85 @@
+# Owner review pass — playbook
+
+The owner is here and deciding. Your job is to present each assessed item compactly, get a
+decision plus any design answers, write both down where they survive, and then start the work
+they approved.
+
+Optional argument: a short id (e.g. `6a69a8a2`) to review just that item.
+
+## 1. Load the queue
+
+```
+cd C:\source\repos\FCDiceBotCCVer
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 status -AwaitingOwner
+```
+
+Read each row's `dossierPath`. Also run `ft.ps1 status -Open` once so you can mention anything
+already approved or in flight if the owner asks.
+
+If nothing is awaiting a decision, say so, mention what is in flight, and stop. Do not go
+hunting for new feedback — `ft.ps1 new` is the daily pass's job (though if it reports entries
+and the owner wants them assessed now, follow `TRIAGE_PLAYBOOK.md` for those first).
+
+## 2. Present one item at a time
+
+Oldest submission first. Before asking anything, give the owner a tight read — a few lines,
+not the whole dossier:
+
+- what the resident said (quoted, trimmed to the point)
+- what you found, with the `file:line` that matters
+- your recommendation and the effort estimate
+- for a `needs_info` item: exactly what question they would need to relay to the submitter
+
+Link the dossier so they can open the full assessment.
+
+## 3. Ask
+
+Use one `AskUserQuestion` call per item, up to 4 questions: the decision first, then that
+item's design questions from the dossier (recommended option first, as written). Keep the
+questions the dossier already framed — do not invent new forks at this stage.
+
+The decision question always offers:
+
+- **Approve** — do it now.
+- **Defer** — worth doing, not now (goes to `deferred`; it will not be re-assessed).
+- **Decline** — not doing it (goes to `declined`; ask for a one-line reason if they don't give
+  one, since it is the only record of why).
+- **Needs info** — cannot proceed until the submitter clarifies (`needs_info`).
+
+If the owner's answer conflicts with something the dossier assumed, say so plainly in one
+sentence and follow their call.
+
+## 4. Record the decision
+
+For each item, in this order:
+
+1. Append to the dossier's **Owner decision** section — the date, the decision, every answer
+   they gave verbatim-in-substance, and any instruction that changes the plan. Append; never
+   overwrite an earlier decision.
+2. Update the ledger:
+
+```
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 set ^
+  -Id <full feedback id> ^
+  -Fields "{\"status\":\"approved\",\"decidedAt\":null,\"decision\":{\"action\":\"fix\",\"notes\":\"<what they chose>\"}}" ^
+  -Event decision -Detail "<one-line summary of the decision>"
+```
+
+`status` is one of `approved`, `deferred`, `declined`, `needs_info`. For `duplicate`, set
+`duplicateOf`. Move the dossier to `done\` for anything closed out (`declined`, `duplicate`,
+`obsolete`); `deferred` dossiers stay in `queue\` so they remain visible.
+
+## 5. Start the approved work
+
+Ask whether to start now or leave it queued. When starting, follow
+[IMPLEMENT_PLAYBOOK.md](IMPLEMENT_PLAYBOOK.md) — bugs and wording fixes go to a branch and a
+PR, features get a spec for sign-off first.
+
+Handle approved items one at a time, finishing each (PR opened, or spec written) before
+starting the next, unless the owner says otherwise.
+
+## 6. Close the session out
+
+Report: what was decided, what is now in flight (with PR links), what is deferred, and what
+still needs the submitter contacted. The bot never PMs residents on its own — if the owner
+promised someone an answer, that is theirs to send.

--- a/scripts/feedback-triage/TRIAGE_PLAYBOOK.md
+++ b/scripts/feedback-triage/TRIAGE_PLAYBOOK.md
@@ -1,0 +1,151 @@
+# Daily triage pass — playbook
+
+You are running the unattended daily feedback pass. Nobody is watching: finish the whole
+pass, leave the repo in a clean state, and put anything that needs a human into the queue
+rather than guessing.
+
+**This pass assesses. It does not decide and it does not implement.**
+
+## Hard limits for this pass
+
+- **Never write to the `Feedback` collection.** It is read-only here. (`FeedbackEntry` in
+  `FChatDicebot/Model/ChateauDB.cs` has no `[BsonIgnoreExtraElements]`, so an extra field
+  breaks `!feedbacklist` until the bot model changes and redeploys.) All state goes in
+  `FeedbackTriage` via `ft.ps1`.
+- **Never commit, push, branch, or open a PR.** The dossiers you write stay untracked in the
+  working tree; the review pass commits them with the fix.
+- **Never change bot code.** No fixes, not even one-line typo fixes, however obvious.
+- **Never message a resident.** The bot is not driven from here; if a submission needs
+  clarification, that is a `needs_info` item for the owner to relay.
+- **Do not re-open closed rows.** A `declined` or `deferred` row stays closed unless the owner
+  says otherwise. In particular `6a51dd0b` (breadcrumb titles / more random events) is the
+  owner's own creative work and is declined on purpose.
+- **No silent truncation.** If you cap the work (see step 3), say so in the notification and
+  the log.
+
+## 1. Get to the repo
+
+Work in the main checkout, not a worktree:
+
+```
+cd C:\source\repos\FCDiceBotCCVer
+git checkout main
+git pull
+```
+
+If `scripts\feedback-triage\ft.ps1` does not exist, the feedback-triage branch has not been
+merged yet. Stop, notify the owner with exactly that, and do nothing else.
+
+## 2. Reconcile what is already in flight
+
+```
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 status -Open
+```
+
+For each open row:
+
+- `pr_open` with a `prNumber` — check it: `gh pr view <n> --json state,mergedAt,title`. If
+  merged, set `shipped` and move its dossier from `queue\` to `done\`. If closed unmerged, set
+  the row back to `approved` and note it in the notification.
+- `in_progress` older than 3 days with no PR — flag it in the notification as stalled. Do not
+  restart the work yourself.
+- `missing: true` and still pre-decision (`assessed` / `needs_info`) — the submission was
+  deleted from the collection, which is how the owner resolves things by hand. Set the row to
+  `obsolete` with a detail saying the submission is gone, and move the dossier to `done\`.
+  Leave post-decision rows alone; work already approved stays approved.
+
+## 3. Pick up new submissions
+
+```
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 new
+```
+
+Oldest first. If the list is empty and step 2 changed nothing, write the log line (step 7) and
+finish **without notifying** — a quiet day should stay quiet.
+
+Assess at most **6** new entries in one pass. Anything beyond that stays untriaged for
+tomorrow (it has no ledger row, so it comes back automatically) and gets counted in the
+notification.
+
+## 4. Assess each entry
+
+Read the submission carefully, then investigate the code before forming a verdict. For each
+entry:
+
+1. **Understand the claim.** Identify the commands and systems it names — residents write
+   things like "`!seteicon pet` says the wrong thing", which points at a specific string in a
+   specific processor.
+2. **Search the code.** Find the behavior. Get to a `file:line` you can point at. For a bug,
+   trace the actual cause rather than the first plausible-looking line; if you cannot confirm
+   it from the code, say so and record what would confirm it (a test, a DB query, a repro in
+   channel).
+3. **Check it is not already handled.** `git log --since="<submittedAt>" --oneline` plus a
+   grep of the relevant file. Feedback often lands before a fix ships.
+4. **Check for duplicates** against the other rows (`ft.ps1 status`) and the dossiers in
+   `queue\` and `done\`. If it duplicates an open item, verdict `duplicate` and name the
+   sibling; do not write a second full assessment.
+5. **Check the docs.** `wiki-docs\specs\` may already have a spec, a parked decision, or an
+   explicit "not doing this" for the idea. `wiki-docs\Feature-Requests.md` is the backlog.
+6. **Classify.**
+   - `bug` — behavior contradicts the design.
+   - `wording` — behavior is right, the text is wrong or misleading. Still a real fix.
+   - `feature` — new capability or a design change. Needs a spec before code.
+   - `duplicate`, `invalid` (mistaken premise — explain why), `owner_creative` (the owner's
+     own creative territory: title flavor, event authoring, lore), `needs_info` (cannot be
+     assessed without asking the submitter).
+7. **Recommend** `fix`, `spec`, `defer`, `decline`, or `ask`, with an effort estimate.
+8. **Write the open design questions.** Only genuine forks — each with 2–4 concrete options,
+   recommended first. These become the question dialogs the owner answers in the review pass,
+   so phrase them so they stand alone.
+9. **List every user-facing string that would change**, before → after, drafted against
+   `wiki-docs\Style-Guide.md`. The owner approves wording before anything ships, so having the
+   drafts ready is most of the review.
+
+## 5. Write the dossier
+
+Copy `dossier-template.md` and fill every section. One file per entry:
+
+```
+scripts\feedback-triage\queue\<yyyy-mm-dd of submission>-<shortId>-<slug>.md
+```
+
+e.g. `queue\2026-07-29-6a69a8a2-pledge-fulfilled-by-wrong-interaction.md`. Leave the
+**Owner decision** section empty.
+
+Length follows the item: a wording fix is half a page; a suspected cross-system bug earns as
+much detail as it takes to make the decision obvious. Quote the submission verbatim — never
+paraphrase it in the "What they said" block.
+
+## 6. Record it in the ledger
+
+One `set` per entry, after its dossier is written:
+
+```
+powershell -ExecutionPolicy Bypass -File scripts\feedback-triage\ft.ps1 set ^
+  -Id <full 24-char feedback id> ^
+  -Fields "{\"status\":\"assessed\",\"verdict\":\"bug\",\"recommendation\":\"fix\",\"confidence\":\"high\",\"effort\":\"small\",\"title\":\"<short title>\",\"dossierPath\":\"scripts/feedback-triage/queue/<file>.md\",\"duplicateOf\":null}" ^
+  -Event assessed -Detail "<one-line summary of the finding>"
+```
+
+Use `needs_info` as the status instead of `assessed` when the item cannot move without asking
+the submitter. Set `duplicateOf` to the other short id and status `duplicate` for dupes — no
+dossier needed for those beyond a two-line stub.
+
+## 7. Log and notify
+
+Append one line per run to `scripts\feedback-triage\triage-log.md` (create it if missing):
+
+```
+- 2026-07-30 — 2 assessed (6a69a8a2 bug/fix, 6a59933a wording/fix), 0 shipped, 0 stalled, 0 deferred to tomorrow.
+```
+
+Then, **only if the owner has something to act on** (a new `assessed`/`needs_info` row, a
+stalled item, a merged PR to celebrate, or entries left over past the cap), send one
+`PushNotification`: what is waiting and what to run. Keep it one line, under 200 characters:
+
+```
+2 feedback items need your call (1 bug, 1 wording fix). Run /feedback-review in FCDiceBotCCVer.
+```
+
+Finally, print a short summary of the pass: what you assessed, each verdict, each dossier
+path, anything you could not determine, and anything left for tomorrow.

--- a/scripts/feedback-triage/done/.gitkeep
+++ b/scripts/feedback-triage/done/.gitkeep
@@ -1,0 +1,1 @@
+# Dossiers for shipped, declined, duplicate, and obsolete items land here.

--- a/scripts/feedback-triage/dossier-template.md
+++ b/scripts/feedback-triage/dossier-template.md
@@ -1,0 +1,65 @@
+# <shortId> — <one-line title>
+
+| | |
+|---|---|
+| **Feedback id** | `<full 24-char _id>` |
+| **Submitted** | `<ISO timestamp>` (<relative>) by **<display name>** (`<login name>`) |
+| **Source** | channel `<name>` / private message |
+| **Tagged** | `<category as submitted>` |
+| **Verdict** | `bug` \| `wording` \| `feature` \| `duplicate` \| `invalid` \| `owner_creative` \| `needs_info` |
+| **Recommendation** | `fix` \| `spec` \| `defer` \| `decline` \| `ask` |
+| **Confidence** | high \| medium \| low |
+| **Effort** | trivial (<1h) \| small \| medium \| large |
+
+## What they said
+
+> <verbatim submission text, unedited>
+
+## What it means
+
+<Plain restatement of the complaint or request, naming the actual commands and systems
+involved. If the submission is ambiguous, say what the readings are and which one this
+assessment assumes.>
+
+## Assessment
+
+<What the code actually does today, with file:line references. For a bug: the root cause if
+found, or the narrowed-down suspects and what would confirm it. For a feature: what exists
+already, what would have to change, and which existing systems it rides on. Note whether
+anything since the submission date already changed this (git log check).>
+
+- **Reproduces / confirmed:** yes | no | can't tell from code alone — <why>
+- **Related code:** <file:line>, <file:line>
+- **Related specs / docs:** <wiki-docs/... links, or "none">
+- **Duplicate of:** <shortId, or "none">
+- **Already fixed since submission:** no | yes — <commit>
+
+## Recommended action
+
+<One paragraph: what should be done, and why that scope. If the recommendation is decline or
+defer, say plainly what the resident loses by that.>
+
+## Decisions needed from the owner
+
+<Numbered. Each one is a real fork where the answer changes the work — not a rubber stamp.
+Give 2–4 concrete options, recommended one first, and state what each implies. Omit this
+section entirely if the fix is unambiguous.>
+
+1. **<Short question>**
+   - **<Option A>** (recommended) — <what it implies>
+   - **<Option B>** — <what it implies>
+
+## User-facing text that would change
+
+<Every string a resident would read, before → after, per the standing rule that changed
+wording gets owner approval before anything is called done. Draft from
+wiki-docs/Style-Guide.md. Write "none" if the change is invisible to residents.>
+
+| Where | Now | Proposed |
+|---|---|---|
+| `<file:line>` | <current> | <proposed> |
+
+## Owner decision
+
+<Left empty by the daily pass. The review pass appends the decision, the answers to the
+questions above, and the date. Never overwrite an earlier decision — append.>

--- a/scripts/feedback-triage/ft.ps1
+++ b/scripts/feedback-triage/ft.ps1
@@ -1,0 +1,120 @@
+# Feedback triage ledger CLI. Reads the bot's `Feedback` collection (read-only) and
+# maintains a sibling `FeedbackTriage` collection that records what has been assessed,
+# what the owner decided, and where the work ended up. Every verb prints JSON.
+#
+#   .\ft.ps1 info                                  # counts by status + how many are untriaged
+#   .\ft.ps1 new                                   # submissions with no triage row yet (the work list)
+#   .\ft.ps1 status                                # every triage row
+#   .\ft.ps1 status -AwaitingOwner                 # rows waiting on an owner decision
+#   .\ft.ps1 status -Open                          # everything not yet closed out
+#   .\ft.ps1 status -Status approved,pr_open
+#   .\ft.ps1 set -Id 6a69a8a25b3b20a4bbe5cd64 -Fields '{"status":"assessed","verdict":"bug"}' `
+#            -Event assessed -Detail "dossier queue/2026-07-29-....md"
+#   .\ft.ps1 seed -Rows '[{"feedbackId":"...","fields":{"status":"declined"},"detail":"why"}]'
+#
+# Statuses: assessed, needs_info (awaiting owner) | approved, in_progress, pr_open,
+#           deferred (decided, in flight) | shipped, declined, duplicate, obsolete (closed).
+#
+# Requires mongosh on PATH or at the default install location. The `Feedback` documents
+# themselves are never written to - see bin\ft.js for why.
+#
+# Connection overrides: -Conn mongodb://... -Database OtherDb -MongoSh C:\path\mongosh.exe
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [ValidateSet("new", "status", "set", "seed", "info")]
+    [string]$Mode,
+
+    [string]$Id = "",
+    [string]$Fields = "",
+    [string]$Event = "",
+    [string]$Detail = "",
+    [string[]]$Status = @(),
+    [string]$Rows = "",
+    [switch]$AwaitingOwner,
+    [switch]$Open,
+
+    [string]$Conn = "mongodb://localhost:27017",
+    # Named -Database, not the sibling scripts' -Db: this script takes [Parameter()]
+    # attributes, so PowerShell adds the common parameters and -Db collides with the
+    # alias of -Debug.
+    [string]$Database = "ChateauDb",
+    [string]$MongoSh = ""
+)
+
+$ErrorActionPreference = "Stop"
+$here = $PSScriptRoot
+$js = Join-Path $here "bin\ft.js"
+if (-not (Test-Path $js)) { throw "Missing $js" }
+
+if (-not $MongoSh) {
+    $cmd = Get-Command mongosh -ErrorAction SilentlyContinue
+    if ($cmd) {
+        $MongoSh = $cmd.Source
+    }
+    elseif (Test-Path "$env:ProgramFiles\mongosh\mongosh.exe") {
+        $MongoSh = "$env:ProgramFiles\mongosh\mongosh.exe"
+    }
+    else {
+        throw "mongosh not found on PATH - install it or pass -MongoSh <path to mongosh.exe>."
+    }
+}
+
+# Build the mode's payload. Passed as base64 in an env var so JSON never has to survive
+# a trip through PowerShell and shell quoting.
+#
+# The -Fields / -Rows JSON is validated and then spliced in verbatim rather than
+# round-tripped: Windows PowerShell's ConvertTo-Json re-serializes a nested array of
+# ConvertFrom-Json objects as a {"value":[...],"Count":n} envelope. Only scalars go
+# through ConvertTo-Json, which does escape them correctly.
+function Get-JsonScalar([string]$Value) {
+    return ($Value | ConvertTo-Json -Compress)
+}
+
+$payload = $null
+switch ($Mode) {
+    "status" {
+        $parts = @()
+        if ($Status.Count -gt 0) {
+            $encoded = ($Status | ForEach-Object { Get-JsonScalar $_ }) -join ","
+            $parts += '"status":[' + $encoded + ']'
+        }
+        if ($AwaitingOwner) { $parts += '"awaitingOwner":true' }
+        if ($Open) { $parts += '"open":true' }
+        if ($parts.Count -gt 0) { $payload = "{" + ($parts -join ",") + "}" }
+    }
+    "set" {
+        if (-not $Id) { throw "set requires -Id <feedback _id hex>" }
+        if (-not $Fields) { throw "set requires -Fields '<json object>'" }
+        try { $Fields | ConvertFrom-Json | Out-Null } catch { throw "-Fields is not valid JSON: $($_.Exception.Message)" }
+        # Parens around each element are load-bearing: PowerShell's comma binds tighter
+        # than +, so `'a:' + $x, 'b:' + $y` builds one space-joined string, not two elements.
+        $parts = @( ('"feedbackId":' + (Get-JsonScalar $Id)), ('"fields":' + $Fields) )
+        if ($Event) { $parts += '"event":' + (Get-JsonScalar $Event) }
+        if ($Detail) { $parts += '"detail":' + (Get-JsonScalar $Detail) }
+        $payload = "{" + ($parts -join ",") + "}"
+    }
+    "seed" {
+        if (-not $Rows) { throw "seed requires -Rows '<json array>'" }
+        try { $Rows | ConvertFrom-Json | Out-Null } catch { throw "-Rows is not valid JSON: $($_.Exception.Message)" }
+        $payload = '{"rows":' + $Rows + '}'
+    }
+}
+
+$uri = $Conn.TrimEnd("/") + "/" + $Database
+
+$env:FT_MODE = $Mode
+if ($payload) {
+    $env:FT_PAYLOAD = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($payload))
+}
+else {
+    $env:FT_PAYLOAD = ""
+}
+
+try {
+    & $MongoSh --quiet $uri $js
+    if ($LASTEXITCODE -ne 0) { throw "mongosh exited with code $LASTEXITCODE (mode: $Mode)" }
+}
+finally {
+    $env:FT_MODE = ""
+    $env:FT_PAYLOAD = ""
+}

--- a/scripts/feedback-triage/queue/.gitkeep
+++ b/scripts/feedback-triage/queue/.gitkeep
@@ -1,0 +1,1 @@
+# Dossiers awaiting an owner decision (and deferred ones) land here.

--- a/scripts/feedback-triage/queue/2026-07-17-6a59933a-seteicon-pet-wording-already-fixed.md
+++ b/scripts/feedback-triage/queue/2026-07-17-6a59933a-seteicon-pet-wording-already-fixed.md
@@ -1,0 +1,63 @@
+# 6a59933a — `!seteicon pet` confirmation described the wrong direction (already fixed)
+
+| | |
+|---|---|
+| **Feedback id** | `6a59933ae91eb416bbf7b3ed` |
+| **Submitted** | `2026-07-17T02:28:10Z` by **Queen Contract** (`Queen Contract`) |
+| **Source** | private message |
+| **Tagged** | `bug` |
+| **Verdict** | `wording` |
+| **Recommendation** | `decline` — nothing left to do, the fix already shipped |
+| **Confidence** | high |
+| **Effort** | none |
+
+## What they said
+
+> !seteicon pet says 'whenever you pet someone' even though display behavior is 'whenever you are pet by someone'
+
+## What it means
+
+Setting a custom `!pet` eicon confirmed with "whenever you pet someone", but the `pet` eicon that
+actually surfaces belongs to the resident *being* petted. The confirmation described the opposite
+direction from the behavior.
+
+## Assessment
+
+Fixed on 2026-07-24 in commit `6f23fdd` ("Add bodypart eicons and identifier eicons"), a week
+after this was submitted.
+
+[ChateauSeteicon.cs:135](../../../FChatDicebot/BotCommands/ChateauSeteicon.cs:135) now routes the
+confirmation through `SetConfirmationClause(token)`, which special-cases `pet` and returns
+**"whenever someone pets you"**; everything else keeps "whenever you {token} someone". Its
+doc-comment records why, and flags that any future interaction redirecting `GetEiconSubject` to
+the recipient needs an entry too.
+
+The direction is the right way round: `PetProcessor.GetEiconSubject`
+([PetProcessor.cs:108](../../../FChatDicebot/InteractionProcessors/Casual/PetProcessor.cs:108))
+returns the recipient profile, and `GetGroupEiconSuffix` mirrors it for group pets — so the
+displayed icon is the petted resident's, which is what the confirmation now says.
+
+- **Reproduces / confirmed:** no — cannot reproduce on current `main`
+- **Related code:** `ChateauSeteicon.cs:135`, `PetProcessor.cs:108`
+- **Related specs / docs:** [Custom-Interaction-Eicons.md](../../../wiki-docs/specs/Custom-Interaction-Eicons.md)
+- **Duplicate of:** none
+- **Already fixed since submission:** yes — `6f23fdd`, 2026-07-24
+
+## Recommended action
+
+Close it. Nothing to implement. Worth a word to the submitter that it was fixed on the 24th,
+since they reported it a week before and would have no way to know.
+
+## Decisions needed from the owner
+
+None — unless you want the fix generalized. Right now the recipient-side phrasing is a hardcoded
+`pet` special case; a future interaction that redirects its eicon to the recipient will silently
+get the wrong clause again until someone adds it to that method. Making the clause read from the
+processor (asking it who the eicon subject is) would remove that trap, but it is speculative work
+for a single known case today.
+
+## User-facing text that would change
+
+None.
+
+## Owner decision

--- a/scripts/feedback-triage/queue/2026-07-29-6a69a8a2-pledge-title-lands-on-later-interaction.md
+++ b/scripts/feedback-triage/queue/2026-07-29-6a69a8a2-pledge-title-lands-on-later-interaction.md
@@ -1,0 +1,101 @@
+# 6a69a8a2 — "Milking Fia fulfilled a pledge" — the pledge title fires on the next unrelated interaction
+
+| | |
+|---|---|
+| **Feedback id** | `6a69a8a25b3b20a4bbe5cd64` |
+| **Submitted** | `2026-07-29T07:15:46Z` by **Queen Contract** (`Queen Contract`) |
+| **Source** | channel `ADH-ac1885cd73f31adfaefb` |
+| **Tagged** | `bug` |
+| **Verdict** | `bug` |
+| **Recommendation** | `fix` |
+| **Confidence** | high — reproduced from the live data, root cause identified |
+| **Effort** | trivial (one call site, plus a sibling) |
+
+## What they said
+
+> pledge might be broken, milking Fia fulfilled a pledge after pledging to !bond pet Celeste
+
+## What it means
+
+They pledged to bond with Celeste, later milked Fia, and the bot announced a pledge-related
+title right after the milk — which reads as "that milk fulfilled my pledge to Celeste".
+
+**No pledge was actually fulfilled.** The pledge is still `active` in the DB and the profile has
+no `pledgesfulfilled` count. What they saw was the *"Made A Promise"* title — earned by making
+the pledge 40 minutes earlier — being granted and announced during the milk.
+
+## Assessment
+
+Timeline from the live `ChateauDb` (all 2026-07-29 UTC):
+
+| Time | Event |
+|---|---|
+| 06:28:55 | `!pledge` → `Pledges` doc `6a699da7`: pledger Queen Contract, pledgee Celeste Kristoph, type `bond`, **identifier `null`**, status `active` (still active today). `pledgesactive` → 1. |
+| 07:11:04 | `!milk` Queen Contract → Fia Violafalki (`Interactions` `6a69a78f`) |
+| **07:11:11** | **title "Made A Promise" granted** (`RegisteredProfiles.titles`) — 7 seconds after the milk, 42 minutes after the pledge |
+| 07:15:46 | this feedback submitted |
+
+Root cause: [ChateauPledge.cs:115](../../../FChatDicebot/BotCommands/ChateauPledge.cs:115) increments
+`pledgesactive` but never calls `ChateauSystemTitles.CheckAndGrantTitles`. The count-title sweep
+only runs on the interaction consent path
+([ChateauConsent.cs:270](../../../FChatDicebot/BotCommands/ChateauConsent.cs:270)) and in `!work`,
+`!volunteer`, and the climax support. So a pledge's title sits unclaimed until the resident's
+next consented interaction — whatever and whoever that is — and is then announced on top of it.
+
+`!abandonpledge` has the same shape: it increments `pledgesabandoned` with no title check, so
+"Broke Their Promise" will likewise surface on some later unrelated interaction.
+
+Fulfilment itself is sound: `TryMarkPledgeFulfilled`
+([ChateauInteractionHandler.cs:22](../../../FChatDicebot/ChateauInteractionHandler.cs:22)) only
+fires for an interaction stamped with a `pledgeId` by `!fulfill`, and it runs just before the
+title sweep on the same consent path, so fulfilment titles land correctly.
+
+- **Reproduces / confirmed:** yes — grant timestamp lands 7s after the milk, 42m after the pledge
+- **Related code:** `ChateauPledge.cs:115`, `ChateauAbandonPledge.cs`, `ChateauSystemTitles.cs:243`, `ChateauConsent.cs:270`
+- **Related specs / docs:** none for pledges specifically
+- **Duplicate of:** none
+- **Already fixed since submission:** no
+
+### Second, separate defect found along the way
+
+`!pledge` throws away the identifier: [ChateauPledge.cs:105](../../../FChatDicebot/BotCommands/ChateauPledge.cs:105)
+hardcodes `identifier = null` with a "we'll add identifier support later" comment, and the
+`else` branch at line 89 that should read it is empty. The submitter pledged **`bond pet`**; the
+stored pledge is plain `bond`. `!fulfill` then passes that null identifier into the interaction,
+so fulfilling produces a bond with no identifier rather than the pet bond they promised. This
+is why their report says "bond pet" while the DB says `bond`.
+
+## Recommended action
+
+Call `ChateauSystemTitles.CheckAndGrantTitles(characterName)` at the end of a successful
+`!pledge` and append the notification to the channel message, exactly as `!work`
+([ChateauWork.cs:164](../../../FChatDicebot/BotCommands/ChateauWork.cs:164)) and `!volunteer` do.
+Same in `!abandonpledge`. Titles then land on the action that earned them, and nothing else about
+pledges changes.
+
+The dropped identifier is a real but distinct bug — bigger, since it touches `!pledge` parsing,
+the stored `Pledge`, `!fulfill`'s consent warning, and `!viewpledges` display.
+
+## Decisions needed from the owner
+
+1. **How wide should the title-timing fix go?**
+   - **`!pledge` and `!abandonpledge`** (recommended) — fixes the reported bug and its twin; two call sites, no behavior change beyond when the banner appears.
+   - **`!pledge` only** — narrowest possible fix; leaves the abandon case to resurface as its own report later.
+   - **Audit every count-changing command** — sweep all `incrementCount` callers for missing title checks and fix them together. Bigger diff, likely finds more of these, better done as its own item.
+
+2. **The dropped pledge identifier — now or separately?**
+   - **Separate item** (recommended) — keep this PR to the one-line timing fix; I write the identifier bug up as its own dossier with its own design questions (how `!fulfill` should match a pledge whose identifier differs, what `!viewpledges` shows).
+   - **Same PR** — fix both together; the PR grows to pledge parsing, storage, fulfil matching, and display.
+   - **Leave it** — the TODO stands and `!pledge <type> <identifier>` keeps silently dropping the identifier.
+
+## User-facing text that would change
+
+No new strings. The `!pledge` confirmation would gain the existing "Title Time!" notification
+appended to it — the same banner `!work` already appends, unchanged in wording. The only visible
+difference is *when* residents see it.
+
+| Where | Now | Proposed |
+|---|---|---|
+| `ChateauPledge.cs:171` channel message | pledge confirmation only; any earned title appears later, attached to an unrelated interaction | pledge confirmation + the title notification it earned, in the same message |
+
+## Owner decision

--- a/scripts/feedback-triage/triage-log.md
+++ b/scripts/feedback-triage/triage-log.md
@@ -1,0 +1,5 @@
+# Triage log
+
+One line per pass. Newest at the bottom.
+
+- 2026-07-30 — first pass (run by hand during setup, from the feedback-triage worktree). 3 in the collection: 1 seeded closed (6a51dd0b, owner's creative work), 2 assessed — 6a69a8a2 bug/fix (pledge title timing, root cause confirmed from live data), 6a59933a wording/decline (already fixed in 6f23fdd). 0 shipped, 0 stalled, 0 left over.


### PR DESCRIPTION
Once a day, assess new `!feedback` submissions against the code, queue them for your decision, and take the approved ones through to a fix or a spec.

## How it works

| Phase | When | Ends with |
|---|---|---|
| **Triage** | daily 08:17, unattended | a dossier per new submission + a push notification (only when something needs you) |
| **Review** | `/feedback-review` | your decision + design answers recorded |
| **Implement** | straight after approval | a PR (bugs) or a spec for sign-off (features) |

The playbooks are versioned in `scripts/feedback-triage/`, so tuning what the automation does is a normal PR rather than editing a hidden prompt.

## State

A new `FeedbackTriage` Mongo collection, keyed by feedback `_id`. The `Feedback` docs themselves are never written to: `FeedbackEntry` has no `[BsonIgnoreExtraElements]`, so an extra field there would break `!feedbacklist` deserialization until the bot model changes and redeploys. Rows snapshot the submission, so they stay readable after you delete the original.

The unattended pass never commits, never changes bot code, never merges, and never messages residents.

## First pass, included here

- **6a69a8a2** — "milking Fia fulfilled a pledge". Confirmed against live data: no pledge was fulfilled. `!pledge` increments `pledgesactive` without running the title check, so "Made A Promise" was granted 7 seconds after an unrelated `!milk`, 42 minutes after the pledge. One-line fix, two design questions in the dossier. Also found: `!pledge` hardcodes `identifier = null`, so `!pledge <name> bond pet` silently stores a plain `bond`.
- **6a59933a** — `!seteicon pet` wording. Already fixed in `6f23fdd` on 2026-07-24, a week after it was reported. Recommend closing.
- **6a51dd0b** — breadcrumb titles, seeded as declined per the 2026-07-15 decision that it is your own creative work.

Run `/feedback-review` to decide on the two open ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
