### PR TITLE
Grant pledge titles on the pledge, not the next unrelated interaction

### DIFF
--- a/FChatDicebot.Tests/Unit/Counttitletimingtests.cs
+++ b/FChatDicebot.Tests/Unit/Counttitletimingtests.cs
@@ -1,0 +1,127 @@
+using FChatDicebot;
+using FChatDicebot.Database;
+using FChatDicebot.Tests.Builders;
+using FChatDicebot.Tests.Fixtures;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Count-milestone titles have to be granted by the command that moved the count.
+    /// <c>ChateauConsent</c> sweeps after every consented interaction, so interaction counts are
+    /// covered; commands off that path (<c>!pledge</c>, <c>!abandonpledge</c>, <c>!work</c>,
+    /// <c>!volunteer</c>) must sweep for themselves. When one doesn't, the title is not lost —
+    /// it is stranded, and the resident's next consented interaction announces it, reading as if
+    /// that unrelated interaction had earned it. That is feedback 6a69a8a2: a pledge to bond with
+    /// one resident surfaced "Made A Promise" during a !milk of another, 42 minutes later.
+    ///
+    /// These tests pin the mechanism the fix relies on rather than driving the commands, which
+    /// need a live <c>BotMain</c> to run.
+    /// </summary>
+    [Collection("Database")]
+    public class CountTitleTimingTests : IDisposable
+    {
+        private readonly TestDatabaseFixture _fixture;
+        private readonly IChateauDatabase _database;
+
+        public CountTitleTimingTests(TestDatabaseFixture fixture)
+        {
+            _fixture = fixture;
+            _fixture.Reset();
+            _database = _fixture.Database;
+        }
+
+        public void Dispose()
+        {
+            _fixture.Reset();
+        }
+
+        [Fact]
+        public void PledgesActive_FirstPledge_EarnsMadeAPromiseImmediately()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.IncrementCount("Alice", "pledgesactive");
+
+            string notification = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            Assert.Contains("Made A Promise", notification);
+            Assert.Contains("Title Time!", notification);
+        }
+
+        [Fact]
+        public void PledgesAbandoned_FirstAbandon_EarnsBrokeTheirPromiseImmediately()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.IncrementCount("Alice", "pledgesabandoned");
+
+            string notification = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            Assert.Contains("Broke Their Promise", notification);
+        }
+
+        [Fact]
+        public void PledgeThatChecksItsOwnTitles_StrandsNothingForTheNextInteraction()
+        {
+            // The regression. First sweep stands in for the fixed !pledge; the second for
+            // whatever the resident does next (ChateauConsent's post-interaction sweep).
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.IncrementCount("Alice", "pledgesactive");
+
+            string atPledgeTime = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+            string atNextInteraction = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            Assert.Contains("Made A Promise", atPledgeTime);
+            Assert.Equal(string.Empty, atNextInteraction);
+        }
+
+        [Fact]
+        public void UncheckedCountChange_LeavesTheTitleForALaterUnrelatedAction()
+        {
+            // The bug's shape, kept as documentation: skip the sweep at pledge time and the
+            // title waits, then lands on an interaction that had nothing to do with it.
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.IncrementCount("Alice", "pledgesactive");
+
+            // ... time passes, Alice milks someone else; ChateauConsent sweeps afterwards.
+            _database.IncrementCount("Alice", "milkgive");
+            string atUnrelatedInteraction = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            Assert.Contains("Made A Promise", atUnrelatedInteraction);
+            Assert.Contains("Milker", atUnrelatedInteraction);
+        }
+
+        [Fact]
+        public void GrantedTitlesAreRecordedOnTheProfileAsSystemTitles()
+        {
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.IncrementCount("Alice", "pledgesactive");
+
+            ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            var profile = _database.GetProfile("Alice");
+            var title = profile.titles.FirstOrDefault(t => t.titleText == "Made A Promise");
+            Assert.NotNull(title);
+            Assert.True(title.IsSystemTitle);
+        }
+
+        [Fact]
+        public void PledgeCountLabels_StillMatchTheMilestoneTable()
+        {
+            // !pledge and !abandonpledge write these three labels. If one is renamed on either
+            // side, the titles silently stop being earned — the sweep would find nothing and
+            // report nothing, which looks identical to "no new titles".
+            new ProfileBuilder().WithUserName("Alice").WithDisplayName("Alice").BuildAndSave(_database);
+            _database.ChangeCount("Alice", "pledgesactive", 25);
+            _database.ChangeCount("Alice", "pledgesfulfilled", 25);
+            _database.ChangeCount("Alice", "pledgesabandoned", 25);
+
+            string notification = ChateauSystemTitles.CheckAndGrantTitles("Alice");
+
+            Assert.Contains("Lazy", notification);
+            Assert.Contains("Whose Word Is Law", notification);
+            Assert.Contains("Chopped A Cherry Tree In A Past Life", notification);
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/ChateauAbandonPledge.cs
+++ b/FChatDicebot/BotCommands/ChateauAbandonPledge.cs
@@ -117,6 +117,16 @@ namespace FChatDicebot.BotCommands
 
                     // Send confirmation message
                     string message = $"{pledgerProfile.displayName} has abandoned their pledge to {Utils.interactionToVerb(pledgeToCancel.interactionType, false)} {pledgeeProfile.displayName}. The act of turning one's back on this promise has been permanently recorded on their dossier. Future pledges will carry with them an indication of this trend of oathbreaking...";
+
+                    // Grant "Broke Their Promise" and its tiers here rather than leaving them
+                    // for the next consented interaction to announce — the same timing bug
+                    // !pledge had. Stays private, like the rest of this confirmation.
+                    string titleNotification = ChateauSystemTitles.CheckAndGrantTitles(characterName);
+                    if (!string.IsNullOrEmpty(titleNotification))
+                    {
+                        message += titleNotification;
+                    }
+
                     bot.SendPrivateMessage(message, characterName);
                 }
             }

--- a/FChatDicebot/BotCommands/ChateauPledge.cs
+++ b/FChatDicebot/BotCommands/ChateauPledge.cs
@@ -113,6 +113,13 @@ namespace FChatDicebot.BotCommands
 
                 // increment active pledge count
                 MonDB.incrementCount(characterName, "pledgesactive");
+
+                // Re-read before the ratio messaging below: pledgerProfile was fetched at the
+                // top of Run, before the increment, so its pledgesactive was one behind and the
+                // honor cascade described the pledger's record as of just *before* this pledge.
+                // The "else 1" fallback masked it for a first-ever pledge and only there.
+                pledgerProfile = MonDB.getProfile(characterName);
+
                 int activePledges = (pledgerProfile.counts.ContainsKey("pledgesactive")) ? pledgerProfile.counts["pledgesactive"] : 1;
                 int abandonedPledges = (pledgerProfile.counts.ContainsKey("pledgesabandoned")) ? pledgerProfile.counts["pledgesabandoned"] : 0;
                 int fulfilledPledges = (pledgerProfile.counts.ContainsKey("pledgesfulfilled")) ? pledgerProfile.counts["pledgesfulfilled"] : 0;
@@ -167,6 +174,17 @@ namespace FChatDicebot.BotCommands
                 //    message += $" This is {pledgerProfile.displayName}'s first pledge! How exciting!";
                 //}
 
+
+                // Grant the titles this pledge just earned, here, on the action that earned
+                // them. Without this the count sweep only runs on the consent path, so
+                // "Made A Promise" sat unclaimed until the pledger's next consented
+                // interaction and was then announced on top of it — reading as if that
+                // unrelated interaction had fulfilled the pledge. Same shape as !work.
+                string titleNotification = ChateauSystemTitles.CheckAndGrantTitles(characterName);
+                if (!string.IsNullOrEmpty(titleNotification))
+                {
+                    message += titleNotification;
+                }
 
                 bot.SendMessageInChannel(message, channel);
             }

--- a/FChatDicebot/BotCommands/ChateauSystemTitles.cs
+++ b/FChatDicebot/BotCommands/ChateauSystemTitles.cs
@@ -14,6 +14,18 @@ namespace FChatDicebot
         /// <summary>
         /// Check if a user has earned any new system titles and grant them.
         /// Returns a string with notification messages for any newly earned titles, or empty string if none.
+        /// <para>
+        /// Invariant: <b>every command that changes a count with a milestone below must call this
+        /// before it returns</b>, and append the result to its own message. A path that changes a
+        /// count without checking does not lose the title — it strands it, and the next command
+        /// that does check announces it on top of an unrelated action. That is exactly how
+        /// "Made A Promise" came to be announced during a `!milk` (feedback 6a69a8a2). Most
+        /// interaction counts are covered because <c>ChateauConsent</c> checks after every
+        /// consented interaction; anything off that path (<c>!work</c>, <c>!volunteer</c>,
+        /// <c>!pledge</c>, <c>!abandonpledge</c>, the climax support) checks for itself.
+        /// <c>ChateauBirth</c> increments <c>birth</c>, which has no milestone — give it a check
+        /// if one is ever added.
+        /// </para>
         /// </summary>
         /// <param name="userName">The user to check for new titles</param>
         /// <returns>Notification text for earned titles, or empty string</returns>

--- a/scripts/feedback-triage/done/2026-07-17-6a59933a-seteicon-pet-wording-already-fixed.md
+++ b/scripts/feedback-triage/done/2026-07-17-6a59933a-seteicon-pet-wording-already-fixed.md
@@ -61,3 +61,15 @@ for a single known case today.
 None.
 
 ## Owner decision
+
+**2026-08-02 — Declined.** Nothing left to implement; the fix shipped in `6f23fdd` on 2026-07-24,
+a week after the report. Closed out.
+
+Design answers:
+
+1. *Generalize the recipient-side eicon clause?* — **No, leave it.** One known case today, and
+   `SetConfirmationClause`'s doc-comment already flags the trap for whoever adds the next
+   recipient-side eicon. Not worth speculative work now.
+
+Follow-up owed outside the pipeline: the submitter has not been told it was fixed. The bot does
+not PM residents on its own, so that word is the owner's to send.

--- a/scripts/feedback-triage/queue/2026-07-29-6a69a8a2-pledge-title-lands-on-later-interaction.md
+++ b/scripts/feedback-triage/queue/2026-07-29-6a69a8a2-pledge-title-lands-on-later-interaction.md
@@ -99,3 +99,40 @@ difference is *when* residents see it.
 | `ChateauPledge.cs:171` channel message | pledge confirmation only; any earned title appears later, attached to an unrelated interaction | pledge confirmation + the title notification it earned, in the same message |
 
 ## Owner decision
+
+**2026-08-02 — Approved, and widened.** Fix the title-timing bug, starting immediately.
+
+Design answers:
+
+1. *How wide should the fix go?* — **Audit every count-changing command.** Not the recommended
+   option: the dossier proposed `!pledge` + `!abandonpledge` and argued the full sweep was better
+   as its own item. The owner chose the sweep, so it lands in this PR — every `incrementCount`
+   caller gets checked for a missing `ChateauSystemTitles.CheckAndGrantTitles` call, and the
+   misses are fixed together.
+2. *The dropped pledge identifier?* — **Separate item.** Keep this PR to title timing; the
+   identifier bug gets its own dossier with its own design questions (how `!fulfill` matches a
+   pledge whose identifier differs, what `!viewpledges` shows).
+3. *Start now?* — **Yes**, branch and PR before moving to the next queue item.
+4. *The stale profile read found during implementation* (`ChateauPledge.cs:116` read
+   `pledgerProfile.counts` from a profile fetched before the increment, so the honor-ratio
+   cascade described the pledger's record as of just before this pledge) — **fold into this PR.**
+
+### Audit result (the widened scope)
+
+Every path that writes `Profile.counts` or `dailyClimaxCounts`:
+
+| Call site | Count(s) | Title check before the fix |
+|---|---|---|
+| `InteractionProcessorBase.cs:639,701`, `TrainProcessor.cs:168` | all interaction counts | yes — `ChateauConsent.cs:270` |
+| `ClimaxforProcessor` | `dailyClimaxCounts` | yes — `ClimaxCommandSupport.cs:78` + consent |
+| `ChateauInteractionHandler.cs:49` | `pledgesfulfilled` | yes — consent path, sweep runs right after |
+| `ChateauWork.cs`, `ChateauVolunteer.cs` | job counts | yes — check for themselves |
+| `ChateauPledge.cs:115` | `pledgesactive` | **no — fixed** |
+| `ChateauAbandonPledge.cs:115` | `pledgesabandoned` | **no — fixed** |
+| `ChateauBirth.cs:192` | `birth` | no, but `birth` has no milestone, so nothing is stranded |
+| `InteractionCountMigration.cs:107` | bulk backfill | n/a — migration, deliberately silent |
+
+Two real gaps, both pledges. `ChateauBirth.ExecuteBirth` is a cleanly DB-injected static and
+`CheckAndGrantTitles` resolves through the static `MonDB`, so wiring it in would cost the
+injection discipline for no present benefit; the invariant is documented on
+`CheckAndGrantTitles` instead, naming `birth` as the one to revisit if a milestone is added.

--- a/scripts/feedback-triage/queue/2026-08-02-6a6efae4-drink-from-the-source.md
+++ b/scripts/feedback-triage/queue/2026-08-02-6a6efae4-drink-from-the-source.md
@@ -1,0 +1,146 @@
+# 6a6efae4 — Drink straight from the source, skipping the bottle (`!drinkfrom` / `!forcedrink`)
+
+| | |
+|---|---|
+| **Feedback id** | `6a6efae4f86b7e092f61a452` |
+| **Submitted** | `2026-08-02T08:08:04Z` (today) by **Queen Contract** (`Queen Contract`) |
+| **Source** | private message |
+| **Tagged** | `idea` |
+| **Verdict** | `feature` |
+| **Recommendation** | `spec` |
+| **Confidence** | high on what exists; the design is open |
+| **Effort** | medium — two new interactions, but every effect they need already exists |
+
+## What they said
+
+> expand the drink and feed system to allow residents to consume directly from the source, gaining any corruption effects and fueling any addictions but skipping the !milk step. Consider the reverse interaction as well. Something like !drinkfrom and !forcedrink
+
+## What it means
+
+Today, consuming another resident's fluid is a two-step loop: `!milk` them into a numbered
+bottle, then `!drink` that bottle. The request is a one-step path — drink from the person
+directly, keeping the mechanical payload (corruption shift, craving satisfaction, addiction
+deepening) but producing no bottle. `!forcedrink` is the mirror: the donor initiates, putting
+their own fluid into someone else.
+
+## Assessment
+
+**Every mechanical effect this needs already exists and is already factored into reusable
+pieces.** The gap is a delivery path, not new mechanics.
+
+`ChateauDrink.Execute`
+([ChateauDrink.cs:109](../../../FChatDicebot/BotCommands/ChateauDrink.cs:109)) is already a pure,
+DB-injected static that applies exactly the three effects the submission names:
+
+| Effect | Where | Tuning |
+|---|---|---|
+| Corruption / purity shift from the bottle's tag | `ChateauDrink.ApplyCorruption` ([:205](../../../FChatDicebot/BotCommands/ChateauDrink.cs:205)) | ±1 per bottle, 3/day (`DrinkCorruptionShiftPerBottle`, `DrinkCorruptionDailyLimit`) |
+| Craving satisfaction | `SelfCommandStatusEffects.GetCompletionFragments` via `DoseStatusContributor.DrinkType` ([:137](../../../FChatDicebot/BotCommands/ChateauDrink.cs:137)) | — |
+| Addiction deepening | `DoseProcessor.IntensifyExistingVices` ([:287](../../../FChatDicebot/BotCommands/ChateauDrink.cs:287)) | 10% roll (`DrinkAddictionChance`) |
+
+The corruption tag those effects key off is derived from the **donor's** corruption at milking
+time (`corrupt` at ≤ −10, `purified` at ≥ +10, `ChateauCurrency.cs:166`), so drinking from the
+source can compute the same tag live from the donor's current corruption — no bottle needed.
+
+### The reverse interaction largely exists already, minus the effects
+
+`!feed` ([ChateauFeed.cs](../../../FChatDicebot/BotCommands/ChateauFeed.cs)) is already a
+consent-gated Involved interaction — `!feed [user] {substance}`, 30-minute rate limit on both
+parties, mouth eicon on the recipient. But `FeedProcessor.ProcessInteraction`
+([FeedProcessor.cs:68](../../../FChatDicebot/InteractionProcessors/Involved/FeedProcessor.cs:68))
+only records the interaction and increments `feedgive`/`feedtake`. **It applies no corruption, no
+craving satisfaction, and no addiction roll** — it is flavor and bookkeeping. Its completion
+message is "Was it yummy? I bet it was."
+
+So `!forcedrink` as described is close to "`!feed`, but the substance comes from the initiator's
+own body and it actually does something." Whether that is a new command or a promotion of `!feed`
+is the central design fork, and it is the owner's call — `!feed` today accepts *any* substance
+identifier (food, energy), which a source-based interaction cannot.
+
+### What is genuinely new
+
+- **Consent shape.** `!drink` is self-targeted and needs no consent
+  ([ChateauDrink.cs:15](../../../FChatDicebot/BotCommands/ChateauDrink.cs:15)). `!drinkfrom`
+  targets another resident, so it needs the two-phase `PendingCommand` flow like every other
+  interaction.
+- **No keepsake.** The bottle system's whole premise is that the numbered empty is permanent
+  proof (`Bottle-Consumption-And-Transfer.md` §31, §35). A source drink leaves no serial, so it
+  is deliberately the *ephemeral* option — worth stating in the spec so it does not read as an
+  oversight.
+- **Cooldown relationship with `!milk`.** `!milk` uses per-direction locks
+  (`*_give_<recipient>` keys, shipped 2026-06-28). Whether drinking from someone consumes the
+  same lock decides whether `!drinkfrom` is a shortcut around milk's rate limit or a separate
+  budget — this is the balance question.
+- **The daily corruption budget.** `DrinkCorruptionDailyLimit` is 3/day and keyed
+  `drinkshift_<date>` on the drinker's profile. Source drinks should almost certainly draw from
+  that same budget, or the bottle path becomes the strictly worse way to get corrupted.
+
+- **Reproduces / confirmed:** n/a (feature)
+- **Related code:** `ChateauDrink.cs:109` (reusable `Execute`), `FeedProcessor.cs:68` (the
+  effect-free reverse), `MilkProcessor.cs`, `DoseProcessor.IntensifyExistingVices`,
+  `ChateauCurrency.cs:54-82` (tuning)
+- **Related specs / docs:** `wiki-docs/specs/Bottle-Consumption-And-Transfer.md`,
+  `wiki-docs/specs/Milk.md`, `wiki-docs/specs/Dose-and-Detox.md`
+- **Duplicate of:** none — not in `wiki-docs/Feature-Requests.md` and no `Future-*` spec covers it
+- **Already fixed since submission:** no
+
+## Recommended action
+
+Spec before code — this is a new interaction pair with real balance questions (the milk cooldown
+relationship above all), which is exactly what the specs folder is for. The implementation itself
+should be unusually cheap for its size, because `ChateauDrink`'s effect helpers are already
+static, DB-injected, and bottle-agnostic apart from taking a `MilkBottle`; the spec's main job is
+deciding the rules, not inventing mechanics.
+
+Recommend `wiki-docs/specs/Future-Interactions/Drink-From-Source.md` covering both directions
+together — they share every effect and differ only in who initiates and who consents, so
+speccing them apart would duplicate the whole balance section.
+
+## Decisions needed from the owner
+
+1. **Is `!forcedrink` a new command, or does `!feed` grow into it?**
+   - **New command, `!feed` untouched** (recommended) — `!feed` keeps being generic-substance
+     flavor for food and energy; `!forcedrink` is specifically from-the-body and carries effects.
+     No existing behavior changes, no migration of `feedgive`/`feedtake` counts.
+   - **Give `!feed` the effects when the substance is a bodily one** — no new command, but `!feed`
+     silently becomes mechanically loaded, which changes what residents already consented to and
+     retro-reads its existing history.
+   - **Both: `!forcedrink` as an alias-with-effects onto a shared processor** — one processor,
+     two entry points; more design work to keep the consent text honest for each.
+
+2. **Does `!drinkfrom` consume the `!milk` cooldown for that pair/direction?**
+   - **Yes, shares milk's per-direction lock** (recommended) — a resident can be drawn from at
+     one rate regardless of whether it ends up in a bottle; closes the shortcut.
+   - **Its own separate cooldown** — the two paths coexist and a donor can be milked *and* drunk
+     from in the same window; more available, more to balance.
+   - **No cooldown beyond consent** — simplest, but makes bottling pointless for anyone nearby.
+
+3. **What does a source drink leave behind, if anything?**
+   - **Nothing — no bottle, no serial** (recommended) — the bottle collection stays the
+     "keepsake" path and this stays the immediate one; a clean, legible trade-off.
+   - **A numbered empty, marked as drunk-from-source** — the collection records it, but this
+     erodes the distinction the bottle spec is built on and needs a new `MilkBottle` field.
+
+4. **Corruption source: the donor's live corruption, or a rolled tag?**
+   - **Live donor corruption, same ±10 thresholds** (recommended) — reuses
+     `ChateauCurrency.cs:166` exactly, and means a corrupt resident is *known* to be a corrupting
+     drink, which is good social information.
+   - **Something stronger than a bottle** — fresher-is-more-potent is thematically tempting but
+     needs its own numbers and its own budget interaction.
+
+## User-facing text that would change
+
+No existing strings change under the recommended option 1a. Everything below is new and would be
+drafted properly in the spec against `wiki-docs/Style-Guide.md` — listed here so the shape is
+visible, not for approval yet.
+
+| Where | Now | Proposed |
+|---|---|---|
+| `!drinkfrom` consent prompt | — | new — must end with the standing "(or !no)" decline reminder via `BuildConsentWarning` |
+| `!drinkfrom` completion | — | new — carries the corruption/craving/addiction fragments the way `ChateauDrink.BuildChannelMessage` already assembles them |
+| `!forcedrink` consent prompt | — | new |
+| `!forcedrink` completion | — | new |
+| `!drink` `RelatedCommands` | `bottles, milk, sell, dose, detox` | add the new commands |
+| `wiki-docs/Command-Reference.md` | — | two new entries |
+
+## Owner decision

--- a/scripts/feedback-triage/queue/2026-08-02-6a6f3d94-generalize-the-collection-concept.md
+++ b/scripts/feedback-triage/queue/2026-08-02-6a6f3d94-generalize-the-collection-concept.md
@@ -1,0 +1,150 @@
+# 6a6f3d94 — Generalize "collections": user-keyed collectibles beyond bottles
+
+| | |
+|---|---|
+| **Feedback id** | `6a6f3d94ed5471a2a4bc7654` |
+| **Submitted** | `2026-08-02T12:52:36Z` (today) by **Queen Contract** (`Queen Contract`) |
+| **Source** | private message |
+| **Tagged** | `idea` |
+| **Verdict** | `feature` |
+| **Recommendation** | `spec` |
+| **Confidence** | high on what exists; the design is open |
+| **Effort** | large — it is an infrastructure change, not one feature |
+
+## What they said
+
+> expand the 'collection' concept. Consider panties, signatures, portraits, statuettes, make sure it's expandable and tied to users (as opposed to currencies which are generic)
+
+## What it means
+
+Build a general collectibles system: individually-identified items that remember **whose** they
+are, in contrast with the existing currency stores, which are interchangeable numbers. The named
+examples — panties, signatures, portraits, statuettes — all carry a person: something taken
+*from* a resident, or made *of* one.
+
+## Assessment
+
+**The bottle collection is already exactly this system, built once for one item type.** The
+request is effectively "promote `MilkBottle` to a framework." That is a good sign for
+feasibility and the main reason to spec it carefully rather than grow a second copy.
+
+The contrast the submission draws is already the real architectural split on `Profile`:
+
+| | Store | Shape |
+|---|---|---|
+| Generic / fungible | `Profile.currencies` ([ChateauDB.cs:27](../../../FChatDicebot/Model/ChateauDB.cs:27)) | `Dictionary<string, int>` — a name and a count, no identity |
+| Individual / user-keyed | `Profile.bottles` ([ChateauDB.cs:47](../../../FChatDicebot/Model/ChateauDB.cs:47)) | one document per item, each with its own serial and donor |
+
+`MilkBottle` ([Model/MilkBottle.cs](../../../FChatDicebot/Model/MilkBottle.cs)) already has every
+field a general collectible needs:
+
+- `serial` — globally unique, never reused, issued from an atomic `$inc` on the `Counters`
+  collection ([Chateaudatabase.cs:344](../../../FChatDicebot/Database/Chateaudatabase.cs:344),
+  counter id `bottleSerial` at `:359`). **The counter mechanism is already generic** — a second
+  counter id costs one constant.
+- `sourceName` — the donor's `userName`, frozen against renames and resolved through
+  `GetDisplayName` before display ([MilkBottle.cs:38](../../../FChatDicebot/Model/MilkBottle.cs:38)).
+  This is the "tied to users" property the submission asks for, already solved including the
+  rename trap.
+- `substance` — an entry in the `Identifier` catalog.
+- `corruptionTag`, `milkedAt`, `emptiedAt` — per-type state and provenance.
+
+And the collectible framing is already explicit in the spec, not accidental:
+`Bottle-Consumption-And-Transfer.md` §31 — global serials "give the collection a collectible
+dimension for free: a low serial is demonstrably old" — and §35, where the numbered empty is
+"permanent proof that you once held a bottle of Alice's corrupt milk, and drank it."
+
+### What the generalization would ride on
+
+- **The `Identifier` catalog** ([ChateauDB.cs:244](../../../FChatDicebot/Model/ChateauDB.cs:244))
+  has a `categories` array, an optional `displayText`, and an optional `eicon`. A new category
+  (`keepsake`, say) would let new collectible *kinds* be added as data — rendering and icons
+  included — with no code change, which is the same trick `Utils.*ToText` already relies on.
+- **Existing verbs to mirror**: `!bottles` (list with filters and display caps), `!drink`
+  (consume), `!sell` (convert to currency), `!pay` (transfer). A general system needs the same
+  four shapes, and the bottle versions are the reference implementations.
+- **`!dossier`'s privacy line**: another resident's collection is visible only in summary — counts
+  public, donor names not (`Bottle-Consumption-And-Transfer.md` §113). Any new collectible
+  inherits that question immediately.
+
+### Where it gets hard
+
+- **The examples are not one thing.** Panties come *from* a resident (like milk). A portrait or
+  statuette is *of* a resident but made by someone else — so `sourceName` splits into at least
+  "subject" and "provenance." A signature is *given*, which implies a consent flow the bottle
+  system never needed.
+- **Acquisition is per-type and is most of the work.** Bottles exist because `!milk` makes them.
+  Each new collectible needs its own way of coming into being — an interaction, an event reward,
+  a purchase — and that, not the storage, is where the effort is.
+- **Migration.** Whether `bottles` folds into a general `collectibles` list or stays beside it
+  decides how much existing, live, serial-bearing data has to move. Bottles are permanent by
+  design and residents can hold hundreds.
+
+- **Reproduces / confirmed:** n/a (feature)
+- **Related code:** `Model/MilkBottle.cs`, `ChateauDB.cs:27,47,244`,
+  `Database/Chateaudatabase.cs:344-359`, `BottleInventory`, `ChateauBottles.cs`
+- **Related specs / docs:** `wiki-docs/specs/Bottle-Consumption-And-Transfer.md` — the de facto
+  prototype spec for this
+- **Duplicate of:** none — not in `wiki-docs/Feature-Requests.md`, no `Future-*` spec
+- **Already fixed since submission:** no
+
+## Recommended action
+
+Spec it as **infrastructure**, in `wiki-docs/specs/Future-*/Infrastructure`, and deliberately
+without a shopping list of item types. The valuable and reusable half is the model: a serialized,
+user-keyed item document; a shared counter; catalog-driven types so new kinds are data; and the
+list/consume/sell/transfer verb set. Item types are the owner's creative territory and can be
+added indefinitely afterward.
+
+Scoping note worth making explicitly in the spec: shipping the framework with **zero** new item
+types is a legitimate and probably correct Phase 1 — it is not user-visible on its own, but it is
+what makes each later type cheap. Trying to land the framework *and* panties *and* portraits in
+one pass is how this becomes a large risky change instead of a foundation.
+
+## Decisions needed from the owner
+
+1. **Does the framework absorb bottles, or sit beside them?**
+   - **Absorb, with bottles as the first collectible type** (recommended) — one system, one set
+     of verbs, and the bottle code becomes the proof the abstraction works. Costs a migration of
+     live `Profile.bottles` data, and `MilkBottle`'s bottle-specific fields
+     (`corruptionTag`, `emptiedAt`) need a per-type extension slot.
+   - **Sit beside** — no migration and no risk to a shipped system, but two parallel collection
+     systems forever, and `!bottles` vs a new list command will confuse residents.
+   - **Absorb later** — build the framework standalone, migrate bottles once it has proven
+     itself on a new type. Defers the risk; runs two systems in the interim.
+
+2. **How is "tied to users" modelled when the item isn't taken from a body?**
+   - **One `subjectName` plus an optional `createdBy`** (recommended) — covers "panties from
+     Alice" and "a portrait of Alice by Bob" in one shape; `sourceName` maps onto `subjectName`.
+   - **Just `sourceName`, renamed** — simplest, matches bottles exactly, but cannot express a
+     portrait's two people.
+   - **A free-form provenance list** — most flexible, hardest to render consistently and to query.
+
+3. **Are new collectible types data or code?**
+   - **Data, via a new `Identifier` category** (recommended) — a new type needs no build and no
+     redeploy, and gets `displayText`/`eicon` rendering for free. Limits types to what a common
+     field set can express.
+   - **Code, one class per type** — every type can have bespoke fields and behavior; every type
+     is also a PR and a redeploy.
+   - **Hybrid — data types with an optional per-type extension document** — the most capable, and
+     the most to design.
+
+4. **Does Phase 1 ship any new item type at all?**
+   - **No — framework plus bottles migrated** (recommended) — nothing new for residents to see,
+     but the next type is small.
+   - **Yes, one simple type (signatures)** — gives residents something immediately and validates
+     the abstraction against a non-bottle item; roughly doubles Phase 1.
+
+## User-facing text that would change
+
+None yet — nothing here is decided enough to draft strings. Under option 1a a later phase would
+touch `!bottles`, `!drink`, `!sell` and `!bank` wording as bottles become "a collectible you
+hold" rather than "the collection", and every one of those strings would come back for approval
+in the spec. Flagging now because option 1a's true cost includes a wording pass over a system
+whose text is already settled.
+
+| Where | Now | Proposed |
+|---|---|---|
+| — | — | none this pass; deferred to the spec |
+
+## Owner decision

--- a/scripts/feedback-triage/queue/2026-08-02-6a6fb15d-random-event-text-assumes-plural-winners.md
+++ b/scripts/feedback-triage/queue/2026-08-02-6a6fb15d-random-event-text-assumes-plural-winners.md
@@ -1,0 +1,151 @@
+# 6a6fb15d — Random event result text says "each" when there's only one winner
+
+| | |
+|---|---|
+| **Feedback id** | `6a6fb15d4770dbd4a8792faa` |
+| **Submitted** | `2026-08-02T21:06:37Z` (today) by **Queen Contract** (`Queen Contract`) |
+| **Source** | channel `ADH-ac1885cd73f31adfaefb` |
+| **Tagged** | `bug` |
+| **Verdict** | `wording` |
+| **Recommendation** | `fix` |
+| **Confidence** | high — exact string located in the live event data |
+| **Effort** | trivial (data only) / small (if the engine gains a count-aware placeholder) |
+
+## What they said
+
+> event text still outputs 'each' with single participants, "[user]Fia Violafalki[/user] each happen to receive a taste of [b][color=black]corruption[/color][/b]. It tastes rich and decadent."
+
+## What it means
+
+A random event fired, exactly one resident won it, and the announcement read as if several
+people had. The reported sentence is the "Just A Taste" slime-twins event's outcome text, with
+`{winners}` substituted for the single winner — leaving the surrounding plural grammar ("each
+happen to receive") stranded.
+
+## Assessment
+
+**This is authored event data, not engine output.** The string is not in the C# — no source
+match for the phrase — and the `[color=black]corruption[/color]` markup is not a shape the
+engine produces (its own corruption fragment is `"[b]" + amount + "[/b] corruption"`,
+[RandomEventEngine.cs:589](../../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs:589)).
+
+The source is `RandomEvents` document `6a53696f814fcb51bb23cf4f`, both of its outcomes:
+
+```
+{winners} each happen to receive a taste of [b][color=black]corruption[/color][/b]. It tastes rich and decadent.
+{winners} each happen to receive a taste of [b][color=white]purity[/color][/b].    It tastes pure and invigorating.
+```
+
+`SubstituteWinners`
+([RandomEventEngine.cs:663](../../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs:663))
+does a straight `Replace("{winners}", ...)`. It joins the names correctly ("A, B and C") but has
+no notion of winner count, so it cannot touch the author's surrounding grammar.
+
+Worth noting the engine gets this right for *its own* line: the grouped reward line picks
+`" receive "` vs `" receives "` off `tags.Count`
+([RandomEventEngine.cs:352](../../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs:352)).
+So the message the resident saw is half correct-by-code and half wrong-by-data.
+
+### This is not a one-string problem
+
+`allInWindow` is the **only** winner rule with a variable winner count — `firstValid`, `nth`,
+and `random` each resolve to exactly one winner by construction
+([RandomEventEngine.cs:501-520](../../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs:501)).
+So every `allInWindow` event whose `resultText` names `{winners}` is exposed. Surveying all 12
+authored events, three are affected — four outcome strings in total:
+
+| Event | Rule | Current text | Reads as, with one winner |
+|---|---|---|---|
+| `6a53696f` "Just A Taste" | allInWindow | `{winners} each happen to receive a taste of …` (×2 outcomes) | the reported bug |
+| `6a45bfc3` "Cutie says" | allInWindow | `{winners} are all officially cuties, …` | "Fia **are all** officially cuties" |
+| `6a53651d` "Everybody dance now" | allInWindow | `… as {winners} bust it down on the dance floor.` | "Fia **bust** it down" |
+
+The other nine are safe: single-winner rules with correctly singular text (`{winners} is the
+6th to join…`, `only {winners} has the honor…`), vocatives (`It's your lucky day, {winners}!`),
+or no placeholder at all.
+
+**The authoring guidance actively causes this.** The builder's placeholder example is
+`{winners} are showered in rose petals!`
+([scripts/random-event-builder/ui.html:462](../../../scripts/random-event-builder/ui.html:462))
+and its `allInWindow` help says "everyone wins together (use {winners} in result text)"
+([ui.html:594](../../../scripts/random-event-builder/ui.html:594)) — both steering authors to
+plural on the one rule where the count varies. The spec's own example is plural too
+(`"{winners} are now glowing purple."`,
+[Random-Events.md:195](../../../wiki-docs/specs/Future-Social/Random-Events.md:195)). Nothing
+warns that `allInWindow` can resolve to one person. So the next authored event repeats this.
+
+- **Reproduces / confirmed:** yes — the exact string is in the live `RandomEvents` document, and
+  the single-winner path substitutes it verbatim
+- **Related code:** `RandomEventEngine.cs:663` (`SubstituteWinners`), `:352` (the reward line
+  that *does* agree), `:501` (winner rules), `scripts/random-event-builder/ui.html:462,594`
+- **Related specs / docs:** `wiki-docs/specs/Future-Social/Random-Events.md` §195 — documents
+  `{winners}` as a plain substitution and is silent on count agreement
+- **Duplicate of:** none
+- **Already fixed since submission:** no — no commits since `efa818c` (New icon), and the live
+  data still carries the string
+- **"still outputs"** — the submitter's word suggests they may have reported this before. There
+  is no earlier row in the ledger and no matching entry in the `Feedback` collection, so this is
+  the first written record of it; they may have raised it verbally.
+
+## Recommended action
+
+Reword the four outcome strings to be count-neutral. It is a data edit in the `RandomEvents`
+collection (via `scripts/random-event-builder`, or a direct update), takes effect on the next
+fire with **no code change and no redeploy**, and clears everything a resident can currently
+see.
+
+That leaves the authoring hazard open, which is the part worth a decision: the builder still
+suggests plural text for `allInWindow`, so event #13 lands the same way. The cheap half of that
+is a note in the builder's help; the durable half is giving authors a count-aware placeholder.
+Recommend doing the data fix now and treating the engine affordance as a separate, specced item
+rather than bundling them.
+
+Note this item's fix does **not** flow through the normal implement-a-PR path — the strings live
+in Mongo, not in the repo. If the engine option is chosen, that half is a normal PR.
+
+## Decisions needed from the owner
+
+1. **How far does the fix go?**
+   - **Data only, now** (recommended) — reword the four strings; nothing ships, nothing
+     redeploys, the visible bug is gone today. The hazard remains for future events.
+   - **Data + a builder warning** — also reword the builder's example and `allInWindow` help so
+     the next author is told the count can be one. Small, repo-side, no bot change.
+   - **Data + engine placeholder (spec first)** — add count-aware authoring to
+     `SubstituteWinners`, e.g. a paired form `{winners} {is|are} …` / `{winners}
+     happen{s} …`, resolved on winner count. Durable, but it is new authored syntax: needs a
+     spec, tests, a builder update, and a redeploy.
+
+2. **Who writes the replacement flavor?** These are your event prose, not framework strings.
+   - **You reword them** (recommended) — I have drafted minimal count-neutral edits below purely
+     as a starting point; the voice is yours.
+   - **Take the drafts as-is** — they change as few words as possible and keep the imagery.
+
+3. **Should `allInWindow` events be authored to assume one winner, or many?** Answering this
+   once settles the guidance the builder should give.
+   - **Neutral phrasing always** (recommended) — safest, works at any count, costs some flourish.
+   - **Plural, with the engine fixing agreement** — only viable if option 1c is taken.
+
+## User-facing text that would change
+
+All four are `resultText` in the `RandomEvents` Mongo collection, not the repo. Drafts keep the
+imagery and change as few words as possible; each is count-neutral rather than newly plural.
+
+| Where | Now | Proposed |
+|---|---|---|
+| `6a53696f` outcome 1 | `{winners} each happen to receive a taste of [b][color=black]corruption[/color][/b]. It tastes rich and decadent.` | `{winners} happen to get a taste of [b][color=black]corruption[/color][/b]. It tastes rich and decadent.` |
+| `6a53696f` outcome 2 | `{winners} each happen to receive a taste of [b][color=white]purity[/color][/b]. It tastes pure and invigorating.` | `{winners} happen to get a taste of [b][color=white]purity[/color][/b]. It tastes pure and invigorating.` |
+| `6a45bfc3` outcome 1 | `{winners} are all officially cuties, as recognized by the walls of the Chateau itself!` | `The walls of the Chateau itself recognize {winners} as officially certified cuties!` |
+| `6a53651d` outcome 1 | `Everyone follows her lead, as {winners} bust it down on the dance floor. It's a lot of fun, and she has some awesome moves that are surprisingly easy to pick up.` | `Everyone follows her lead, and {winners} end up owning the dance floor. It's a lot of fun, and she has some awesome moves that are surprisingly easy to pick up.` |
+
+`{winners} happen to get` and `{winners} end up` read correctly at one name or several — English
+lets a bare name take the plural-form verb here without sounding wrong, which is what makes the
+neutral phrasing possible at all.
+
+If option 1b is taken, two more strings change:
+
+| Where | Now | Proposed |
+|---|---|---|
+| `ui.html:462` placeholder | `{winners} are showered in rose petals!` | `{winners} end up showered in rose petals!` |
+| `ui.html:594` allInWindow help | `Collects every correct responder until the window closes, then everyone wins together (use {winners} in result text).` | `Collects every correct responder until the window closes, then everyone wins together (use {winners} in result text). Only one person may answer, so avoid wording that assumes a crowd.` |
+
+## Owner decision

--- a/scripts/feedback-triage/triage-log.md
+++ b/scripts/feedback-triage/triage-log.md
@@ -3,3 +3,4 @@
 One line per pass. Newest at the bottom.
 
 - 2026-07-30 — first pass (run by hand during setup, from the feedback-triage worktree). 3 in the collection: 1 seeded closed (6a51dd0b, owner's creative work), 2 assessed — 6a69a8a2 bug/fix (pledge title timing, root cause confirmed from live data), 6a59933a wording/decline (already fixed in 6f23fdd). 0 shipped, 0 stalled, 0 left over.
+- 2026-08-02 — 3 assessed (6a6fb15d wording/fix, 6a6efae4 feature/spec, 6a6f3d94 feature/spec), 0 shipped, 0 stalled, 0 deferred to tomorrow. Pass was blocked on start: `bin/ft.js` is matched by `.gitignore`'s `**/bin/` and was never committed, so `ft.ps1` on main throws. Restored it untracked from the `magical-morse-09753b` worktree (its only copy on disk) to finish the run — the real fix is a PR, flagged to the owner.

--- a/wiki-docs/specs/Pledges.md
+++ b/wiki-docs/specs/Pledges.md
@@ -48,6 +48,8 @@ Three `Profile.counts` keys drive both the reputation messaging and the title la
 
 All three counts also feed system-title ladders (`ChateauSystemTitles.cs`), which is why they are profile counts rather than derived queries over the `Pledges` collection.
 
+`!pledge` and `!abandonpledge` call `ChateauSystemTitles.CheckAndGrantTitles` themselves and append the "Title Time!" banner to their own message. They have to: the count sweep otherwise only runs on the consent path, and a title earned by a pledge would sit unclaimed until the pledger's next consented interaction, then be announced on top of it — which reads as though that unrelated interaction fulfilled the pledge. `pledgesfulfilled` needs no such call, since it is incremented on the consent path immediately before the sweep.
+
 ## Data and files
 
 The `Pledges` collection and the `Pledge` model are summarized in [Database-and-Persistence](../Database-and-Persistence.md); `Model/ChateauDB.cs` is the schema.


### PR DESCRIPTION
## What the resident reported

> pledge might be broken, milking Fia fulfilled a pledge after pledging to !bond pet Celeste

Feedback `6a69a8a2`, submitted 2026-07-29.

## What actually happened

No pledge was fulfilled. The pledge is still `active` in the DB and the profile has no
`pledgesfulfilled` count. What they saw was the **"Made A Promise"** title — earned by making the
pledge 42 minutes earlier — being granted and announced during an unrelated `!milk`.

| Time (2026-07-29 UTC) | Event |
|---|---|
| 06:28:55 | `!pledge` → `pledgesactive` = 1 |
| 07:11:04 | `!milk` Queen Contract → Fia Violafalki |
| **07:11:11** | **title "Made A Promise" granted** — 7s after the milk, 42m after the pledge |

## Root cause

`ChateauSystemTitles.CheckAndGrantTitles` is the count-milestone sweep. It ran on the consent path
(`ChateauConsent.cs:270`), in `!work`, in `!volunteer`, and in the climax support — but **not** in
`!pledge`, which increments `pledgesactive` and returned. A title earned off the consent path is
not lost; it is stranded, and the next command that *does* sweep announces it on top of an
unrelated action.

## The audit

The owner widened the scope from the two pledge call sites to a sweep of every count-changing
command. Every path that writes `Profile.counts` or `dailyClimaxCounts`:

| Call site | Count(s) | Title check before this PR |
|---|---|---|
| `InteractionProcessorBase.cs:639,701`, `TrainProcessor.cs:168` | all interaction counts | yes — consent path |
| `ClimaxforProcessor` | `dailyClimaxCounts` | yes — `ClimaxCommandSupport.cs:78` + consent |
| `ChateauInteractionHandler.cs:49` | `pledgesfulfilled` | yes — consent path, sweep runs right after |
| `ChateauWork.cs:164`, `ChateauVolunteer.cs:128` | job counts | yes — check for themselves |
| `ChateauPledge.cs:115` | `pledgesactive` | **no — fixed here** |
| `ChateauAbandonPledge.cs:115` | `pledgesabandoned` | **no — fixed here** |
| `ChateauBirth.cs:192` | `birth` | no, but `birth` has no milestone — nothing stranded |
| `InteractionCountMigration.cs:107` | bulk backfill | n/a — migration, deliberately silent |

Two real gaps, both pledges.

`ChateauBirth.ExecuteBirth` is deliberately DB-injected while `CheckAndGrantTitles` resolves
through the static `MonDB`, so wiring it in would cost that injection discipline for zero present
benefit. The invariant is documented on `CheckAndGrantTitles` instead, naming `birth` as the one
to revisit if a milestone is ever added for it.

## The fix

- `!pledge` and `!abandonpledge` call `CheckAndGrantTitles(characterName)` and append the result
  to their own message, exactly as `!work` does.
- Invariant documented on `CheckAndGrantTitles` so the next count added off the consent path
  doesn't repeat this.
- Folded in at the owner's request: `!pledge` built its honor-ratio messaging from a `Profile`
  fetched *before* the increment, so the cascade described the pledger's record as of just before
  this pledge. It now re-reads.

## User-facing text

**No string changed.** `!pledge`'s channel message and `!abandonpledge`'s private message gain the
existing "Title Time!" banner, verbatim from `FormatTitleNotification`. The only difference is
which message it is attached to.

## Tests

New `FChatDicebot.Tests/Unit/Counttitletimingtests.cs` (6 tests) pins the mechanism the fix relies
on — the commands themselves need a live `BotMain` to drive:

- first pledge earns "Made A Promise" immediately; first abandon earns "Broke Their Promise"
- **the regression:** after the pledge-time sweep, a second sweep standing in for the next
  consented interaction returns empty — nothing stranded
- the bug's shape kept as documentation: skip the pledge-time sweep and the title lands on an
  unrelated `!milk`
- granted titles are recorded on the profile as system titles
- the three pledge count labels still match the milestone table, so a rename on either side can't
  silently unhook the ladders

`dotnet test`: **1815 passed, 0 failed.**

## Docs

`wiki-docs/specs/Pledges.md` §Honor accounting now records that `!pledge` and `!abandonpledge`
sweep for themselves and why. `Command-Reference.md` needs no change — usage and help text are
untouched.

## Not in this PR

- **Pledges carry no identifier.** `ChateauPledge.cs:105` hardcodes `identifier = null`, so the
  reported `!pledge bond pet` was stored as plain `bond` and `!fulfill` would produce a bond with
  no identifier. Already a listed known gap in `Pledges.md`; the owner split it out as its own
  feedback item with its own design questions.

Dossier: `scripts/feedback-triage/queue/2026-07-29-6a69a8a2-pledge-title-lands-on-later-interaction.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
