### PR TITLE
Correct the !help claim: the no-arg listing is curated, not generated

### DIFF
--- a/wiki-docs/Command-Reference.md
+++ b/wiki-docs/Command-Reference.md
@@ -2,7 +2,7 @@
 
 Reference of all FCDiceBot commands, organized by category.
 
-**The bot itself is the authoritative reference:** `!help` lists every command with help metadata, `!help {command}` shows its usage, cooldown, and related commands — all generated from the command classes, so it can't drift. This page is the browsable index; when a command here disagrees with `!help`, trust `!help` and fix this page.
+**The bot itself is the authoritative reference:** `!help {command}` shows a command's usage, cooldown, and related commands, generated from the command class itself, so it can't drift. (The no-arg `!help` *listing* is a curated set of section arrays in `ChateauHelp.cs` — a test guarantees every listed name resolves, but a new command must be added to a section by hand; admin/test commands are deliberately unlisted.) This page is the browsable index; when a command here disagrees with `!help`, trust `!help` and fix this page.
 
 **Note:** Default command prefix is `!` but can be configured per-channel.
 

--- a/wiki-docs/Development-Guide.md
+++ b/wiki-docs/Development-Guide.md
@@ -58,7 +58,7 @@ FCDiceBotCCVer/
 
 ## Adding a New Command
 
-Create one file in `BotCommands/`. Reflection discovers it at startup; the csproj glob picks it up at build. There is no registration step.
+Create one file in `BotCommands/`. Reflection discovers it at startup; the csproj glob picks it up at build. There is no dispatch registration step — but **do add the command's name to the right section array in `ChateauHelp.cs`** (`GeneralCommands`, `CasualCommands`, …) or it won't appear in the no-arg `!help` listing. Dispatch and `!help {command}` work without that; a test verifies listed names still resolve, but nothing checks that a new command got listed.
 
 The `Run` signature takes a `MessageAddress` (character + channel), not separate name/channel strings:
 


### PR DESCRIPTION
## What this does

Follow-up to #72, which merged before this fix landed on the branch.

While investigating the pledge system afterward, I found that Command-Reference.md overstated how `!help` works: the no-arg listing is **not** generated from the command classes — it's hand-curated section arrays in `ChateauHelp.cs` (`GeneralCommands`, `CasualCommands`, etc.). A test verifies every *listed* name still resolves, but nothing checks that a *new* command actually got added to a section — so a command can dispatch fine and even answer `!help {command}` correctly while being invisible in the general listing.

Only `!help {command}` *detail* (usage, cooldown, related commands) is truly generated from the command class and can't drift.

Changes:
- `Command-Reference.md`: corrects the claim, clarifies that `!help {command}` detail is generated but the listing is curated
- `Development-Guide.md`: adds "add the command to the right `ChateauHelp.cs` section array" as an explicit step when adding a new command, since it's easy to miss

No bot code changed — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)