### PR TITLE
Winner-conditional random event outcomes + the invert reward

### DIFF
--- a/FChatDicebot.Tests/Unit/Eventconditionsupporttests.cs
+++ b/FChatDicebot.Tests/Unit/Eventconditionsupporttests.cs
@@ -1,0 +1,377 @@
+﻿using FChatDicebot.BotCommands.Support;
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.InteractionProcessors.Consequence;
+using FChatDicebot.Model;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FChatDicebot.Tests.Unit
+{
+    /// <summary>
+    /// Pure unit tests for the random-event winner conditions: the per-stat integer projection
+    /// and the inclusive-range test built on it. No Mongo, no engine — these are all static reads
+    /// of a hand-built <see cref="Profile"/>.
+    /// </summary>
+    public class EventConditionSupportTests
+    {
+        private static EventCondition Cond(string stat, string key = null, int? min = null, int? max = null)
+        {
+            return new EventCondition { stat = stat, key = key, min = min, max = max };
+        }
+
+        private static Profile WithCorruption(int value)
+        {
+            var p = new Profile { userName = "Alice" };
+            p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = value.ToString();
+            return p;
+        }
+
+        // =========================== The signed corruption axis ===========================
+
+        // The reason these conditions exist rather than reusing the duty Conditional: corruption
+        // runs negative-for-corrupt through positive-for-pure, so both halves must be expressible.
+        [Theory]
+        [InlineData(-120, true)]
+        [InlineData(-10, true)]
+        [InlineData(-9, false)]
+        [InlineData(0, false)]
+        [InlineData(40, false)]
+        public void Corruption_UpperBoundSelectsTheCorrupted(int corruption, bool expected)
+        {
+            Assert.Equal(expected, EventConditionSupport.Matches(WithCorruption(corruption), Cond("corruption", max: -10)));
+        }
+
+        [Theory]
+        [InlineData(120, true)]
+        [InlineData(10, true)]
+        [InlineData(9, false)]
+        [InlineData(-40, false)]
+        public void Corruption_LowerBoundSelectsThePure(int corruption, bool expected)
+        {
+            Assert.Equal(expected, EventConditionSupport.Matches(WithCorruption(corruption), Cond("corruption", min: 10)));
+        }
+
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(9, true)]
+        [InlineData(-9, true)]
+        [InlineData(10, false)]
+        [InlineData(-10, false)]
+        public void Corruption_TwoBoundsSelectTheNeutralBand(int corruption, bool expected)
+        {
+            Assert.Equal(expected, EventConditionSupport.Matches(WithCorruption(corruption), Cond("corruption", min: -9, max: 9)));
+        }
+
+        [Fact]
+        public void Corruption_AbsentCharacteristicReadsAsZero()
+        {
+            var p = new Profile { userName = "Alice" };
+            Assert.True(EventConditionSupport.Matches(p, Cond("corruption", min: 0, max: 0)));
+        }
+
+        // =========================== Bounds are inclusive and optional ===========================
+
+        [Fact]
+        public void NoBounds_MatchesAnyProjectableValue()
+        {
+            Assert.True(EventConditionSupport.Matches(WithCorruption(-77), Cond("corruption")));
+        }
+
+        [Fact]
+        public void Bounds_AreInclusiveOnBothEnds()
+        {
+            Assert.True(EventConditionSupport.Matches(WithCorruption(5), Cond("corruption", min: 5, max: 5)));
+            Assert.False(EventConditionSupport.Matches(WithCorruption(4), Cond("corruption", min: 5, max: 5)));
+            Assert.False(EventConditionSupport.Matches(WithCorruption(6), Cond("corruption", min: 5, max: 5)));
+        }
+
+        // =========================== Dictionary-backed stats ===========================
+
+        [Fact]
+        public void Currency_ProjectsTheBalance_MissingKeyIsZero()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.currencies["rosequartz"] = 40;
+
+            Assert.True(EventConditionSupport.Matches(p, Cond("currency", "rosequartz", min: 40)));
+            Assert.False(EventConditionSupport.Matches(p, Cond("currency", "rosequartz", min: 41)));
+            // An unheld currency projects to zero rather than failing, so "the broke" is authorable.
+            Assert.True(EventConditionSupport.Matches(p, Cond("currency", "gold", max: 0)));
+        }
+
+        [Fact]
+        public void Currency_KeyLookupIsCaseInsensitive()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.currencies["RoseQuartz"] = 12;
+            Assert.True(EventConditionSupport.Matches(p, Cond("currency", "rosequartz", min: 12, max: 12)));
+        }
+
+        [Fact]
+        public void Training_And_Job_And_Count_ProjectTheirDictionaries()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.trainings["magic"] = 80;
+            p.jobExperience["adventurer"] = 6;
+            p.counts["kissgive"] = 3;
+
+            Assert.True(EventConditionSupport.Matches(p, Cond("training", "magic", min: 50)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("job", "adventurer", min: 5)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("count", "kissgive", min: 3, max: 3)));
+            Assert.False(EventConditionSupport.Matches(p, Cond("count", "kissgive", min: 4)));
+        }
+
+        // A dictionary stat has no meaningful "total across all keys", so a blank key is treated
+        // as authoring error and fails closed rather than matching everyone.
+        [Theory]
+        [InlineData("currency")]
+        [InlineData("training")]
+        [InlineData("job")]
+        [InlineData("count")]
+        public void DictionaryStats_RequireAKey(string stat)
+        {
+            var p = new Profile { userName = "Alice" };
+            Assert.True(EventConditionSupport.RequiresKey(stat));
+            Assert.False(EventConditionSupport.Matches(p, Cond(stat, null, min: 0)));
+        }
+
+        // =========================== List-backed stats ===========================
+
+        [Fact]
+        public void Title_BlankKeyCountsThemAll_NamedKeyNarrows()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.titles.Add(new Title { titleText = "Cutie", givenBy = "Chateau" });
+            p.titles.Add(new Title { titleText = "Lucky", givenBy = "Chateau" });
+
+            // Blank key is how a "titles held" count is authored — no separate stat needed.
+            Assert.True(EventConditionSupport.Matches(p, Cond("title", min: 2, max: 2)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("title", "cutie", min: 1)));   // has it
+            Assert.True(EventConditionSupport.Matches(p, Cond("title", "Sinner", max: 0)));  // lacks it
+            Assert.False(EventConditionSupport.Matches(p, Cond("title", "Sinner", min: 1)));
+        }
+
+        [Fact]
+        public void Curse_And_Parasite_ProjectHeldInstances()
+        {
+            var p = new Profile { userName = "Alice" };
+            CurseInstance.SaveAll(p, new List<CurseInstance>
+            {
+                new CurseInstance { Curse = "poverty", AppliedBy = "Chateau", AppliedAt = DateTime.UtcNow },
+            });
+            ParasiteInstance.SaveAll(p, new List<ParasiteInstance>
+            {
+                new ParasiteInstance { Parasite = "worms", InfestedBy = "Chateau", InfestedAt = DateTime.UtcNow },
+            });
+
+            Assert.True(EventConditionSupport.Matches(p, Cond("curse", "poverty", min: 1)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("curse", min: 1, max: 1)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("parasite", min: 1)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("parasite", "worms", min: 1)));
+            Assert.False(EventConditionSupport.Matches(p, Cond("parasite", "botfly", min: 1)));
+        }
+
+        [Fact]
+        public void Curse_And_Parasite_AreZeroOnACleanProfile()
+        {
+            var p = new Profile { userName = "Alice" };
+            Assert.True(EventConditionSupport.Matches(p, Cond("curse", max: 0)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("parasite", max: 0)));
+        }
+
+        // A NAMED vice projects its addiction level rather than a plain 0/1 — that is the number
+        // an author wants to gate on. A blank key falls back to the plain list count.
+        [Fact]
+        public void Vice_NamedKeyProjectsAddictionLevel_BlankKeyCountsThem()
+        {
+            var p = new Profile { userName = "Alice" };
+            ViceInstance.SaveAll(p, new List<ViceInstance>
+            {
+                new ViceInstance { Vice = "lustessence", AddictionLevel = 7, DosedBy = "Chateau" },
+                new ViceInstance { Vice = "golden", AddictionLevel = 1, DosedBy = "Chateau" },
+            });
+
+            Assert.True(EventConditionSupport.Matches(p, Cond("vice", "lustessence", min: 7, max: 7)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("vice", "lustessence", min: 1)));  // "has it" still reads
+            Assert.False(EventConditionSupport.Matches(p, Cond("vice", "golden", min: 5)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("vice", min: 2, max: 2)));         // holds two vices
+            Assert.True(EventConditionSupport.Matches(p, Cond("vice", "cream", max: 0)));        // not hooked on it
+        }
+
+        [Fact]
+        public void Pregnancy_CountsActiveOnes_NamedKeyNarrowsBySpecies()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.pregnancies.Add(new Pregnancy { Id = "1", MonsterType = "slime" });
+            p.pregnancies.Add(new Pregnancy { Id = "2", MonsterType = "slime" });
+            p.pregnancies.Add(new Pregnancy { Id = "3", MonsterType = "imp" });
+
+            Assert.True(EventConditionSupport.Matches(p, Cond("pregnancy", min: 3, max: 3)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("pregnancy", "slime", min: 2, max: 2)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("pregnancy", min: 1)));    // "the expecting"
+            Assert.False(EventConditionSupport.Matches(p, Cond("pregnancy", max: 0)));
+        }
+
+        [Fact]
+        public void Collectible_CountsHeldItems_NamedKeyNarrowsByTypeLabel()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.collectibles.Add(new MilkBottle { serial = 1, subjectName = "Alice", acquiredAt = DateTime.UtcNow });
+            p.collectibles.Add(new MilkBottle { serial = 2, subjectName = "Bob", acquiredAt = DateTime.UtcNow });
+
+            string label = p.collectibles[0].TypeLabel;
+            Assert.True(EventConditionSupport.Matches(p, Cond("collectible", min: 2, max: 2)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("collectible", label, min: 2)));
+            Assert.True(EventConditionSupport.Matches(p, Cond("collectible", "not-a-type", max: 0)));
+        }
+
+        // =========================== Failure direction ===========================
+
+        // A typo must kill the branch it was written on, never widen it — a malformed condition
+        // that "passed" would silently hand a winner the wrong outcome.
+        [Fact]
+        public void UnknownStat_FailsRatherThanMatching()
+        {
+            var p = new Profile { userName = "Alice" };
+            Assert.False(EventConditionSupport.Matches(p, Cond("corrpution", min: 0)));  // typo
+            Assert.False(EventConditionSupport.Matches(p, Cond("", min: 0)));
+            Assert.False(EventConditionSupport.Matches(p, Cond(null, min: 0)));
+        }
+
+        [Fact]
+        public void NullProfile_NeverMatchesAProjectedCondition()
+        {
+            Assert.False(EventConditionSupport.Matches(null, Cond("corruption", max: -10)));
+        }
+
+        [Fact]
+        public void StatNamesAreTrimmedAndCaseInsensitive()
+        {
+            Assert.True(EventConditionSupport.Matches(WithCorruption(-50), Cond("  Corruption ", max: -10)));
+        }
+
+        // =========================== Composition ===========================
+
+        [Fact]
+        public void NullCondition_IsNoConstraint()
+        {
+            Assert.True(EventConditionSupport.Matches(new Profile { userName = "Alice" }, null));
+        }
+
+        [Fact]
+        public void MatchesAll_RequiresEveryCondition_EmptyIsUnconditional()
+        {
+            var p = WithCorruption(-40);
+            p.currencies["rosequartz"] = 100;
+
+            Assert.True(EventConditionSupport.MatchesAll(p, null));
+            Assert.True(EventConditionSupport.MatchesAll(p, new List<EventCondition>()));
+            Assert.True(EventConditionSupport.MatchesAll(p, new List<EventCondition>
+            {
+                Cond("corruption", max: -10), Cond("currency", "rosequartz", min: 50),
+            }));
+            // One failing condition sinks the whole set.
+            Assert.False(EventConditionSupport.MatchesAll(p, new List<EventCondition>
+            {
+                Cond("corruption", max: -10), Cond("currency", "rosequartz", min: 500),
+            }));
+        }
+
+        // =========================== Event-level helpers ===========================
+
+        [Fact]
+        public void HasAnyConditions_IsFalseForEveryPreConditionsEvent()
+        {
+            var ev = new RandomEvent
+            {
+                outcomes = new List<EventOutcome>
+                {
+                    new EventOutcome { weight = 1, resultText = "a" },
+                    new EventOutcome { weight = 1, resultText = "b", conditions = new List<EventCondition>() },
+                }
+            };
+            Assert.False(EventConditionSupport.HasAnyConditions(ev));
+            Assert.False(EventConditionSupport.HasAnyConditions(null));
+            Assert.False(EventConditionSupport.HasAnyConditions(new RandomEvent()));
+
+            ev.outcomes[1].conditions.Add(Cond("corruption", max: -10));
+            Assert.True(EventConditionSupport.HasAnyConditions(ev));
+        }
+
+        [Fact]
+        public void EligibleOutcomes_FiltersToWhatThisWinnerQualifiesFor()
+        {
+            var corrupted = new EventOutcome { weight = 1, resultText = "dark", conditions = new List<EventCondition> { Cond("corruption", max: -10) } };
+            var pure = new EventOutcome { weight = 1, resultText = "light", conditions = new List<EventCondition> { Cond("corruption", min: 10) } };
+            var anyone = new EventOutcome { weight = 1, resultText = "plain" };
+            var ev = new RandomEvent { outcomes = new List<EventOutcome> { corrupted, pure, anyone } };
+
+            Assert.Equal(new List<EventOutcome> { corrupted, anyone }, EventConditionSupport.EligibleOutcomes(ev, WithCorruption(-50)));
+            Assert.Equal(new List<EventOutcome> { pure, anyone }, EventConditionSupport.EligibleOutcomes(ev, WithCorruption(50)));
+            Assert.Equal(new List<EventOutcome> { anyone }, EventConditionSupport.EligibleOutcomes(ev, WithCorruption(0)));
+        }
+
+        // =========================== Stored document shape ===========================
+        //
+        // Events are authored straight into Mongo (the random-event-builder writes the documents),
+        // so the model has to survive the exact BSON that tool emits. The bounds are nullable on
+        // purpose - an omitted min must read back as "unbounded", NOT as zero, or "the pure"
+        // (min: 10, no max) would silently become "between 10 and 0" and match nobody.
+
+        [Fact]
+        public void StoredShape_OmittedBoundDeserializesAsUnboundedNotZero()
+        {
+            var doc = new BsonDocument
+            {
+                { "stat", "corruption" },
+                { "key", "" },
+                { "max", -10 },   // no "min" key at all, exactly as the builder writes it
+            };
+
+            EventCondition condition = BsonSerializer.Deserialize<EventCondition>(doc);
+
+            Assert.False(condition.min.HasValue);
+            Assert.Equal(-10, condition.max.Value);
+            Assert.True(EventConditionSupport.Matches(WithCorruption(-9999), condition));
+            Assert.False(EventConditionSupport.Matches(WithCorruption(0), condition));
+        }
+
+        [Fact]
+        public void StoredShape_OutcomeWithoutConditionsKeyIsUnconditional()
+        {
+            var doc = new BsonDocument
+            {
+                { "weight", 1 },
+                { "resultText", "Resolved!" },
+                { "rewards", new BsonArray() },
+                // No "conditions" key - every event authored before conditions existed looks
+                // like this, and must keep behaving as a plain shared-roll outcome.
+            };
+
+            EventOutcome outcome = BsonSerializer.Deserialize<EventOutcome>(doc);
+
+            Assert.Null(outcome.conditions);
+            Assert.True(EventConditionSupport.MatchesAll(new Profile { userName = "Alice" }, outcome.conditions));
+            Assert.False(EventConditionSupport.HasAnyConditions(
+                new RandomEvent { outcomes = new List<EventOutcome> { outcome } }));
+        }
+
+        [Fact]
+        public void StoredShape_RoundTripsThroughBsonWithBothBounds()
+        {
+            var original = new EventCondition { stat = "vice", key = "lustessence", min = 5, max = null };
+
+            EventCondition restored = BsonSerializer.Deserialize<EventCondition>(original.ToBsonDocument());
+
+            Assert.Equal("vice", restored.stat);
+            Assert.Equal("lustessence", restored.key);
+            Assert.Equal(5, restored.min.Value);
+            Assert.False(restored.max.HasValue);
+            // [BsonIgnoreIfNull] keeps the unbounded side out of the stored document entirely.
+            Assert.False(original.ToBsonDocument().Contains("max"));
+        }
+    }
+}

--- a/FChatDicebot.Tests/Unit/Randomeventenginetests.cs
+++ b/FChatDicebot.Tests/Unit/Randomeventenginetests.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.BotCommands.Support;
+﻿using FChatDicebot.BotCommands.Support;
 using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.Model;
 using System;
@@ -388,6 +388,77 @@ namespace FChatDicebot.Tests.Unit
             Assert.Equal("2", p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]); // -5 + 7
         }
 
+        // ------------------------------------------------------------------
+        // "invert": mirror the whole signed corruption axis. Always the full flip - min/max/key
+        // are unused - which is why it dwarfs the per-day magnitude quota that gates the
+        // player-driven !corrupt / !purify.
+        // ------------------------------------------------------------------
+
+        [Theory]
+        [InlineData(-27, 27)]
+        [InlineData(27, -27)]
+        [InlineData(-1, 1)]
+        [InlineData(250, -250)]
+        public void Reward_Invert_MirrorsTheSignedAxis(int before, int after)
+        {
+            var p = new Profile { userName = "Alice" };
+            p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = before.ToString();
+
+            RandomEventEngine.ApplyEventReward(p, Reward("invert", null, 0, 0), new Random(1));
+
+            Assert.Equal(after.ToString(), p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+        }
+
+        // Unlike every other reward, invert's fragment is a whole PREDICATE carrying its own
+        // verb - an inversion is not something you "receive", it happens to what you already had.
+        [Fact]
+        public void Reward_Invert_FragmentIsASelfVerbedPredicateNamingBothSidesOfTheFlip()
+        {
+            var corrupted = new Profile { userName = "Alice" };
+            corrupted.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = "-27";
+            Assert.Equal("now {has|have} [b]27 purity[/b], inverted from [b]27 corruption[/b]",
+                RandomEventEngine.ApplyEventReward(corrupted, Reward("invert", null, 0, 0), new Random(1)));
+
+            var pure = new Profile { userName = "Bob" };
+            pure.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = "27";
+            Assert.Equal("now {has|have} [b]27 corruption[/b], inverted from [b]27 purity[/b]",
+                RandomEventEngine.ApplyEventReward(pure, Reward("invert", null, 0, 0), new Random(1)));
+        }
+
+        [Fact]
+        public void Reward_Invert_IsTheOnlySelfVerbedRewardType()
+        {
+            Assert.True(RandomEventEngine.IsSelfVerbedReward("invert"));
+            Assert.True(RandomEventEngine.IsSelfVerbedReward("  Invert "));
+            foreach (string other in new[] { "currency", "title", "training", "corruption", "purity", "curse", "none", null })
+                Assert.False(RandomEventEngine.IsSelfVerbedReward(other));
+        }
+
+        // Dead neutral has nothing to mirror: no write and no fragment, which drops the winner
+        // out of the reward lines entirely and leaves the outcome text to cover them.
+        [Fact]
+        public void Reward_Invert_AtZero_IsANoOpWithNoFragment()
+        {
+            var p = new Profile { userName = "Alice" };
+            Assert.Equal("", RandomEventEngine.ApplyEventReward(p, Reward("invert", null, 0, 0), new Random(1)));
+            Assert.False(p.characteristics.ContainsKey(CorruptionProcessor.CorruptionCharacteristicKey));
+
+            var explicitZero = new Profile { userName = "Bob" };
+            explicitZero.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = "0";
+            Assert.Equal("", RandomEventEngine.ApplyEventReward(explicitZero, Reward("invert", null, 0, 0), new Random(1)));
+            Assert.Equal("0", explicitZero.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+        }
+
+        // Only reachable from a hand-edited characteristic, but Math.Abs would throw on it.
+        [Fact]
+        public void Reward_Invert_IntMinValue_IsRefusedRatherThanThrowing()
+        {
+            var p = new Profile { userName = "Alice" };
+            p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = int.MinValue.ToString();
+            Assert.Equal("", RandomEventEngine.ApplyEventReward(p, Reward("invert", null, 0, 0), new Random(1)));
+            Assert.Equal(int.MinValue.ToString(), p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+        }
+
         [Fact]
         public void Reward_Curse_AddsKnownCurseOnce_RejectsUnknown()
         {
@@ -748,6 +819,420 @@ namespace FChatDicebot.Tests.Unit
             var output = engine.Tick(Channel, t0.AddSeconds(31), () => new List<RandomEvent>());
             Assert.Single(output);
             Assert.False(engine.HasActiveEvent(Channel));
+        }
+
+        // ==================== Winner-conditional outcomes (per-winner roll) ====================
+        //
+        // An event that authors ANY outcome condition switches from one shared outcome roll to a
+        // per-winner roll among the outcomes that winner qualifies for. Winners are then grouped
+        // by the outcome they landed on, and each group gets its own header block.
+
+        private static EventCondition Cond(string stat, string key = null, int? min = null, int? max = null)
+        {
+            return new EventCondition { stat = stat, key = key, min = min, max = max };
+        }
+
+        private static EventOutcome Outcome(string resultText, List<EventCondition> conditions, params EventReward[] rewards)
+        {
+            return new EventOutcome
+            {
+                weight = 1,
+                resultText = resultText,
+                conditions = conditions,
+                rewards = rewards.ToList(),
+            };
+        }
+
+        private static RandomEvent AllInWindowEvent(params EventOutcome[] outcomes)
+        {
+            return new RandomEvent
+            {
+                label = "mirror",
+                weight = 1,
+                announceText = "The mirror turns.",
+                responseType = RandomEventEngine.ResponseTypeNone,
+                responseWindowSeconds = 60,
+                winnerRule = RandomEventEngine.WinnerRuleAllInWindow,
+                outcomes = outcomes.ToList(),
+            };
+        }
+
+        private Profile AddProfileWithCorruption(string userName, int corruption)
+        {
+            Profile p = AddProfile(userName);
+            p.characteristics[CorruptionProcessor.CorruptionCharacteristicKey] = corruption.ToString();
+            return p;
+        }
+
+        // The whole point of the feature: one event, three states, three different announcements.
+        [Fact]
+        public void Conditional_SplitsWinnersIntoOneBlockPerOutcomeTheyQualifyFor()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);  // corrupted
+            AddProfileWithCorruption("Bob", 40);     // pure
+            AddProfileWithCorruption("Cass", 0);     // neutral
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("{winners} {sees|see} the mirror turn.",
+                    new List<EventCondition> { Cond("corruption", max: -10) },
+                    Reward("invert", null, 0, 0)),
+                Outcome("{winners} {is|are} pulled into the dark.",
+                    new List<EventCondition> { Cond("corruption", min: 10) },
+                    Reward("invert", null, 0, 0)),
+                Outcome("{winners} {finds|find} the glass blank.",
+                    new List<EventCondition> { Cond("corruption", min: -9, max: 9) },
+                    Reward("currency", "rosequartz", 5, 5)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+            engine.HandleRandom(Channel, "Cass", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            string expected = string.Join("\n", new[]
+            {
+                "[user]Alice[/user] sees the mirror turn.",
+                "[user]Alice[/user] now has [b]30 purity[/b], inverted from [b]30 corruption[/b]!",
+                "[user]Bob[/user] is pulled into the dark.",
+                "[user]Bob[/user] now has [b]40 corruption[/b], inverted from [b]40 purity[/b]!",
+                "[user]Cass[/user] finds the glass blank.",
+                "[user]Cass[/user] receives [b]5 rosequartz[/b]!",
+            });
+            Assert.Equal(expected, output[0]);
+
+            // And the grants actually landed, mirrored.
+            Assert.Equal("30", _profiles["Alice"].characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+            Assert.Equal("-40", _profiles["Bob"].characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+            Assert.Equal(5, _profiles["Cass"].currencies["rosequartz"]);
+        }
+
+        // Count agreement has to resolve against the BLOCK size, not the event total - otherwise a
+        // 3-winner event with one corrupted winner would read "Alice see the mirror turn".
+        [Fact]
+        public void Conditional_CountAgreementFollowsTheBlockNotTheEventTotal()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Bob", -30);
+            AddProfileWithCorruption("Cass", 0);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("{winners} {sees|see} the mirror turn.",
+                    new List<EventCondition> { Cond("corruption", max: -10) }),
+                Outcome("{winners} {finds|find} the glass blank.",
+                    new List<EventCondition> { Cond("corruption", min: -9, max: 9) }));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+            engine.HandleRandom(Channel, "Cass", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            Assert.Equal(
+                "[user]Alice[/user] and [user]Bob[/user] see the mirror turn.\n"
+                + "[user]Cass[/user] finds the glass blank.",
+                output[0]);
+        }
+
+        // Identical grants still collapse onto one line - but only within their own block, so
+        // winners under different headers can never be merged into the same sentence.
+        [Fact]
+        public void Conditional_RewardLineGroupingIsScopedToItsOwnBlock()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Bob", -30);
+            AddProfileWithCorruption("Cass", 0);
+            AddProfileWithCorruption("Dee", 0);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("The corrupted are called.",
+                    new List<EventCondition> { Cond("corruption", max: -10) },
+                    Reward("currency", "rosequartz", 3, 3)),
+                Outcome("The rest look on.",
+                    new List<EventCondition> { Cond("corruption", min: -9, max: 9) },
+                    Reward("currency", "rosequartz", 3, 3)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            foreach (string name in new[] { "Alice", "Bob", "Cass", "Dee" })
+                engine.HandleRandom(Channel, name, "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            Assert.Equal(
+                "The corrupted are called.\n"
+                + "[user]Alice[/user] and [user]Bob[/user] receive [b]3 rosequartz[/b]!\n"
+                + "The rest look on.\n"
+                + "[user]Cass[/user] and [user]Dee[/user] receive [b]3 rosequartz[/b]!",
+                output[0]);
+        }
+
+        // A winner who qualifies for no outcome is dropped from the announcement rather than
+        // showing up under someone else's header. Authors are told to keep a catch-all.
+        [Fact]
+        public void Conditional_WinnerWhoQualifiesForNothingIsOmitted()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Cass", 0);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("{winners} {sees|see} the mirror turn.",
+                    new List<EventCondition> { Cond("corruption", max: -10) }));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Cass", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            Assert.Equal("[user]Alice[/user] sees the mirror turn.", output[0]);
+            Assert.DoesNotContain("Cass", output[0]);
+        }
+
+        // Silence after people responded reads as the bot having broken, so a fully gated-out
+        // resolution closes with the existing no-winner line and logs why.
+        [Fact]
+        public void Conditional_AllWinnersGatedOut_ClosesWithNoWinnerLineAndLogs()
+        {
+            var logged = new List<string>();
+            var engine = NewEngine(log: logged.Add);
+            AddProfileWithCorruption("Cass", 0);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("Only the corrupted are called.",
+                    new List<EventCondition> { Cond("corruption", max: -10) }));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Cass", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            Assert.Equal(RandomEventEngine.NoWinnerMessage(new ActiveRandomEvent { Event = ev }), output[0]);
+            Assert.Contains(logged, m => m.Contains("no outcome applied"));
+            Assert.False(engine.HasActiveEvent(Channel));
+        }
+
+        // Conditions FILTER the outcome table; they do not replace the weighted roll. A winner who
+        // qualifies for both a gated outcome and an unconditional catch-all can land on either -
+        // which is what lets an author mix "rare thing that can happen to anyone" with
+        // state-specific branches. Deterministic branching is authored by gating EVERY outcome so
+        // the conditions partition the space (see the tests above, where the catch-all is itself
+        // pinned to the neutral band).
+        [Fact]
+        public void Conditional_UnconditionalOutcomeStaysInTheRollForAQualifyingWinner()
+        {
+            var seen = new HashSet<string>();
+            for (int seed = 1; seed <= 40 && seen.Count < 2; seed++)
+            {
+                var run = new RandomEventEngineTests();
+                var engine = run.NewEngine(seed);
+                run.AddProfileWithCorruption("Alice", -30);
+
+                DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                var ev = AllInWindowEvent(
+                    Outcome("Gated.", new List<EventCondition> { Cond("corruption", max: -10) }),
+                    Outcome("Catch-all.", null));
+
+                engine.ForceOpen(Channel, ev, t0);
+                engine.HandleRandom(Channel, "Alice", "", t0);
+                seen.Add(engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>())[0]);
+            }
+
+            Assert.Equal(new HashSet<string> { "Gated.", "Catch-all." }, seen);
+        }
+
+        // The compatibility guarantee: with no conditions anywhere, every winner still shares ONE
+        // rolled outcome. Two heavily-weighted mutually-exclusive outcomes would split under a
+        // per-winner roll; here all four winners must land in the same block.
+        [Fact]
+        public void NoConditions_StillRollsASingleSharedOutcomeForEveryWinner()
+        {
+            var engine = NewEngine();
+            foreach (string name in new[] { "Alice", "Bob", "Cass", "Dee" })
+                AddProfile(name);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("Heads.", null),
+                Outcome("Tails.", null));
+
+            engine.ForceOpen(Channel, ev, t0);
+            foreach (string name in new[] { "Alice", "Bob", "Cass", "Dee" })
+                engine.HandleRandom(Channel, name, "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Single(output);
+            // Exactly one header, so exactly one outcome was rolled for the whole event.
+            Assert.True(output[0] == "Heads." || output[0] == "Tails.", "unexpected resolution: " + output[0]);
+        }
+
+        // Conditions read the winner's state BEFORE this event grants anything - which is what
+        // lets the invert outcome gate on the very stat it is about to flip.
+        [Fact]
+        public void Conditional_EvaluatesStateBeforeThisEventGrantsAnything()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(
+                Outcome("{winners} {is|are} mirrored.",
+                    new List<EventCondition> { Cond("corruption", max: -10) },
+                    Reward("invert", null, 0, 0)),
+                Outcome("Nothing happens.",
+                    new List<EventCondition> { Cond("corruption", min: -9) }));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Contains("mirrored", output[0]);
+            // Post-flip she is +30, which would no longer satisfy the gate she came in through.
+            Assert.Equal("30", _profiles["Alice"].characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+        }
+
+        // Two winners who happened to hold the same magnitude group onto one line, and the
+        // predicate's {has|have} has to follow the GROUP size, not stay stuck on the singular.
+        [Fact]
+        public void Invert_GroupedWinners_AgreeInThePlural()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Bob", -30);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(Outcome("The mirror turns.", null, Reward("invert", null, 0, 0)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal(
+                "The mirror turns.\n"
+                + "[user]Alice[/user] and [user]Bob[/user] now have [b]30 purity[/b], inverted from [b]30 corruption[/b]!",
+                output[0]);
+        }
+
+        // Winners whose corruption differs end up with different predicates, so they do NOT group
+        // - each gets their own truthful line.
+        [Fact]
+        public void Invert_WinnersWithDifferentMagnitudes_GetSeparateLines()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Bob", 12);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(Outcome("The mirror turns.", null, Reward("invert", null, 0, 0)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Bob", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal(
+                "The mirror turns.\n"
+                + "[user]Alice[/user] now has [b]30 purity[/b], inverted from [b]30 corruption[/b]!\n"
+                + "[user]Bob[/user] now has [b]12 corruption[/b], inverted from [b]12 purity[/b]!",
+                output[0]);
+        }
+
+        // An outcome mixing a received reward with an inversion keeps them on separate lines -
+        // joining them would put two verbs in one clause ("receives 5 rosequartz and now has...").
+        [Fact]
+        public void Invert_AlongsideAReceivedReward_KeepsTheTwoLineShapesApart()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(Outcome("The mirror turns.", null,
+                Reward("currency", "rosequartz", 5, 5),
+                Reward("invert", null, 0, 0)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal(
+                "The mirror turns.\n"
+                + "[user]Alice[/user] receives [b]5 rosequartz[/b]!\n"
+                + "[user]Alice[/user] now has [b]30 purity[/b], inverted from [b]30 corruption[/b]!",
+                output[0]);
+        }
+
+        // A winner at dead neutral has nothing to mirror, so they contribute no line at all and
+        // the outcome's own text is left to cover them.
+        [Fact]
+        public void Invert_AtZero_ProducesNoLineForThatWinner()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", -30);
+            AddProfileWithCorruption("Cass", 0);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = AllInWindowEvent(Outcome("{winners} {steps|step} up to the mirror.", null,
+                Reward("invert", null, 0, 0)));
+
+            engine.ForceOpen(Channel, ev, t0);
+            engine.HandleRandom(Channel, "Alice", "", t0);
+            engine.HandleRandom(Channel, "Cass", "", t0);
+
+            var output = engine.Tick(Channel, t0.AddSeconds(61), () => new List<RandomEvent>());
+
+            Assert.Equal(
+                "[user]Alice[/user] and [user]Cass[/user] step up to the mirror.\n"
+                + "[user]Alice[/user] now has [b]30 purity[/b], inverted from [b]30 corruption[/b]!",
+                output[0]);
+            Assert.Equal("0", _profiles["Cass"].characteristics[CorruptionProcessor.CorruptionCharacteristicKey]);
+        }
+
+        [Fact]
+        public void Conditional_SingleWinnerRules_PickTheBranchThatWinnerQualifiesFor()
+        {
+            var engine = NewEngine();
+            AddProfileWithCorruption("Alice", 55);
+
+            DateTime t0 = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            var ev = new RandomEvent
+            {
+                label = "mirror", weight = 1, announceText = "The mirror turns.",
+                responseType = RandomEventEngine.ResponseTypeNone, responseWindowSeconds = 60,
+                winnerRule = RandomEventEngine.WinnerRuleFirstValid,
+                outcomes = new List<EventOutcome>
+                {
+                    Outcome("The dark takes {winners}.", new List<EventCondition> { Cond("corruption", min: 10) },
+                        Reward("invert", null, 0, 0)),
+                    Outcome("Nothing stirs.", new List<EventCondition> { Cond("corruption", max: 9) }),
+                }
+            };
+
+            engine.ForceOpen(Channel, ev, t0);
+            var result = engine.HandleRandom(Channel, "Alice", "", t0);
+
+            Assert.Equal(
+                "The dark takes [user]Alice[/user].\n"
+                + "[user]Alice[/user] now has [b]55 corruption[/b], inverted from [b]55 purity[/b]!",
+                result.ChannelAnnouncement);
         }
     }
 }

--- a/FChatDicebot/BotCommands/Support/EventConditionSupport.cs
+++ b/FChatDicebot/BotCommands/Support/EventConditionSupport.cs
@@ -1,0 +1,231 @@
+using FChatDicebot.InteractionProcessors.Commitment;
+using FChatDicebot.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FChatDicebot.BotCommands.Support
+{
+    /// <summary>
+    /// Evaluates the authored <see cref="EventCondition"/> gates that make a random event's
+    /// outcomes sensitive to the winner who is about to receive them ("the corrupted are flipped,
+    /// the pure are blessed, everyone else gets pocket change").
+    ///
+    /// The whole system is one idea: <b>every stat projects a profile down to a single integer,
+    /// and a condition is an inclusive range on that integer.</b> That removes any operator
+    /// vocabulary (atLeast / atMost / has / lacks) and — the reason this exists rather than
+    /// reusing the duty <see cref="Conditional"/> — it expresses the negative half of a signed
+    /// axis. Corruption is stored signed (negative = corrupt, positive = pure), so "the corrupted"
+    /// is <c>max: -10</c>, "the pure" is <c>min: 10</c>, and "the untouched middle" is
+    /// <c>min: -9, max: 9</c>. The duty conditional's three-letter-prefix plus single "at least"
+    /// comparison cannot say any of that.
+    ///
+    /// <b>Key semantics are per stat, and consistently shaped:</b> for the stats backed by a list
+    /// (title / curse / parasite / vice / pregnancy / collectible) a blank key projects "how many
+    /// do they have at all", and a named key narrows to that one. So a titles-held count needs no
+    /// separate stat — it is <c>{stat:"title"}</c> with no key. The dictionary-backed stats
+    /// (currency / training / job / count) have no meaningful total, so they require a key.
+    ///
+    /// <b>Failure direction is deliberate.</b> An unknown stat, or a blank key where one is
+    /// required, makes the condition <i>fail</i> rather than pass. A typo therefore kills the
+    /// branch it was written on and the winner falls through to an unconditional outcome; the
+    /// alternative (treating malformed as satisfied) would silently hand out the wrong branch.
+    /// This mirrors the <see cref="DutyConditionalSupport"/> rule that a malformed conditional
+    /// must never crash the roll — here it also must never widen it.
+    ///
+    /// Every projection is a pure read. Nothing in this class mutates a profile.
+    /// </summary>
+    public static class EventConditionSupport
+    {
+        // Signed corruption axis; key is ignored. Negative = corrupt, positive = pure.
+        public const string StatCorruption = "corruption";
+        // Dictionary-backed stats: a key is required (there is no meaningful "total").
+        public const string StatCurrency = "currency";
+        public const string StatTraining = "training";
+        public const string StatJob = "job";
+        public const string StatCount = "count";
+        // List-backed stats: blank key = how many they hold, named key = narrowed to that one.
+        public const string StatTitle = "title";
+        public const string StatCurse = "curse";
+        public const string StatParasite = "parasite";
+        public const string StatVice = "vice";
+        public const string StatPregnancy = "pregnancy";
+        public const string StatCollectible = "collectible";
+
+        /// <summary>
+        /// The authorable stat vocabulary, in the order the builder UI lists them. Adding a stat
+        /// means adding a const, an entry here, and a case in <see cref="TryProject"/>.
+        /// </summary>
+        public static readonly string[] Stats = new string[]
+        {
+            StatCorruption, StatCurrency, StatTraining, StatJob, StatCount,
+            StatTitle, StatCurse, StatParasite, StatVice, StatPregnancy, StatCollectible,
+        };
+
+        /// <summary>Stats whose projection is meaningless without a key.</summary>
+        public static bool RequiresKey(string stat)
+        {
+            string s = Normalize(stat);
+            return s == StatCurrency || s == StatTraining || s == StatJob || s == StatCount;
+        }
+
+        /// <summary>
+        /// Project a profile to the single integer this stat measures. Returns false (with
+        /// <paramref name="value"/> zeroed) for an unknown stat or a missing required key, which
+        /// callers treat as "the condition does not match".
+        /// </summary>
+        public static bool TryProject(Profile profile, string stat, string key, out int value)
+        {
+            value = 0;
+            if (profile == null) return false;
+
+            string s = Normalize(stat);
+            string k = (key ?? "").Trim();
+            if (RequiresKey(s) && k.Length == 0) return false;
+
+            switch (s)
+            {
+                case StatCorruption:
+                    value = CorruptionProcessor.ReadCorruption(profile);
+                    return true;
+
+                case StatCurrency:
+                    value = LookupInt(profile.currencies, k);
+                    return true;
+
+                case StatTraining:
+                    value = LookupInt(profile.trainings, k);
+                    return true;
+
+                case StatJob:
+                    value = LookupInt(profile.jobExperience, k);
+                    return true;
+
+                case StatCount:
+                    value = LookupInt(profile.counts, k);
+                    return true;
+
+                case StatTitle:
+                    if (profile.titles == null) return true;
+                    value = k.Length == 0
+                        ? profile.titles.Count
+                        : profile.titles.Count(t => t != null && Same(t.titleText, k));
+                    return true;
+
+                case StatCurse:
+                    value = CountInstances(CurseInstance.LoadAll(profile).Select(c => c.Curse), k);
+                    return true;
+
+                case StatParasite:
+                    value = CountInstances(ParasiteInstance.LoadAll(profile).Select(p => p.Parasite), k);
+                    return true;
+
+                case StatVice:
+                    // A named vice projects its ADDICTION LEVEL (1-10, 0 when absent) rather than
+                    // a plain 0/1, because that is the number an author actually wants to gate on
+                    // ("the deeply hooked"). A min of 1 still reads as "has this vice" either way.
+                    // A blank key falls back to the list-count shape the other list stats use.
+                    {
+                        List<ViceInstance> vices = ViceInstance.LoadAll(profile);
+                        if (k.Length == 0) { value = vices.Count; return true; }
+                        ViceInstance match = vices.FirstOrDefault(v => v != null && Same(v.Vice, k));
+                        value = match != null ? match.AddictionLevel : 0;
+                        return true;
+                    }
+
+                case StatPregnancy:
+                    // Only active pregnancies live in the list — !birth removes them — so the
+                    // count is "currently carrying", not "ever conceived".
+                    if (profile.pregnancies == null) return true;
+                    value = k.Length == 0
+                        ? profile.pregnancies.Count
+                        : profile.pregnancies.Count(p => p != null && Same(p.MonsterType, k));
+                    return true;
+
+                case StatCollectible:
+                    if (profile.collectibles == null) return true;
+                    value = k.Length == 0
+                        ? profile.collectibles.Count
+                        : profile.collectibles.Count(c => c != null && Same(c.TypeLabel, k));
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Does this profile satisfy one condition? A null condition is no constraint at all
+        /// (true); an unprojectable one is false. Bounds are inclusive and independently optional.
+        /// </summary>
+        public static bool Matches(Profile profile, EventCondition condition)
+        {
+            if (condition == null) return true;
+
+            int value;
+            if (!TryProject(profile, condition.stat, condition.key, out value)) return false;
+            if (condition.min.HasValue && value < condition.min.Value) return false;
+            if (condition.max.HasValue && value > condition.max.Value) return false;
+            return true;
+        }
+
+        /// <summary>All conditions must hold (an empty or null list is unconditional).</summary>
+        public static bool MatchesAll(Profile profile, List<EventCondition> conditions)
+        {
+            if (conditions == null || conditions.Count == 0) return true;
+            return conditions.All(c => Matches(profile, c));
+        }
+
+        /// <summary>
+        /// Does this event author ANY outcome condition? This is the switch between the original
+        /// "roll one outcome and share it across every winner" behavior and the per-winner roll —
+        /// an event with no conditions anywhere behaves exactly as it did before conditions
+        /// existed, so no authored event changes meaning by being loaded into the new engine.
+        /// </summary>
+        public static bool HasAnyConditions(RandomEvent ev)
+        {
+            if (ev == null || ev.outcomes == null) return false;
+            return ev.outcomes.Any(o => o != null && o.conditions != null && o.conditions.Count > 0);
+        }
+
+        /// <summary>The subset of an event's outcomes this winner is eligible for (never null).</summary>
+        public static List<EventOutcome> EligibleOutcomes(RandomEvent ev, Profile profile)
+        {
+            if (ev == null || ev.outcomes == null) return new List<EventOutcome>();
+            return ev.outcomes.Where(o => o != null && MatchesAll(profile, o.conditions)).ToList();
+        }
+
+        // ============================ Small private helpers ============================
+
+        private static string Normalize(string stat)
+        {
+            return (stat ?? "").Trim().ToLowerInvariant();
+        }
+
+        private static bool Same(string a, string b)
+        {
+            return string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static int LookupInt(Dictionary<string, int> store, string key)
+        {
+            if (store == null) return 0;
+            int value;
+            if (store.TryGetValue(key, out value)) return value;
+            // These dictionaries are authored by several different code paths, so fall back to a
+            // case-insensitive scan rather than reporting zero for a key that differs only in
+            // casing from what the event author typed.
+            foreach (KeyValuePair<string, int> entry in store)
+            {
+                if (Same(entry.Key, key)) return entry.Value;
+            }
+            return 0;
+        }
+
+        private static int CountInstances(IEnumerable<string> names, string key)
+        {
+            List<string> all = names.Where(n => !string.IsNullOrEmpty(n)).ToList();
+            return key.Length == 0 ? all.Count : all.Count(n => Same(n, key));
+        }
+    }
+}

--- a/FChatDicebot/BotCommands/Support/RandomEventEngine.cs
+++ b/FChatDicebot/BotCommands/Support/RandomEventEngine.cs
@@ -1,4 +1,4 @@
-using FChatDicebot.InteractionProcessors.Commitment;
+﻿using FChatDicebot.InteractionProcessors.Commitment;
 using FChatDicebot.InteractionProcessors.Consequence;
 using FChatDicebot.Model;
 using System;
@@ -267,12 +267,23 @@ namespace FChatDicebot.BotCommands.Support
         // map, grants the rolled outcome's rewards to each winner, and returns the public
         // announcement. The next fire was already scheduled when this event fired.
         //
-        // Multi-winner support: the outcome's own resultText is expected to carry whatever
-        // flavor applies to every winner together (via the {winners} placeholder — e.g. "{winners}
-        // are now glowing purple."), rather than the engine bolting on a generic "joins in" line.
+        // Multi-winner support: an outcome's own resultText is expected to carry whatever flavor
+        // applies to the winners it covers (via the {winners} placeholder - e.g. "{winners} are
+        // now glowing purple."), rather than the engine bolting on a generic "joins in" line.
         // Reward grants are still per-winner (magnitudes are re-rolled per person), but winners
         // who end up with identical reward fragments are combined onto one line so identical
         // grants read as one clean sentence instead of a repeated line per person.
+        //
+        // Outcome scope depends on whether the event authors any winner conditions:
+        //   - no conditions anywhere -> ONE outcome is rolled and shared by every winner. This is
+        //     the original behavior, preserved exactly for every event authored before conditions
+        //     existed.
+        //   - any condition present  -> the outcome is rolled PER WINNER among the outcomes that
+        //     winner qualifies for, so the corrupted and the pure can be told apart. Winners are
+        //     then grouped by the outcome they landed on, and each group gets its own header
+        //     block (count agreement resolved against that group's size) followed by its own
+        //     reward lines. A winner who qualifies for nothing is omitted from the announcement;
+        //     authors are expected to keep one unconditional outcome as the catch-all.
         private string ResolveLocked(string key, ActiveRandomEvent ae, List<string> winnersOverride)
         {
             ae.Resolved = true;
@@ -282,20 +293,36 @@ namespace FChatDicebot.BotCommands.Support
             if (winners == null || winners.Count == 0)
                 return NoWinnerMessage(ae);
 
-            EventOutcome outcome = SelectOutcome(ae.Event, _rng);
+            bool perWinnerOutcome = EventConditionSupport.HasAnyConditions(ae.Event);
+            EventOutcome sharedOutcome = perWinnerOutcome ? null : SelectOutcome(ae.Event, _rng);
 
             // Apply rewards per winner (each profile saved at most once) and collect their
             // fragments. Currency grants don't touch the loaded profile at all: they're
             // collected here and applied through the atomic _changeCurrency delegate AFTER
             // the whole-profile save, so the ReplaceOne can neither revert a concurrent
-            // balance change nor overwrite our own credit — and a pure-currency outcome
+            // balance change nor overwrite our own credit - and a pure-currency outcome
             // (the common case) skips the whole-profile write entirely (B12-2).
             var fragmentsByWinner = new Dictionary<string, List<string>>();
+            // Self-verbed rewards (currently just "invert") carry their own verb, so they can't
+            // join the "receives" line and are rendered one per line instead.
+            var predicatesByWinner = new Dictionary<string, List<string>>();
+            // Keyed by outcome REFERENCE, so two structurally identical authored outcomes stay
+            // distinct blocks rather than silently merging. Order preserves first-seen winner order.
+            var outcomeOrder = new List<EventOutcome>();
+            var winnersByOutcome = new Dictionary<EventOutcome, List<string>>();
+
             foreach (string winner in winners)
             {
                 Profile p = _getProfile != null ? _getProfile(winner) : null;
+                // Conditions are evaluated against the winner's state BEFORE this event grants
+                // anything, so an outcome can gate on a stat it is itself about to move.
+                EventOutcome outcome = perWinnerOutcome ? SelectOutcomeFor(ae.Event, p, _rng) : sharedOutcome;
+                if (outcome == null)
+                    continue;
+
                 var fragments = new List<string>();
-                if (p != null && outcome != null && outcome.rewards != null)
+                var predicates = new List<string>();
+                if (p != null && outcome.rewards != null)
                 {
                     var currencyGrants = new List<KeyValuePair<string, int>>();
                     Action<string, int> creditCurrency = _changeCurrency == null
@@ -309,10 +336,13 @@ namespace FChatDicebot.BotCommands.Support
                         string frag = ApplyEventReward(p, reward, _rng, creditCurrency);
                         if (string.IsNullOrEmpty(frag))
                             continue;
-                        fragments.Add(frag);
+                        if (IsSelfVerbedReward(reward.type))
+                            predicates.Add(frag);
+                        else
+                            fragments.Add(frag);
                         // A fragment that didn't add a deferred currency grant means the
                         // reward wrote to the profile document itself (title/training/
-                        // corruption/purity/curse — or currency in degraded mode).
+                        // corruption/purity/invert/curse - or currency in degraded mode).
                         if (currencyGrants.Count == grantsBefore)
                             profileDirty = true;
                     }
@@ -322,41 +352,90 @@ namespace FChatDicebot.BotCommands.Support
                     foreach (var grant in currencyGrants)
                         _changeCurrency(winner, grant.Key, grant.Value);
                 }
+
                 fragmentsByWinner[winner] = fragments;
+                predicatesByWinner[winner] = predicates;
+                if (!winnersByOutcome.ContainsKey(outcome))
+                {
+                    winnersByOutcome[outcome] = new List<string>();
+                    outcomeOrder.Add(outcome);
+                }
+                winnersByOutcome[outcome].Add(winner);
+            }
+
+            // Nobody landed on an outcome at all - either the event authors none, or its
+            // conditions excluded every winner. Announcing nothing after people responded reads
+            // as the bot having broken, so close it out with the existing no-winner line.
+            if (outcomeOrder.Count == 0)
+            {
+                Log("[random-events] " + ae.Channel + ": event " + (ae.Event.label ?? "(unlabeled)")
+                    + " resolved with " + winners.Count + " winner(s) but no outcome applied to any of them"
+                    + (perWinnerOutcome
+                        ? " (every outcome was gated out by its conditions; author an unconditional catch-all outcome)"
+                        : " (the event has no outcomes authored)")
+                    + ".");
+                return NoWinnerMessage(ae);
             }
 
             StringBuilder sb = new StringBuilder();
-            // Count agreement resolves BEFORE the names go in: winner tags are spliced in as
-            // [user]Name[/user], and doing the alternation first means the resolver never has to
-            // reason about what a name might contain.
-            string header = outcome != null
-                ? SubstituteWinners(ResolveCountAgreement(outcome.resultText, winners.Count), winners)
-                : null;
-            if (!string.IsNullOrEmpty(header))
-                sb.Append(header);
-
-            // Group winners with identical reward fragments (in first-seen order) into one line
-            // each. A winner with no reward at all gets no line — the header already covers the
-            // flavor for everyone via {winners}.
-            var groups = new List<WinnerGroup>();
-            foreach (string winner in winners)
+            foreach (EventOutcome outcome in outcomeOrder)
             {
-                List<string> fragments = fragmentsByWinner[winner];
-                if (fragments.Count == 0) continue;
+                List<string> groupWinners = winnersByOutcome[outcome];
 
-                WinnerGroup existing = groups.FirstOrDefault(g => g.Fragments.SequenceEqual(fragments));
-                if (existing != null)
-                    existing.Names.Add(winner);
-                else
-                    groups.Add(new WinnerGroup { Fragments = fragments, Names = new List<string> { winner } });
-            }
+                // Count agreement resolves BEFORE the names go in: winner tags are spliced in as
+                // [user]Name[/user], and doing the alternation first means the resolver never has
+                // to reason about what a name might contain. It agrees with THIS block's winner
+                // count, not the event's total, so a per-winner split still reads grammatically.
+                string header = SubstituteWinners(
+                    ResolveCountAgreement(outcome.resultText, groupWinners.Count), groupWinners);
+                if (!string.IsNullOrEmpty(header))
+                {
+                    if (sb.Length > 0) sb.Append("\n");
+                    sb.Append(header);
+                }
 
-            foreach (WinnerGroup group in groups)
-            {
-                List<string> tags = group.Names.Select(n => "[user]" + n + "[/user]").ToList();
-                string verb = tags.Count > 1 ? " receive " : " receives ";
-                if (sb.Length > 0) sb.Append("\n");
-                sb.Append(JoinWithAnd(tags) + verb + JoinWithAnd(group.Fragments) + "!");
+                // Group winners with identical reward fragments (in first-seen order) into one
+                // line each. A winner with no reward at all gets no line - the header already
+                // covers the flavor for everyone via {winners}. Grouping is scoped to this
+                // outcome block so winners under different headers never merge onto one line.
+                var groups = new List<WinnerGroup>();
+                foreach (string winner in groupWinners)
+                {
+                    List<string> fragments = fragmentsByWinner[winner];
+                    List<string> predicates = predicatesByWinner[winner];
+                    if (fragments.Count == 0 && predicates.Count == 0) continue;
+
+                    WinnerGroup existing = groups.FirstOrDefault(g =>
+                        g.Fragments.SequenceEqual(fragments) && g.Predicates.SequenceEqual(predicates));
+                    if (existing != null)
+                        existing.Names.Add(winner);
+                    else
+                        groups.Add(new WinnerGroup
+                        {
+                            Fragments = fragments,
+                            Predicates = predicates,
+                            Names = new List<string> { winner },
+                        });
+                }
+
+                foreach (WinnerGroup group in groups)
+                {
+                    List<string> tags = group.Names.Select(n => "[user]" + n + "[/user]").ToList();
+                    if (group.Fragments.Count > 0)
+                    {
+                        string verb = tags.Count > 1 ? " receive " : " receives ";
+                        if (sb.Length > 0) sb.Append("\n");
+                        sb.Append(JoinWithAnd(tags) + verb + JoinWithAnd(group.Fragments) + "!");
+                    }
+                    // Self-verbed rewards each get their own line - they already read as a
+                    // complete sentence about the winner, so joining them with "and" onto the
+                    // receives line would produce two verbs in one clause.
+                    foreach (string predicate in group.Predicates)
+                    {
+                        if (sb.Length > 0) sb.Append("\n");
+                        sb.Append(JoinWithAnd(tags) + " " + ResolveCountAgreement(predicate, tags.Count) + "!");
+                    }
+                }
             }
 
             return sb.ToString();
@@ -364,7 +443,8 @@ namespace FChatDicebot.BotCommands.Support
 
         private class WinnerGroup
         {
-            public List<string> Fragments;
+            public List<string> Fragments;   // noun phrases, joined onto one "receives" line
+            public List<string> Predicates;  // self-verbed, one line each
             public List<string> Names;
         }
 
@@ -484,19 +564,39 @@ namespace FChatDicebot.BotCommands.Support
         /// <summary>Weighted pick over an event's outcomes; null if it has none.</summary>
         public static EventOutcome SelectOutcome(RandomEvent ev, Random rng)
         {
-            if (ev == null || ev.outcomes == null || ev.outcomes.Count == 0) return null;
-            if (ev.outcomes.Count == 1) return ev.outcomes[0];
+            if (ev == null) return null;
+            return SelectFromOutcomes(ev.outcomes, rng);
+        }
 
-            int total = ev.outcomes.Sum(o => Math.Max(0, o.weight));
-            if (total <= 0) return ev.outcomes[rng.Next(ev.outcomes.Count)];
+        /// <summary>
+        /// Weighted pick over the outcomes this particular winner is eligible for. An event with
+        /// no authored conditions short-circuits to the plain whole-list pick, so the conditional
+        /// path costs nothing for the events that don't use it. Null when the winner qualifies for
+        /// nothing (the caller omits them from the announcement).
+        /// </summary>
+        public static EventOutcome SelectOutcomeFor(RandomEvent ev, Profile profile, Random rng)
+        {
+            if (ev == null || ev.outcomes == null || ev.outcomes.Count == 0) return null;
+            if (!EventConditionSupport.HasAnyConditions(ev)) return SelectFromOutcomes(ev.outcomes, rng);
+            return SelectFromOutcomes(EventConditionSupport.EligibleOutcomes(ev, profile), rng);
+        }
+
+        /// <summary>Shared weighted roll used by both selection entry points.</summary>
+        private static EventOutcome SelectFromOutcomes(List<EventOutcome> outcomes, Random rng)
+        {
+            if (outcomes == null || outcomes.Count == 0) return null;
+            if (outcomes.Count == 1) return outcomes[0];
+
+            int total = outcomes.Sum(o => Math.Max(0, o.weight));
+            if (total <= 0) return outcomes[rng.Next(outcomes.Count)];
 
             int pick = rng.Next(0, total);
-            foreach (EventOutcome o in ev.outcomes)
+            foreach (EventOutcome o in outcomes)
             {
                 pick -= Math.Max(0, o.weight);
                 if (pick < 0) return o;
             }
-            return ev.outcomes[ev.outcomes.Count - 1];
+            return outcomes[outcomes.Count - 1];
         }
 
         /// <summary>
@@ -599,6 +699,29 @@ namespace FChatDicebot.BotCommands.Support
                     WriteCorruption(profile, CorruptionProcessor.ReadCorruption(profile) + amount);
                     return "[b]" + amount + "[/b] purity";
 
+                case "invert":
+                    // Mirror the whole signed axis: a deeply corrupted resident comes out equally
+                    // pure and vice versa. min/max/key are unused - this is always the full flip,
+                    // which is what makes it legible as a rare event payoff (and why it dwarfs the
+                    // per-day magnitude quota that gates player-driven !corrupt / !purify).
+                    {
+                        int before = CorruptionProcessor.ReadCorruption(profile);
+                        // Nothing to mirror at dead neutral: no write, no fragment, so the winner
+                        // simply gets no reward line and the outcome text still covers them.
+                        if (before == 0) return "";
+                        // Only reachable from a hand-edited characteristic; Math.Abs would throw.
+                        if (before == int.MinValue) return "";
+                        WriteCorruption(profile, -before);
+                        int magnitude = Math.Abs(before);
+                        string had = before < 0 ? "corruption" : "purity";
+                        string now = before < 0 ? "purity" : "corruption";
+                        // A whole predicate rather than a noun phrase - see IsSelfVerbedReward.
+                        // The {has|have} alternation is resolved against the line's winner count
+                        // by the same ResolveCountAgreement that handles authored resultText.
+                        return "now {has|have} [b]" + magnitude + " " + now + "[/b], inverted from [b]"
+                            + magnitude + " " + had + "[/b]";
+                    }
+
                 case "curse":
                     if (string.IsNullOrEmpty(reward.key) || !CurseProcessor.CatalogMap.ContainsKey(reward.key)) return "";
                     List<CurseInstance> curses = CurseInstance.LoadAll(profile);
@@ -610,6 +733,21 @@ namespace FChatDicebot.BotCommands.Support
                 default: // "none" and anything unrecognized: flavor only, no write.
                     return "";
             }
+        }
+
+        /// <summary>
+        /// Whether this reward type's fragment is a whole predicate ("now {has|have} X, inverted
+        /// from Y") instead of a noun phrase the engine can hang off its shared "receives" verb.
+        ///
+        /// Every other reward is something a winner *receives*, so they compose onto one line:
+        /// "Alice receives 5 rosequartz and the title Lucky!". An inversion is not received - it
+        /// happens to what the winner already had - so it carries its own verb and gets its own
+        /// line. Keeping the distinction here (rather than sniffing the fragment text) means the
+        /// two line shapes stay explicit and a future self-verbed reward is one entry away.
+        /// </summary>
+        public static bool IsSelfVerbedReward(string type)
+        {
+            return string.Equals((type ?? "").Trim(), "invert", StringComparison.OrdinalIgnoreCase);
         }
 
         public bool IsValidArg(ActiveRandomEvent ae, string arg)

--- a/FChatDicebot/Model/ChateauDB.cs
+++ b/FChatDicebot/Model/ChateauDB.cs
@@ -369,9 +369,39 @@ namespace FChatDicebot.Model
         public List<EventOutcome> outcomes { get; set; } = new List<EventOutcome>(); // weighted roll on resolve
     }
 
+    /// <summary>
+    /// One gate on an <see cref="EventOutcome"/>, tested against a winner's profile at resolve
+    /// time. Every supported stat projects the winner down to a single integer, and the condition
+    /// is an inclusive range on that integer — so there is no operator vocabulary to learn and
+    /// signed stats (corruption runs negative-for-corrupt through positive-for-pure) are
+    /// expressible in both directions. A null bound is unbounded on that side.
+    ///
+    /// Deliberately NOT the duty <see cref="Conditional"/>: that one packs its kind into a
+    /// three-letter prefix and only ever compares "at least", which cannot express the negative
+    /// half of the corruption axis. See <c>BotCommands.Support.EventConditionSupport</c> for the
+    /// stat vocabulary and the projection each one performs.
+    /// </summary>
+    public class EventCondition
+    {
+        public string stat { get; set; }  // see EventConditionSupport.Stats
+        public string key { get; set; }   // which currency/training/title/…; meaning is per-stat
+        [BsonIgnoreIfNull]
+        public int? min { get; set; }     // inclusive lower bound; null = unbounded
+        [BsonIgnoreIfNull]
+        public int? max { get; set; }     // inclusive upper bound; null = unbounded
+    }
+
     public class EventOutcome
     {
         public int weight { get; set; }        // weighted pick among the event's outcomes
+        // Gates this outcome to winners whose profile satisfies every listed condition. Null or
+        // empty (the default, and every pre-existing document) means "eligible to everyone".
+        //
+        // The presence of conditions on ANY outcome of an event switches that event from one
+        // shared outcome roll to a per-winner roll — see RandomEventEngine.ResolveLocked. An
+        // event with no conditions anywhere keeps the original single-roll behavior exactly.
+        [BsonIgnoreIfNull]
+        public List<EventCondition> conditions { get; set; }
         // Announced when this outcome is granted. May include a {winners} placeholder (e.g.
         // "{winners} are now glowing purple.") substituted with every winner's [user] tag —
         // lets a multi-winner outcome (allInWindow/etc.) carry its own combined flavor instead
@@ -382,8 +412,8 @@ namespace FChatDicebot.Model
 
     public class EventReward
     {
-        public string type { get; set; } // "currency" | "title" | "training" | "corruption" | "purity" | "curse" | "none"
-        public string key { get; set; }  // currency name / title text / training skill / curse id (unused for corruption/purity/none)
+        public string type { get; set; } // "currency" | "title" | "training" | "corruption" | "purity" | "invert" | "curse" | "none"
+        public string key { get; set; }  // currency name / title text / training skill / curse id (unused for corruption/purity/invert/none)
         public int min { get; set; }     // magnitude/amount low  (currency, training, corruption, purity)
         public int max { get; set; }     // magnitude/amount high
     }

--- a/scripts/random-event-builder/README.md
+++ b/scripts/random-event-builder/README.md
@@ -57,11 +57,67 @@ as its own app. Re-run the copy above after changing the tool in the repo.
 | responseType | `none` (any `!random` counts), `keyword` (must repeat a random word from the engine's pool), `challenge` (must solve a generated sum) |
 | responseWindowSeconds | How long `!random` responses are accepted (0 = engine default, 60s) |
 | winnerRule | `firstValid`, `allInWindow`, `nth` (with `winnerN`), `random` |
-| outcomes | One is rolled by weight when the event resolves. `resultText` may use `{winners}`; rewards apply per winner |
+| outcomes | Rolled by weight when the event resolves. `resultText` may use `{winners}`; rewards apply per winner. Add **conditions** to make an outcome apply only to certain winners — see below |
 
-Reward types: `currency`, `title`, `training`, `corruption`, `purity`, `curse`
-(must be one of the engine's cataloged curses), `none` (pure flavor). Amounts are
-rolled between `min` and `max` per winner.
+Reward types: `currency`, `title`, `training`, `corruption`, `purity`, `invert`,
+`curse` (must be one of the engine's cataloged curses), `none` (pure flavor).
+Amounts are rolled between `min` and `max` per winner.
+
+`invert` mirrors the winner's whole signed corruption value (`value → -value`) — it
+takes no key and no amount, and it is always the full flip. Unlike every other reward
+it is not something the winner *receives*, so it gets its own line rather than joining
+the "receives" list:
+
+```
+Alice now has 27 purity, inverted from 27 corruption!
+```
+
+A winner sitting at exactly 0 has nothing to mirror and gets no line at all. The
+preview uses a stand-in magnitude; the live event uses whatever the winner holds.
+
+## Winner conditions
+
+Each outcome can carry conditions that gate it to certain winners. Every stat
+projects the winner's profile down to one integer, and a condition is an **inclusive
+range** on it — `min` and `max` are each optional, and blank means unbounded on that
+side (which is *not* the same as 0).
+
+Corruption is stored **signed**: negative is corrupt, positive is pure. So:
+
+| Intent | stat | key | min | max |
+| --- | --- | --- | --- | --- |
+| the corrupted | corruption | — | | -10 |
+| the pure | corruption | — | 10 | |
+| the untouched middle | corruption | — | -9 | 9 |
+| holds 100+ rosequartz | currency | rosequartz | 100 | |
+| has the Cutie title | title | Cutie | 1 | |
+| holds no curses | curse | *(blank)* | | 0 |
+| deeply hooked on a vice | vice | lustessence | 5 | |
+| currently pregnant | pregnancy | *(blank)* | 1 | |
+
+Stats: `corruption`, `currency`, `training`, `job`, `count`, `title`, `curse`,
+`parasite`, `vice`, `pregnancy`, `collectible`. The dictionary-backed ones
+(`currency` / `training` / `job` / `count`) **require** a key. The list-backed ones
+take an optional key — blank counts everything they hold, a named key narrows to
+that one. A named `vice` projects its addiction level (1–10) rather than 0/1.
+
+Two things worth knowing before you author one:
+
+- **Conditions switch the event to a per-winner outcome roll.** With no conditions
+  anywhere, one outcome is rolled and shared by everyone (the original behaviour).
+  Add one condition and each winner rolls their own outcome among the ones they
+  qualify for, then winners are grouped by the outcome they landed on — each group
+  gets its own result-text block, with `{singular|plural}` agreeing with that
+  block's count.
+- **Conditions filter the table; they don't replace the roll.** A winner who
+  qualifies for a gated outcome can still roll an unconditional one. To branch
+  deterministically, put a condition on *every* outcome so they partition the range
+  (≤ -10 / -9…9 / ≥ 10). A winner who qualifies for nothing is dropped from the
+  announcement — keep a catch-all or cover every state.
+
+The stat list mirrors `EventConditionSupport.Stats` in the bot code; the reward-type
+and curse lists mirror the engine likewise. If either grows, update the arrays at the
+top of `server.cs`.
 
 The curse dropdown mirrors `CurseProcessor.CatalogMap` in code (the engine silently
 grants nothing for unknown curse keys) — if new curses are added there, update the

--- a/scripts/random-event-builder/server.cs
+++ b/scripts/random-event-builder/server.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -35,7 +35,20 @@ class RandomEventBuilderServer
 
     static readonly string[] ResponseTypes = new string[] { "none", "keyword", "challenge" };
     static readonly string[] WinnerRules = new string[] { "firstValid", "allInWindow", "nth", "random" };
-    static readonly string[] RewardTypes = new string[] { "currency", "title", "training", "corruption", "purity", "curse", "none" };
+    static readonly string[] RewardTypes = new string[] { "currency", "title", "training", "corruption", "purity", "invert", "curse", "none" };
+
+    // Mirrors EventConditionSupport.Stats - the stat vocabulary an outcome condition can gate on.
+    // Every one of these projects a winner's profile to a single integer; the condition is an
+    // inclusive range on it. Re-sync if stats are added there.
+    static readonly string[] ConditionStats = new string[]
+    {
+        "corruption", "currency", "training", "job", "count",
+        "title", "curse", "parasite", "vice", "pregnancy", "collectible",
+    };
+
+    // Mirrors EventConditionSupport.RequiresKey - the dictionary-backed stats have no meaningful
+    // "total across all keys", so a blank key there is an authoring error rather than a wildcard.
+    static readonly string[] ConditionStatsNeedingKey = new string[] { "currency", "training", "job", "count" };
 
     static IMongoDatabase _db;
     static string _uiPath;
@@ -138,6 +151,8 @@ class RandomEventBuilderServer
                 { "responseTypes", new BsonArray(ResponseTypes) },
                 { "winnerRules", new BsonArray(WinnerRules) },
                 { "rewardTypes", new BsonArray(RewardTypes) },
+                { "conditionStats", new BsonArray(ConditionStats) },
+                { "conditionStatsNeedingKey", new BsonArray(ConditionStatsNeedingKey) },
             };
             Write(ctx, 200, "application/json", ToStrictJson(catalogs));
             return;
@@ -248,6 +263,62 @@ class RandomEventBuilderServer
             if (outcomeWeight < 0) { error = "Outcome " + outcomeIndex + ": weight cannot be negative."; return null; }
 
             string resultText = Trimmed(o, "resultText");
+
+            // Winner conditions. Authoring ANY of them on ANY outcome switches the event from one
+            // shared outcome roll to a per-winner roll among the outcomes that winner qualifies
+            // for - see RandomEventEngine.ResolveLocked.
+            BsonArray conditions = new BsonArray();
+            BsonValue rawConditions;
+            if (o.TryGetValue("conditions", out rawConditions) && rawConditions.IsBsonArray)
+            {
+                int conditionIndex = 0;
+                foreach (BsonValue rawCondition in rawConditions.AsBsonArray)
+                {
+                    conditionIndex++;
+                    string cwhere = "Outcome " + outcomeIndex + " condition " + conditionIndex;
+                    if (!rawCondition.IsBsonDocument) { error = cwhere + " is not an object."; return null; }
+                    BsonDocument c = rawCondition.AsBsonDocument;
+
+                    string stat = OrDefault(Trimmed(c, "stat"), "");
+                    if (!ContainsIgnoreCase(ConditionStats, stat))
+                    {
+                        error = cwhere + ": stat must be one of: " + string.Join(", ", ConditionStats);
+                        return null;
+                    }
+                    stat = Canonical(ConditionStats, stat);
+
+                    string ckey = OrDefault(Trimmed(c, "key"), "");
+                    if (ContainsIgnoreCase(ConditionStatsNeedingKey, stat) && ckey.Length == 0)
+                    {
+                        error = cwhere + ": a key is required for " + stat + " conditions (there is no meaningful total across all keys).";
+                        return null;
+                    }
+
+                    bool hasMin = HasNumber(c, "min");
+                    bool hasMax = HasNumber(c, "max");
+                    if (!hasMin && !hasMax)
+                    {
+                        error = cwhere + ": a condition needs at least a min or a max - with neither it matches everyone and gates nothing.";
+                        return null;
+                    }
+
+                    int cmin = Int(c, "min", 0);
+                    int cmax = Int(c, "max", 0);
+                    // Rewards swap an inverted range; a condition must NOT - an inverted range
+                    // matches nobody, which would silently kill the branch it was written on.
+                    if (hasMin && hasMax && cmin > cmax)
+                    {
+                        error = cwhere + ": min (" + cmin + ") is above max (" + cmax + "), so this condition can never match. Bounds are inclusive.";
+                        return null;
+                    }
+
+                    BsonDocument condition = new BsonDocument { { "stat", stat }, { "key", ckey } };
+                    if (hasMin) condition.Add("min", cmin);
+                    if (hasMax) condition.Add("max", cmax);
+                    conditions.Add(condition);
+                }
+            }
+
             BsonArray rewards = new BsonArray();
             BsonValue rawRewards;
             if (o.TryGetValue("rewards", out rawRewards) && rawRewards.IsBsonArray)
@@ -276,6 +347,9 @@ class RandomEventBuilderServer
                         error = where + ": \"" + key + "\" is not in the engine's curse catalog (valid: " + string.Join(", ", CurseKeys) + ").";
                         return null;
                     }
+                    // "invert" is deliberately absent from both needsKey and needsAmount: it always
+                    // mirrors the winner's whole signed corruption value, so there is nothing to
+                    // roll and nothing to name.
                     bool needsAmount = type == "currency" || type == "training" || type == "corruption" || type == "purity";
                     if (needsAmount && max <= 0)
                     {
@@ -299,12 +373,16 @@ class RandomEventBuilderServer
                 return null;
             }
 
-            outcomes.Add(new BsonDocument
+            BsonDocument outcomeDoc = new BsonDocument
             {
                 { "weight", outcomeWeight },
                 { "resultText", resultText ?? "" },
                 { "rewards", rewards },
-            });
+            };
+            // Omitted entirely when unconditional, so an event that uses no conditions round-trips
+            // to exactly the document shape it had before conditions existed.
+            if (conditions.Count > 0) outcomeDoc.Add("conditions", conditions);
+            outcomes.Add(outcomeDoc);
         }
 
         return new BsonDocument
@@ -388,6 +466,21 @@ class RandomEventBuilderServer
             if (int.TryParse(v.AsString, out parsed)) return parsed;
         }
         return fallback;
+    }
+
+    // A condition bound is optional (null/absent = unbounded on that side), so presence has to be
+    // distinguishable from a zero the author actually typed.
+    static bool HasNumber(BsonDocument d, string field)
+    {
+        BsonValue v;
+        if (!d.TryGetValue(field, out v) || v.IsBsonNull) return false;
+        if (v.IsInt32 || v.IsInt64 || v.IsDouble) return true;
+        if (v.IsString)
+        {
+            int parsed;
+            return int.TryParse(v.AsString, out parsed);
+        }
+        return false;
     }
 
     static bool ContainsIgnoreCase(string[] values, string candidate)

--- a/scripts/random-event-builder/ui.html
+++ b/scripts/random-event-builder/ui.html
@@ -265,12 +265,16 @@
 
 // ============================ state ============================
 
-var catalogs = { currencies: [], trainings: [], curses: [], keywordPool: [], rewardTypes: [] };
+var catalogs = { currencies: [], trainings: [], curses: [], keywordPool: [], rewardTypes: [],
+                 conditionStats: [], conditionStatsNeedingKey: [] };
 var events = [];
 var current = null;        // working copy being edited
 var originalLabel = null;  // label the doc had when loaded (null = brand new)
 
 var SAMPLE_WINNERS = ['Riven Ashvale', 'Mira Solenne', 'Kess Whitlock'];
+// Stand-in corruption magnitude for the invert reward preview - the live event mirrors
+// whatever the winner actually holds.
+var SAMPLE_CORRUPTION = 27;
 var BOT_NAME = 'Chateau Contract';
 
 // ============================ boot ============================
@@ -343,7 +347,7 @@ function newEvent() {
     label: '', categories: [], weight: 10, announceText: '',
     responseType: 'keyword', responseWindowSeconds: 60,
     winnerRule: 'allInWindow', winnerN: 0,
-    outcomes: [{ weight: 1, resultText: '', rewards: [] }]
+    outcomes: [{ weight: 1, resultText: '', rewards: [], conditions: [] }]
   };
   originalLabel = null;
   loadForm();
@@ -424,7 +428,7 @@ function insertAtCursor(id, text) {
 // ============================ outcomes ============================
 
 function addOutcome() {
-  current.outcomes.push({ weight: 1, resultText: '', rewards: [] });
+  current.outcomes.push({ weight: 1, resultText: '', rewards: [], conditions: [] });
   renderOutcomes(); refresh();
 }
 
@@ -465,6 +469,30 @@ function renderOutcomes() {
     rt.appendChild(ta);
     card.appendChild(rt);
 
+    // ---- winner conditions ----
+    var condWrap = document.createElement('div');
+    condWrap.style.marginTop = '10px';
+    condWrap.style.paddingTop = '10px';
+    condWrap.style.borderTop = '1px dashed var(--line)';
+    var condLabel = document.createElement('div');
+    condLabel.className = 'field';
+    condLabel.innerHTML = '<label>Only for winners where\u2026 '
+      + '<span class="muted">(each condition is an inclusive range; leave a bound blank for unbounded. '
+      + 'Corruption is signed: negative is corrupt, positive is pure.)</span></label>';
+    condWrap.appendChild(condLabel);
+    (o.conditions || []).forEach(function (c, ci) {
+      condWrap.appendChild(conditionRow(o, c, ci));
+    });
+    var addC = document.createElement('button');
+    addC.className = 'small'; addC.textContent = '+ Add condition';
+    addC.onclick = function () {
+      if (!o.conditions) o.conditions = [];
+      o.conditions.push({ stat: 'corruption', key: '', min: null, max: -10 });
+      renderOutcomes(); refresh();
+    };
+    condWrap.appendChild(addC);
+    card.appendChild(condWrap);
+
     var rewardsHost = document.createElement('div');
     rewardsHost.style.marginTop = '10px';
     (o.rewards || []).forEach(function (r, ri) {
@@ -485,6 +513,85 @@ function renderOutcomes() {
   });
 }
 
+function conditionRow(outcome, c, ci) {
+  var row = document.createElement('div');
+  row.className = 'reward';
+
+  var kind = document.createElement('div');
+  kind.className = 'field kind';
+  kind.innerHTML = '<label>Stat</label>';
+  var sel = document.createElement('select');
+  (catalogs.conditionStats || ['corruption']).forEach(function (t) {
+    var op = document.createElement('option');
+    op.value = t; op.textContent = t;
+    if (c.stat === t) op.selected = true;
+    sel.appendChild(op);
+  });
+  sel.onchange = function () { c.stat = sel.value; renderOutcomes(); refresh(); };
+  kind.appendChild(sel);
+  row.appendChild(kind);
+
+  // corruption ignores the key entirely; the dictionary stats require one; the list stats take
+  // an optional one (blank = "how many do they hold at all").
+  if (c.stat !== 'corruption') {
+    var needsKey = (catalogs.conditionStatsNeedingKey || []).indexOf(c.stat) >= 0;
+    var keyField = document.createElement('div');
+    keyField.className = 'field';
+    keyField.innerHTML = '<label>' + c.stat + ' key' + (needsKey ? '' : ' <span class="muted">(blank = count them all)</span>') + '</label>';
+    var keyInput = document.createElement('input');
+    keyInput.value = c.key || '';
+    keyInput.placeholder = needsKey ? 'required' : 'optional';
+    keyInput.oninput = function () { c.key = keyInput.value; refresh(); };
+    keyField.appendChild(keyInput);
+    row.appendChild(keyField);
+  }
+
+  ['min', 'max'].forEach(function (bound) {
+    var f = document.createElement('div');
+    f.className = 'field num';
+    f.innerHTML = '<label>' + bound + '</label>';
+    var inp = document.createElement('input');
+    inp.type = 'number';
+    inp.placeholder = bound === 'min' ? '\u2212\u221e' : '+\u221e';
+    inp.value = (c[bound] === null || c[bound] === undefined) ? '' : c[bound];
+    inp.oninput = function () {
+      // Blank means unbounded on that side, which is NOT the same as zero.
+      c[bound] = inp.value === '' ? null : (parseInt(inp.value, 10) || 0);
+      refresh();
+    };
+    f.appendChild(inp);
+    row.appendChild(f);
+  });
+
+  var rm = document.createElement('button');
+  rm.className = 'small danger'; rm.textContent = '\u00d7'; rm.title = 'Remove condition';
+  rm.onclick = function () { outcome.conditions.splice(ci, 1); renderOutcomes(); refresh(); };
+  row.appendChild(rm);
+
+  return row;
+}
+
+// Human-readable gate, used in the resolve preview captions.
+function conditionSummary(c) {
+  var subject = c.stat === 'corruption' ? 'corruption'
+    : (c.key ? c.stat + ' ' + c.key : c.stat + ' count');
+  var hasMin = c.min !== null && c.min !== undefined;
+  var hasMax = c.max !== null && c.max !== undefined;
+  if (hasMin && hasMax) return c.min === c.max ? subject + ' = ' + c.min : subject + ' ' + c.min + '\u2026' + c.max;
+  if (hasMin) return subject + ' \u2265 ' + c.min;
+  if (hasMax) return subject + ' \u2264 ' + c.max;
+  return subject + ' (no bounds \u2014 gates nothing)';
+}
+
+function outcomeGate(o) {
+  var cs = o.conditions || [];
+  return cs.length ? cs.map(conditionSummary).join(' and ') : null;
+}
+
+function eventHasConditions(doc) {
+  return doc.outcomes.some(function (o) { return (o.conditions || []).length > 0; });
+}
+
 function rewardRow(outcome, r, ri) {
   var row = document.createElement('div');
   row.className = 'reward';
@@ -493,7 +600,7 @@ function rewardRow(outcome, r, ri) {
   kind.className = 'field kind';
   kind.innerHTML = '<label>Reward</label>';
   var sel = document.createElement('select');
-  ['currency', 'title', 'training', 'corruption', 'purity', 'curse', 'none'].forEach(function (t) {
+  ['currency', 'title', 'training', 'corruption', 'purity', 'invert', 'curse', 'none'].forEach(function (t) {
     var op = document.createElement('option');
     op.value = t; op.textContent = t;
     if (r.type === t) op.selected = true;
@@ -636,8 +743,18 @@ function rewardFragment(r) {
     case 'corruption': return '[b]' + range + '[/b] corruption';
     case 'purity': return '[b]' + range + '[/b] purity';
     case 'curse': return 'the [b]' + r.key + '[/b] curse';
-    default: return null; // "none": flavor only
+    default: return null; // "none": flavor only; "invert" is a predicate, see rewardPredicate
   }
+}
+
+// Mirrors RandomEventEngine.IsSelfVerbedReward. An inversion is not something a winner
+// "receives" - it happens to what they already had - so it carries its own verb and gets its own
+// line instead of joining the "receives" list. The real numbers mirror whatever the winner
+// actually holds; SAMPLE_CORRUPTION stands in so the preview shows the true sentence shape.
+function rewardPredicate(r) {
+  if (r.type !== 'invert') return null;
+  return 'now {has|have} [b]' + SAMPLE_CORRUPTION + ' purity[/b], inverted from [b]'
+    + SAMPLE_CORRUPTION + ' corruption[/b]';
 }
 
 function renderPreview(doc) {
@@ -677,7 +794,15 @@ function renderPreview(doc) {
     var cap = document.createElement('div');
     cap.className = 'previewCaption';
     var pct = totalW > 0 ? Math.round(100 * Math.max(0, o.weight) / totalW) : Math.round(100 / doc.outcomes.length);
-    cap.textContent = 'On resolve — outcome ' + (i + 1) + ' (' + pct + '% chance)';
+    var gate = outcomeGate(o);
+    if (eventHasConditions(doc)) {
+      // With conditions in play the outcome is rolled PER WINNER among the ones that winner
+      // qualifies for, so a single flat percentage across the whole table would be a lie.
+      cap.textContent = 'On resolve — outcome ' + (i + 1) + ' · weight ' + Math.max(0, o.weight)
+        + ' · ' + (gate ? 'only winners where ' + gate : 'any winner (catch-all)');
+    } else {
+      cap.textContent = 'On resolve — outcome ' + (i + 1) + ' (' + pct + '% chance)';
+    }
     host.appendChild(cap);
 
     previewCounts.forEach(function (variant) {
@@ -692,6 +817,10 @@ function renderPreview(doc) {
         var verb = variant.winners.length > 1 ? ' receive ' : ' receives ';
         lines.push(joinWithAnd(tags) + verb + joinWithAnd(fragments) + '!');
       }
+      // Self-verbed rewards each get their own line, with {has|have} agreeing with the count.
+      (o.rewards || []).map(rewardPredicate).filter(Boolean).forEach(function (pred) {
+        lines.push(joinWithAnd(tags) + ' ' + resolveCountAgreement(pred, variant.winners.length) + '!');
+      });
 
       if (variant.label) {
         var sub = document.createElement('div');
@@ -751,6 +880,31 @@ function renderWarnings(doc) {
   });
   if (doc.responseType !== 'none' && doc.winnerRule === 'firstValid' && doc.responseWindowSeconds > 120)
     w.push('firstValid resolves on the first correct answer — a long window mostly just delays the no-winner message.');
+
+  // ---- conditions ----
+  doc.outcomes.forEach(function (o, i) {
+    (o.conditions || []).forEach(function (c, ci) {
+      var where = 'Outcome ' + (i + 1) + ' condition ' + (ci + 1) + ': ';
+      var hasMin = c.min !== null && c.min !== undefined;
+      var hasMax = c.max !== null && c.max !== undefined;
+      if (!hasMin && !hasMax)
+        w.push(where + 'no min and no max — it matches everyone and gates nothing.');
+      if (hasMin && hasMax && c.min > c.max)
+        w.push(where + 'min (' + c.min + ') is above max (' + c.max + '), so it can never match. Bounds are inclusive.');
+      if ((catalogs.conditionStatsNeedingKey || []).indexOf(c.stat) >= 0 && !c.key)
+        w.push(where + 'a key is required for ' + c.stat + ' (there is no meaningful total across all keys).');
+    });
+  });
+  if (eventHasConditions(doc)) {
+    w.push('This event uses conditions, so the outcome is rolled PER WINNER among the outcomes that winner qualifies for — winners can end up in different blocks, each with its own result text.');
+    var unconditional = doc.outcomes.filter(function (o) { return (o.conditions || []).length === 0; });
+    if (unconditional.length === 0)
+      w.push('No outcome is unconditional. A winner who matches none of the conditions is dropped from the announcement entirely — make sure the conditions cover every state, or add a catch-all outcome.');
+    else
+      w.push('Conditions filter the table; they do not replace the weighted roll. A winner who qualifies for a gated outcome can still roll the unconditional one — to branch deterministically, put a condition on every outcome so they partition the range (e.g. corruption ≤ −10 / −9…9 / ≥ 10).');
+  }
+  if (doc.outcomes.some(function (o) { return (o.rewards || []).some(function (r) { return r.type === 'invert'; }); }))
+    w.push('An "invert" reward mirrors the winner\'s whole signed corruption value and gets its own line (it is not "received" alongside the other rewards) — the preview uses ' + SAMPLE_CORRUPTION + ' as a stand-in. A winner sitting at exactly 0 has nothing to mirror and gets no line at all.');
   var ul = document.getElementById('warnings');
   ul.innerHTML = '';
   w.forEach(function (msg) {

--- a/wiki-docs/specs/Random-Events.md
+++ b/wiki-docs/specs/Random-Events.md
@@ -1,6 +1,6 @@
 # Random Events — ambient channel events + `!random`
 
-**Status:** ✅ SHIPPED 2026-06-29, wording pass + design tweak 2026-07-01 (owner review). Per-event `announceText` / `resultText` and reward magnitudes are authored data in the seeded `RandomEvents` collection; a single starter event ("Cutie says {word}") has been authored — see *Seed data* below.
+**Status:** ✅ SHIPPED 2026-06-29, wording pass + design tweak 2026-07-01 (owner review), **winner conditions + `invert` reward 2026-08-30** (see *Winner conditions* below). Per-event `announceText` / `resultText` and reward magnitudes are authored data in the seeded `RandomEvents` collection; a single starter event ("Cutie says {word}") has been authored — see *Seed data* below.
 **Feature-Requests source:** "Random events, to encourage spontaneous chat activity. Responding to a random event would always start !random but might also require an additional argument, to slow down campers/snipers" (B12).
 
 > **Note on paths:** this spec was written before the latest Dice Bot integration flattened `FChatDicebot/FChatDicebot/…` to `FChatDicebot/…`. The links below predate that move; the as-built files are: model in [Model/ChateauDB.cs](../../FChatDicebot/Model/ChateauDB.cs), engine in [BotCommands/Support/RandomEventEngine.cs](../../FChatDicebot/BotCommands/Support/RandomEventEngine.cs), command in [BotCommands/ChateauRandom.cs](../../FChatDicebot/BotCommands/ChateauRandom.cs), scheduler in [BotMain.cs](../../FChatDicebot/BotMain.cs) (`HandleRandomEventsTick`), DB in [Database/Chateaudatabase.cs](../../FChatDicebot/Database/Chateaudatabase.cs), tests in `FChatDicebot.Tests/Unit/Randomeventenginetests.cs`. Discord is intentionally excluded — the tick is wired into `RunLoopFList` only (the deployment is F-Chat / Chateau-only).
@@ -44,12 +44,13 @@ public class EventOutcome
 {
     public int weight { get; set; }       // weighted pick among the event's outcomes
     public string resultText { get; set; } // announced when this outcome is granted; may use {winners}
+    public List<EventCondition> conditions { get; set; }                      // gates this outcome per winner
     public List<EventReward> rewards { get; set; } = new List<EventReward>(); // applied to winner(s)
 }
 
 public class EventReward
 {
-    public string type { get; set; } // "currency" | "title" | "training" | "corruption" | "purity" | "curse" | "none"
+    public string type { get; set; } // "currency" | "title" | "training" | "corruption" | "purity" | "invert" | "curse" | "none"
     public string key { get; set; }  // currency name / title id / training skill / curse id (unused for corruption/purity/none)
     public int min { get; set; }     // magnitude/amount low  (currency, training, corruption, purity)
     public int max { get; set; }     // magnitude/amount high
@@ -86,6 +87,7 @@ Each `EventReward.type` maps to an **existing** grant mechanism — reuse, don't
 | `training` | `profile.trainings[key]` += `roll(min,max)`, clamped 0–100 ([TrainProcessor](../../FChatDicebot/InteractionProcessors)). |
 | `corruption` | apply magnitude `roll(min,max)` via the existing [CorruptionProcessor / CorruptionCommandSupport](../../FChatDicebot/InteractionProcessors/Commitment/CorruptionCommandSupport.cs) path. |
 | `purity` | the purify/cleanse side of the corruption axis (reduce corruption) — reuse the same support. |
+| `invert` | mirror the whole signed corruption axis (`value → -value`). Added 2026-08-30; see *Winner conditions* below. |
 | `curse` | add curse `key` via [CurseInstance / CurseProcessor](../../FChatDicebot/Model/CurseInstance.cs). |
 | `none` | flavor-only; no profile write. |
 
@@ -200,6 +202,80 @@ All framework strings live as `const`s on `RandomEventEngine` (search `// Framew
 ## Seed data
 
 One starter event, **"Cutie says {word}"**, has been authored (owner inserted the document directly into the `RandomEvents` collection; it isn't tracked in this repo since events are pure Mongo data, not code). It's a `keyword`/`allInWindow` event: every resident who repeats Cutie's randomly-chosen word back within the window is granted the `Cutie` title, using the `{winners}` placeholder to greet everyone who caught it in one line. Authoring more events is tracked as a to-do (see `wiki-docs/Feature-Requests.md`) — write additional `RandomEvent` documents in the same shape; the scheduler picks among all of them by `weight` automatically, no code change needed.
+
+## Winner conditions and the `invert` reward (shipped 2026-08-30)
+
+Owner-specced 2026-08-30 in response to "a random event with a reward that inverts the corruption/purity of the winner — and while we're at it, make the system sensitive to variables of the winner."
+
+### `invert`
+
+A reward type that mirrors the winner's whole signed corruption value: `value → -value`. `key`, `min` and `max` are unused — it is **always the full flip** (owner's call), which is why it dwarfs the `DailyMagnitudeLimit` quota that gates the player-driven `!corrupt` / `!purify`. Like the other system-granted rewards it bypasses the consent flow; the player opted in by responding.
+
+Degenerate cases fall out of the existing machinery rather than needing special handling: a winner sitting at exactly 0 has nothing to mirror, so the reward returns an empty fragment and that winner simply gets no line — the outcome's `{winners}` header still covers them. `int.MinValue` is refused rather than overflowing `Math.Abs`.
+
+**`invert` is the first *self-verbed* reward** (`RandomEventEngine.IsSelfVerbedReward`). Every other reward is a noun phrase the engine hangs off its shared verb — "Alice receives 5 rosequartz and the title ·Lucky·!" — but an inversion is not *received*, it happens to what the winner already had. So its fragment is a whole predicate and it is rendered on its own line:
+
+```
+[user]Alice[/user] now has [b]27 purity[/b], inverted from [b]27 corruption[/b]!
+```
+
+The `{has|have}` alternation is resolved by the same `ResolveCountAgreement` that handles authored `resultText`, against that line's winner count — so winners who happened to hold the same magnitude group onto one line and read "now have". Winners with different magnitudes produce different predicates and therefore don't group, each getting their own truthful line. An outcome that mixes a received reward with an inversion emits both line shapes rather than joining them (which would put two verbs in one clause).
+
+Reward-line grouping keys on the noun fragments **and** the predicates together, so the two shapes can never cross-merge.
+
+### `EventCondition` — one idea, no operator vocabulary
+
+`BotCommands/Support/EventConditionSupport.cs` is authoritative. **Every stat projects a winner's profile down to a single integer, and a condition is an inclusive range on that integer** (`min` / `max`, each independently nullable = unbounded). There is no `atLeast` / `atMost` / `has` / `lacks` vocabulary to learn.
+
+> **Why not the duty `Conditional`?** That shape packs its kind into a three-letter prefix (`curgold`, `trndeepthroat`) and only ever compares "at least". Corruption is stored **signed** — negative is corrupt, positive is pure — so expressing "the corrupted" requires an upper bound on a negative number, which the duty conditional cannot say at all. The two systems are deliberately separate; converging them is a possible follow-up, not part of this change.
+
+Corruption therefore reads naturally in all three directions:
+
+| Intent | Condition |
+|---|---|
+| the corrupted | `{stat: "corruption", max: -10}` |
+| the pure | `{stat: "corruption", min: 10}` |
+| the untouched middle | `{stat: "corruption", min: -9, max: 9}` |
+
+**Stat vocabulary** (`EventConditionSupport.Stats` is the source of truth): `corruption`, `currency`, `training`, `job`, `count`, `title`, `curse`, `parasite`, `vice`, `pregnancy`, `collectible`.
+
+**Key semantics are per stat, and consistently shaped:**
+- The **dictionary-backed** stats (`currency` / `training` / `job` / `count`) **require** a key — there is no meaningful total across all of them. A key that isn't held projects to 0, so "the broke" is authorable as `max: 0`.
+- The **list-backed** stats (`title` / `curse` / `parasite` / `vice` / `pregnancy` / `collectible`) take an **optional** key: blank counts how many they hold at all, a named key narrows to that one. A "titles held" count therefore needs no separate stat — it is `{stat: "title"}` with no key.
+- `corruption` ignores the key entirely.
+- `vice` is the one asymmetry: a **named** vice projects its `AddictionLevel` (1–10, 0 when absent) rather than a plain 0/1, because that is the number an author actually wants to gate on. `min: 1` still reads as "has this vice".
+- `pregnancy` counts **active** pregnancies only — `!birth` removes them from the list.
+
+**Failure direction is deliberate.** An unknown stat, or a blank key where one is required, makes the condition **fail** rather than pass. A typo kills the branch it was written on and the winner falls through to a catch-all; the alternative would silently hand out the wrong branch.
+
+### What conditions do to resolution
+
+Authoring **any** condition on **any** outcome switches that event from one shared outcome roll to a **per-winner** roll. `RandomEventEngine.ResolveLocked` is authoritative:
+
+- **No conditions anywhere** — one outcome is rolled and shared by every winner, exactly as before this change. Every event authored before conditions existed keeps its original behavior; a stored document with no `conditions` key deserializes to `null`, which is unconditional.
+- **Any condition present** — each winner's outcome is rolled among the outcomes *that winner* qualifies for. Winners are then grouped by the outcome they landed on (by reference, so two structurally identical outcomes stay distinct blocks), and each group gets its **own header block** — `{singular|plural}` count agreement resolves against **that block's** winner count, not the event total, and `{winners}` substitutes only that block's names. Reward-line grouping is scoped inside the block, so winners under different headers can never be merged onto one sentence.
+
+Since `firstValid` / `nth` / `random` resolve to exactly one winner by construction, only `allInWindow` can actually produce a multi-block announcement.
+
+**Conditions filter the table; they do not replace the weighted roll.** A winner who qualifies for both a gated outcome and an unconditional catch-all can land on either — which is what lets an author mix "a rare thing that can happen to anyone" with state-specific branches. **To branch deterministically, put a condition on every outcome so they partition the range** (`≤ -10` / `-9…9` / `≥ 10`). The builder surfaces this as a warning.
+
+Conditions are evaluated against the winner's state **before** this event grants anything, which is precisely what lets the invert outcome gate on the very stat it is about to flip.
+
+**A winner who qualifies for nothing is omitted from the announcement.** If *no* winner lands on any outcome, the event closes with the existing `NoWinnerMessage` and logs why (operator-facing only) — posting nothing after residents responded reads as the bot having broken. Authors are expected to keep a catch-all or a total partition; the builder warns when neither is present.
+
+### Authoring
+
+The builder (`scripts/random-event-builder`) gained a conditions editor per outcome, `invert` in the reward dropdown, gate-aware resolve captions, and warnings for the failure modes above. Its `ConditionStats` / `ConditionStatsNeedingKey` / `RewardTypes` arrays in `server.cs` mirror the engine and must be re-synced if the vocabulary grows.
+
+No migration: `conditions` is `[BsonIgnoreIfNull]`, the builder omits it entirely for an unconditional outcome, and an omitted bound stays omitted rather than being stored as 0.
+
+### Files
+
+- `FChatDicebot/BotCommands/Support/EventConditionSupport.cs` (new) — stat projection + range test.
+- `FChatDicebot/Model/ChateauDB.cs` — `EventCondition`; `EventOutcome.conditions`.
+- `FChatDicebot/BotCommands/Support/RandomEventEngine.cs` — `invert` branch in `ApplyEventReward`, `SelectOutcomeFor`, per-winner grouping in `ResolveLocked`.
+- `FChatDicebot.Tests/Unit/Eventconditionsupporttests.cs` (new), additions to `Randomeventenginetests.cs`.
+- `scripts/random-event-builder/server.cs` + `ui.html` + `README.md`.
 
 ## Assumptions
 


### PR DESCRIPTION
Two related additions to the B12 ambient random events system: a reward that inverts the winner's corruption/purity, and a general way for an outcome to be sensitive to the winner receiving it.

## `invert`

Mirrors the winner's whole signed corruption axis (`value → -value`). Always the full flip — `key`/`min`/`max` unused — which is why it dwarfs the per-day magnitude quota that gates player-driven `!corrupt` / `!purify`. A winner at exactly 0 has nothing to mirror and falls out through the existing empty-fragment path (no line, the outcome's `{winners}` header still covers them); `int.MinValue` is refused rather than overflowing `Math.Abs`.

It's also the first **self-verbed** reward. Every other reward is a noun phrase hung off the engine's shared `receives`, but an inversion isn't received — it happens to what the winner already had — so it carries its own predicate and gets its own line:

```
Alice now has 27 purity, inverted from 27 corruption!
```

`{has|have}` resolves through the existing `ResolveCountAgreement` against that line's winner count, so grouped winners read "now have". Grouping keys on the noun fragments **and** the predicates together, so the two line shapes can never cross-merge.

## `EventCondition`

One idea throughout: **every stat projects a profile to a single integer, and a condition is an inclusive range on it** (`min`/`max` each independently nullable = unbounded). No `atLeast`/`atMost`/`has`/`lacks` vocabulary.

Deliberately *not* the duty `Conditional` — that packs its kind into a three-letter prefix and only compares "at least", which can't express the negative half of a signed axis. Corruption reads naturally in all three directions instead:

| Intent | Condition |
|---|---|
| the corrupted | `{stat: "corruption", max: -10}` |
| the pure | `{stat: "corruption", min: 10}` |
| the untouched middle | `{stat: "corruption", min: -9, max: 9}` |

Stats: `corruption`, `currency`, `training`, `job`, `count`, `title`, `curse`, `parasite`, `vice`, `pregnancy`, `collectible`. Dictionary-backed stats require a key; list-backed ones take an optional one (blank counts everything held), so a titles-held count needs no separate stat. A named `vice` projects its addiction level rather than 0/1. Unknown stats and missing required keys **fail closed**, so a typo kills its own branch instead of granting the wrong one.

## What conditions do to resolution

Authoring any condition switches the event from one shared outcome roll to a **per-winner** roll among the outcomes that winner qualifies for. Winners are then grouped into per-outcome blocks, each with its own header and its own count agreement. Only `allInWindow` can actually produce multiple blocks — the other three rules resolve to one winner by construction.

Two behaviours worth knowing, both covered by tests and surfaced as builder warnings:

- **Conditions filter the table; they don't replace the weighted roll.** A winner eligible for both a gated outcome and an unconditional catch-all can land on either — which is what lets an author mix "a rare thing that can happen to anyone" with state-specific branches. Deterministic branching means gating *every* outcome so they partition the range.
- **A winner qualifying for nothing is omitted** from the announcement. If *no* winner lands anywhere, the event closes with the existing `NoWinnerMessage` and logs why — previously that case posted nothing, which reads as the bot having broken after residents responded.

Conditions are evaluated against state *before* this event grants anything, which is what lets the invert outcome gate on the very stat it's about to flip.

## Compatibility

No migration. `conditions` is `[BsonIgnoreIfNull]`, an event with none keeps the original single-roll behaviour exactly, and a stored document with no `conditions` key deserializes to `null`. An omitted bound stays omitted rather than being stored as 0 — verified by round-trip tests, since a `min` silently becoming 0 would turn "the pure" into a range matching nobody.

## Builder

`scripts/random-event-builder` gains a conditions editor per outcome, `invert` in the reward dropdown, gate-aware resolve captions (the flat percentage would be a lie once the roll is per-winner), and warnings for each failure mode above. Verified live: server compiles, UI renders clean, all four validation rejections fire, stored BSON has the right shape, and the preview matches engine output in both singular and plural.

## User-facing text

One new string — the invert line above — at the owner's wording. `NoWinnerMessage` is unchanged text on a new path.

## Testing

`dotnet build` clean; 2011 tests pass. The one failure, `InteractionAliases_AreAlsoRecognisedBySeteicon`, is **pre-existing on `main` and unrelated**: PR #81 added `!cum`/`!cumfor` to the climax commands without registering them in `InteractionEiconSupport.TokenToVerbKeys`, so `!seteicon cum` doesn't resolve today. Left alone here; tracked separately.

Docs: `wiki-docs/specs/Random-Events.md` as-shipped section and the builder README. No `Command-Reference` change — no command or help text moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
