### PR TITLE
Add !cum and !cumfor aliases for !climax and !climaxfor

### DIFF
--- a/FChatDicebot/BotCommands/ChateauClimax.cs
+++ b/FChatDicebot/BotCommands/ChateauClimax.cs
@@ -20,7 +20,7 @@ namespace FChatDicebot.BotCommands
         public ChateauClimax()
         {
             Name = "climax";
-            Aliases = new string[] { };
+            Aliases = new string[] { "cum" };
             Category = "Involved Interaction";
             ShortDescription = "Bring another resident, or yourself, to orgasm.";
             LongDescription = "Bring another resident, or yourself, to orgasm. Specify who you'd like to "

--- a/FChatDicebot/BotCommands/ChateauClimaxfor.cs
+++ b/FChatDicebot/BotCommands/ChateauClimaxfor.cs
@@ -18,7 +18,7 @@ namespace FChatDicebot.BotCommands
         public ChateauClimaxfor()
         {
             Name = "climaxfor";
-            Aliases = new string[] { };
+            Aliases = new string[] { "cumfor" };
             Category = "Involved Interaction";
             ShortDescription = "Bring yourself to orgasm, solo or for another resident.";
             LongDescription = "Bring yourself to orgasm. Specify who you'd like to cum for (with !consent), "

--- a/wiki-docs/Command-Reference.md
+++ b/wiki-docs/Command-Reference.md
@@ -81,10 +81,10 @@ All casual interactions are group-capable (name several residents) and share a 3
 | `!milk` | `!milk [user]Name[/user] {substance}` | Milk a substance from another resident (produces numbered bottles; per-recipient daily cooldown) |
 | `!drinkfrom` | `!drinkfrom [user]Name[/user] {substance}` | Drink a substance straight from another resident — stronger than a bottled drink, but produces no bottle. Shares `!milk`'s per-source daily cooldown |
 | `!forcedrink` | `!forcedrink [user]Name[/user] {substance}` | Offer a drink straight from yourself; the other resident consents and is the one who drinks |
-| `!climax` | `!climax [user]Name[/user]` | Bring another resident, or yourself, to orgasm |
+| `!climax` (`!cum`) | `!climax [user]Name[/user]` | Bring another resident, or yourself, to orgasm |
 | `!panties` | `!panties [user]Name[/user]` | Ask another resident for a pair of their panties. Joins your collection with its own number and their name; per-direction daily lock |
 | `!givepanties` | `!givepanties [user]Name[/user]` | Offer a pair of your own panties; the other resident consents and is the one who keeps them |
-| `!climaxfor` | `!climaxfor [user]Name[/user]` | Bring yourself to orgasm, solo or for another resident |
+| `!climaxfor` (`!cumfor`) | `!climaxfor [user]Name[/user]` | Bring yourself to orgasm, solo or for another resident |
 | `!pay` | see below | Transfer currency or bottles |
 
 ### !pay


### PR DESCRIPTION
## Summary
- Add \`cum\` as an alias for \`!climax\` and \`cumfor\` as an alias for \`!climaxfor\` via each command's \`Aliases\` array
- Update \`wiki-docs/Command-Reference.md\` to show the aliases inline, matching the existing pattern (e.g. \`!dressup\` (\`!dress\`))

## Test plan
- [x] Verified no existing command \`Name\` collides with \`cum\`/\`cumfor\` (grepped for both strings across the codebase)
- [ ] Could not run a full solution build in this environment — \`dotnet build\` fails on an unrelated pre-existing issue (missing \`Discord.Net\` package in \`packages\\`, not touched by this change)